### PR TITLE
Pass field transformers to table

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       name: Install graphviz - MacOS
       run: |
         brew install graphviz pandoc
-        echo '::set-env name=TOX_SKIP_ENV::test-devel'
+        echo "TOX_SKIP_ENV=test-devel" >> $GITHUB_ENV
 
     - name: Install dependencies
       run: |

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -68,6 +68,7 @@ class BaseTabularModel:
                 field_names=field_names,
                 primary_key=primary_key,
                 field_types=field_types,
+                field_transformers=field_transformers,
                 anonymize_fields=anonymize_fields,
                 constraints=constraints,
                 dtype_transformers=self._DTYPE_TRANSFORMERS,

--- a/sdv/tabular/copulagan.py
+++ b/sdv/tabular/copulagan.py
@@ -143,6 +143,7 @@ class CopulaGAN(CTGAN):
             field_names=field_names,
             primary_key=primary_key,
             field_types=field_types,
+            field_transformers=field_transformers,
             anonymize_fields=anonymize_fields,
             constraints=constraints,
             table_metadata=table_metadata,

--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -108,6 +108,7 @@ class GaussianCopula(BaseTabularModel):
     """
 
     _distribution = None
+    _default_distribution = None
     _categorical_transformer = None
     _model = None
 
@@ -217,10 +218,10 @@ class GaussianCopula(BaseTabularModel):
 
         super().__init__(
             field_names=field_names,
-            primary_key=primary_key,
             field_types=field_types,
             field_transformers=field_transformers,
             anonymize_fields=anonymize_fields,
+            primary_key=primary_key,
             constraints=constraints,
             table_metadata=table_metadata,
         )

--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -219,9 +219,10 @@ class GaussianCopula(BaseTabularModel):
             field_names=field_names,
             primary_key=primary_key,
             field_types=field_types,
+            field_transformers=field_transformers,
             anonymize_fields=anonymize_fields,
             constraints=constraints,
-            table_metadata=table_metadata
+            table_metadata=table_metadata,
         )
 
     def get_distributions(self):

--- a/sdv/tabular/ctgan.py
+++ b/sdv/tabular/ctgan.py
@@ -85,6 +85,7 @@ class CTGAN(BaseTabularModel):
             field_names=field_names,
             primary_key=primary_key,
             field_types=field_types,
+            field_transformers=field_transformers,
             anonymize_fields=anonymize_fields,
             constraints=constraints,
             table_metadata=table_metadata


### PR DESCRIPTION
The `field_transformers` argument was not being passed down from the tabular models `__init__` method to the `BaseTabularModel.__init__`, and then neither from there to the `Table.__init__`.

This PR fixes this and adds a couple of tests to certify this for the `GaussianCopula`.