### PR TITLE
Improve testing config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,35 +7,100 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  lint:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, macos-latest]
-
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-
-    - if: matrix.os == 'ubuntu-latest'
-      name: Install graphviz - Ubuntu
-      run: |
-        sudo apt-get install graphviz pandoc
-
-    - if: matrix.os == 'macos-latest'
-      name: Install graphviz - MacOS
-      run: |
-        brew install graphviz pandoc
-        echo "TOX_SKIP_ENV=test-devel" >> $GITHUB_ENV
-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
-
     - name: Test with tox
-      run: tox
+      run: tox -e lint
+
+  readme:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox -e readme
+
+  unit:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox -e unit
+
+  minimum:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox -e minimum
+
+  tutorials:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install graphviz - Ubuntu
+      run: |
+        sudo apt-get install graphviz
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox -e tutorials

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ docs/savefig
 tutorials/**/*.pkl
 tutorials/**/*metadata.json
 notebooks
+tests/readme_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,15 @@
 dist: bionic
 language: python
 python:
-  - 3.8
-  - 3.7
   - 3.6
+  - 3.7
+  - 3.8
+env:
+  - TOXENV=lint
+  - TOXENV=readme
+  - TOXENV=unit
+  - TOXENV=minimum
+  - TOXENV=tutorials
 
 # Command to install dependencies
 install:
@@ -14,5 +20,4 @@ install:
 
 after_success: codecov
 
-# Command to run tests
-script: travis_wait 60 tox
+scropt: travis_wait 60 tox

--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,11 @@ install-test: clean-build clean-pyc ## install the package and test dependencies
 install-develop: clean-build clean-pyc ## install the package in editable mode and dependencies for development
 	pip install -e .[dev]
 
-MINIMUM := $(shell sed -n '/install_requires = \[/,/]/p' setup.py | head -n-1 | tail -n+2 | sed 's/ *\(.*\),$?$$/\1/g' | tr '>' '=')
+MINIMUM := $(shell sed -n '/install_requires = \[/,/]/p' setup.py | grep -v -e '[][]' | sed 's/ *\(.*\),$?$$/\1/g' | tr '>' '=')
 
 .PHONY: install-minimum
 install-minimum: ## install the minimum supported versions of the package dependencies
-	pip install $(MINIMUM)
+	echo pip install $(MINIMUM)
 
 
 # LINT TARGETS
@@ -101,8 +101,12 @@ lint-tests: ## check style with flake8 and isort
 	flake8 --ignore=D,SFS2 tests
 	isort -c --recursive tests
 
+.PHONY: check-dependencies
+check-dependencies: ## test if there are any broken dependencies
+	pip check
+
 .PHONY: lint
-lint: lint-sdv lint-tests  ## Run all code style checks
+lint: check-dependencies lint-sdv lint-tests  ## Run all code style and static testing validations
 
 .PHONY: fix-lint
 fix-lint: ## fix lint issues using autoflake, autopep8, and isort
@@ -131,15 +135,8 @@ test-tutorials: ## run the tutorial notebooks
 .PHONY: test
 test: test-unit test-readme test-tutorials ## test everything that needs test dependencies
 
-.PHONY: check-dependencies
-check-dependencies: ## test if there are any broken dependencies
-	pip check
-
 .PHONY: test-minimum
-test-minimum: install-minimum check-dependencies test ## run tests using the minimum supported dependencies
-
-.PHONY: test-devel
-test-devel: check-dependencies lint docs ## test everything that needs development dependencies
+test-minimum: install-minimum check-dependencies test-unit ## run tests using the minimum supported dependencies
 
 .PHONY: test-all
 test-all: ## run tests on every Python version with tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
-envlist = py3{6,7,8}-{readme,test,devel}
+envlist = py3{6,7,8}-{lint,readme,unit,minimum}
 
 [travis]
 python =
-    3.8: py38-test, py38-readme, py38-devel
-    3.7: py37-test, py37-readme, py37-devel
-    3.6: py36-test, py36-readme, py36-devel
+    3.8: py38-lint, py38-readme, py38-unit, py38-minimum, py38-tutorials
+    3.7: py37-lint, py37-readme, py37-unit, py37-minimum, py37-tutorials
+    3.6: py36-lint, py36-readme, py36-unit, py36-minimum, py36-tutorials
 
 [gh-actions]
 python =
-    3.8: py38-test, py38-readme, py38-devel
-    3.7: py37-test, py37-readme, py37-devel
-    3.6: py36-test, py36-readme, py36-devel
+    3.8: py38-lint, py38-readme, py38-unit, py38-minimum, py38-tutorials
+    3.7: py37-lint, py37-readme, py37-unit, py37-minimum, py37-tutorials
+    3.6: py36-lint, py36-readme, py36-unit, py36-minimum, py36-tutorials
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
@@ -19,10 +19,18 @@ skipsdist = false
 skip_install = false
 deps =
     readme: rundoc
+    tutorials: jupyter
 extras =
-    test: test
-    devel: dev
+    lint: dev
+    unit: test
+    minimum: test
+    tutorials: ctgan
 commands =
+    lint: /usr/bin/env make lint
     readme: /usr/bin/env make test-readme
-    test: /usr/bin/env make test
-    devel: /usr/bin/env make test-devel
+    unit: /usr/bin/env make test-unit
+    minimum: /usr/bin/env make test-minimum
+    tutorials: /usr/bin/env make test-tutorials
+    rm -r {envdir}
+whitelist_externals =
+    rm

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,28 @@
 [tox]
-envlist = py3{6,7,8}, test-devel
+envlist = py3{6,7,8}-{readme,test,devel}
 
 [travis]
 python =
-    3.8: py38
-    3.7: py37
-    3.6: py36
+    3.8: py38-test, py38-readme, py38-devel
+    3.7: py37-test, py37-readme, py37-devel
+    3.6: py36-test, py36-readme, py36-devel
 
 [gh-actions]
 python =
-    3.8: py38, test-devel
-    3.7: py37
-    3.6: py36
+    3.8: py38-test, py38-readme, py38-devel
+    3.7: py37-test, py37-readme, py37-devel
+    3.6: py36-test, py36-readme, py36-devel
 
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
 skipsdist = false
 skip_install = false
-extras = test
+deps =
+    readme: rundoc
+extras =
+    test: test
+    devel: dev
 commands =
-    /usr/bin/env make test
-
-[testenv:test-devel]
-extras = dev
-commands =
-    /usr/bin/env make test-devel
+    readme: /usr/bin/env make test-readme
+    test: /usr/bin/env make test
+    devel: /usr/bin/env make test-devel


### PR DESCRIPTION
This PR changes the way the CI tests are executed to make the builds faster and also test different types of things.

Tests are now performed on both Github Actions, running Linux and macOS, and Travis, running macOS only, and using all the currently supported python versions.

Tests are also split in 5 different categories:
- `lint`: Validate coding style, run static tests and validate that there are no broken dependencies.
- `readme`: Install the package (no test dependencies) and run the readme snippets using `rundoc`.
- `unit`: Install the `test` dependencies and run `pytest`
- `minium`: Install the minimum versions declared in the `setup.py` and then run `pytest`.
- `tutorials`: Install the package (no test dependencies) and run the tutorial notebooks using `jupyter`.