### PR TITLE
Relax sdmetrics dependency range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requires = [
     'graphviz>=0.13.2,<1',
     'copulas>=0.3.2,<0.4',
     'rdt>=0.2.7,<0.3',
-    'sdmetrics>=0.0.2,<0.0.3',
+    'sdmetrics>=0.0.2,<0.1.0',
     'deepecho==0.1.3',
 ]
 


### PR DESCRIPTION
Relax a bit the `sdmetrics` dependency to allow SDMetrics development of new versions without conflicts.