### PR TITLE
Rename GaussianCopula distribution to field_distributions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 # Config file for automatic testing at travis-ci.org
+os: linux
 dist: bionic
 language: python
-os:
-  - linux
-  - osx
 python:
   - 3.6
   - 3.7

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,9 @@ test-readme: ## run the readme snippets
 
 .PHONY: test-tutorials
 test-tutorials: ## run the tutorial notebooks
-	find tutorials -path "*/.ipynb_checkpoints" -prune -false -o -name "*.ipynb" -exec \
-		jupyter nbconvert --execute --ExecutePreprocessor.timeout=3600 --to=html --stdout {} > /dev/null \;
+	find tutorials -path "*/.ipynb_checkpoints" -prune -false -o -name "*.ipynb" | \
+		xargs -n1 -I{} sh -c \
+		"jupyter nbconvert --execute --ExecutePreprocessor.timeout=3600 --to=html --stdout {} > /dev/null || exit 255"
 
 .PHONY: test
 test: test-unit test-readme test-tutorials ## test everything that needs test dependencies

--- a/sdv/sdv.py
+++ b/sdv/sdv.py
@@ -28,7 +28,7 @@ class SDV:
     DEFAULT_MODEL_KWARGS = {
         'model': GaussianCopula,
         'model_kwargs': {
-            'distribution': 'gaussian'
+            'default_distribution': 'gaussian',
         }
     }
 

--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -173,10 +173,13 @@ class GaussianCopula(BaseTabularModel):
             return distribution
         if distribution in cls._DISTRIBUTIONS:
             return cls._DISTRIBUTIONS[distribution]
-        if '.' in distribution:
-            return distribution
 
-        raise ValueError('Invalid distribution specification {}'.format(distribution))
+        try:
+            copulas.get_instance(distribution)
+            return distribution
+        except (ValueError, ImportError):
+            error_message = 'Invalid distribution specification {}'.format(distribution)
+            raise ValueError(error_message) from None
 
     def __init__(self, field_names=None, field_types=None, field_transformers=None,
                  anonymize_fields=None, primary_key=None, constraints=None, table_metadata=None,

--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -201,6 +201,9 @@ class GaussianCopula(BaseTabularModel):
                 if categorical_transformer is None:
                     categorical_transformer = model_kwargs['categorical_transformer']
 
+        if field_distributions and not isinstance(field_distributions, dict):
+            raise TypeError('field_distributions can only be None or a dict instance')
+
         self._field_distributions = {
             field: self._validate_distribution(distribution)
             for field, distribution in (field_distributions or {}).items()

--- a/tests/integration/tabular/test_copulas.py
+++ b/tests/integration/tabular/test_copulas.py
@@ -27,7 +27,7 @@ def test_gaussian_copula():
         field_types=field_types,
         primary_key='user_id',
         anonymize_fields=anonymize_fields,
-        distribution='gaussian_kde',
+        default_distribution='gaussian_kde',
     )
     gc.fit(users)
     with pytest.raises(NonParametricError):
@@ -39,7 +39,7 @@ def test_gaussian_copula():
         field_types=field_types,
         primary_key='user_id',
         anonymize_fields=anonymize_fields,
-        distribution='bounded',
+        default_distribution='bounded',
     )
     gc.fit(users)
 

--- a/tests/unit/tabular/test_copulas.py
+++ b/tests/unit/tabular/test_copulas.py
@@ -446,3 +446,64 @@ class TestGaussianCopula:
         gaussian_copula._rebuild_gaussian_copula.assert_called_once_with(expected)
         assert gaussian_copula._num_rows == 0
         assert isinstance(gaussian_copula._model, GaussianMultivariate)
+
+    def test__validate_distribution_none(self):
+        """Test the ``_validate_distribution`` method if None is passed.
+
+        If None is passed, it should just return None.
+
+        Input:
+        - None
+
+        Output:
+        - None
+        """
+        out = GaussianCopula._validate_distribution(None)
+
+        assert out is None
+
+    def test__validate_distribution_not_str(self):
+        """Test the ``_validate_distribution`` method if something that is not an str is passed.
+
+        If the input is not an str, it should be returned without modification.
+
+        Input:
+        - a dummy object
+
+        Output:
+        - the same dummy object
+        """
+        dummy = object()
+        out = GaussianCopula._validate_distribution(dummy)
+
+        assert out is dummy
+
+    def test__validate_distribution_distribution_name(self):
+        """Test the ``_validate_distribution`` method passing a valid distribution name.
+
+        If the input is one keys from the ``_DISTRIBUTIONS`` dict, the value should be returned.
+
+        Input:
+        - A key from the ``_DISTRIBUTIONS`` dict.
+
+        Output:
+        - The corresponding value.
+        """
+        out = GaussianCopula._validate_distribution('gaussian_kde')
+
+        assert out is GaussianKDE
+
+    def test__validate_distribution_fqn(self):
+        """Test the ``_validate_distribution`` method passing a FQN distribution name.
+
+        If the input is an importable FQN of a Python object, return the input.
+
+        Input:
+        - A univariate distribution FQN.
+
+        Output:
+        - The corresponding class.
+        """
+        out = GaussianCopula._validate_distribution('copulas.univariate.GaussianUnivariate')
+
+        assert out == 'copulas.univariate.GaussianUnivariate'

--- a/tests/unit/tabular/test_copulas.py
+++ b/tests/unit/tabular/test_copulas.py
@@ -12,37 +12,6 @@ from sdv.tabular.copulas import GaussianCopula
 
 class TestGaussianCopula:
 
-    def test___init__(self):
-        """Test ``__init__`` with empty input values.
-
-        All the parameters of the class are inicialized with the default values.
-
-        Expected Output
-        - None
-
-        Side Effects
-        - ``Table.from_dict`` is not called.
-        - ``table_metadata.get_model_kwargs`` is not called.
-        - ``_distribution`` is set to a instance of the indicated distribution.
-        """
-
-    def test__init__metadata(self):
-        """Test ``__init__`` with not empty input values for `table_metadata`.
-
-        Load the values of `table_metadata`
-
-        Input
-        - dict
-
-        Expected Output
-        - None
-
-        Side Effects
-        - ``Table.from_dict`` is called.
-        - ``table_metadata.get_model_kwargs`` is called.
-        - ``_distribution`` is set to a instance of the indicated distribution.
-        """
-
     def test__update_metadata_existing_model_kargs(self):
         """Test ``_update_metadata`` if metadata already has model_kwargs.
 
@@ -90,6 +59,7 @@ class TestGaussianCopula:
         gaussian_copula = Mock(spec_set=GaussianCopula)
         gaussian_copula._metadata.get_model_kwargs.return_value = dict()
         gaussian_copula._categorical_transformer = 'a_categorical_transformer_value'
+        gaussian_copula._default_distribution = 'a_distribution'
         gaussian_copula.get_distributions.return_value = {
             'foo': 'copulas.univariate.gaussian.GaussianUnivariate'
         }
@@ -100,7 +70,8 @@ class TestGaussianCopula:
         # Asserts
         assert out is None
         expected_kwargs = {
-            'distribution': {'foo': 'copulas.univariate.gaussian.GaussianUnivariate'},
+            'field_distributions': {'foo': 'copulas.univariate.gaussian.GaussianUnivariate'},
+            'default_distribution': 'a_distribution',
             'categorical_transformer': 'a_categorical_transformer_value',
         }
         gaussian_copula._metadata.set_model_kwargs.assert_called_once_with(
@@ -137,7 +108,7 @@ class TestGaussianCopula:
         """
         # Setup
         gaussian_copula = Mock(spec_set=GaussianCopula)
-        gaussian_copula._get_distribution.return_value = {'a': 'a_distribution'}
+        gaussian_copula._field_distributions = {'a': 'a_distribution'}
 
         # Run
         data = pd.DataFrame({
@@ -147,7 +118,7 @@ class TestGaussianCopula:
 
         # asserts
         assert out is None
-        assert gaussian_copula._distribution == {'a': 'a_distribution'}
+        assert gaussian_copula._field_distributions == {'a': 'a_distribution'}
         gm_mock.assert_called_once_with(distribution={'a': 'a_distribution'})
 
         assert gaussian_copula._model == gm_mock.return_value
@@ -311,7 +282,7 @@ class TestGaussianCopula:
         # Setup
         gaussian_copula = Mock(autospec=GaussianCopula)
         gaussian_copula._rebuild_covariance_matrix.return_value = [[0.4, 0.17], [0.17, 0.07]]
-        gaussian_copula._distribution = {'foo': 'GaussianUnivariate'}
+        gaussian_copula._field_distributions = {'foo': 'GaussianUnivariate'}
 
         # Run
         model_parameters = {

--- a/tutorials/single_table_data/01_GaussianCopula_Model.ipynb
+++ b/tutorials/single_table_data/01_GaussianCopula_Model.ipynb
@@ -2498,8 +2498,8 @@
     "\n",
     "The `GaussianCopula` class offers the possibility to indicate which distribution to use\n",
     "for each one of the columns in the table, in order to solve situations like the one\n",
-    "that we just described. In order to do this, we need to pass a `distributions` argument\n",
-    "with `dict` that indicates, the distribution that we want to use for each column.\n",
+    "that we just described. In order to do this, we need to pass a `field_distributions` argument\n",
+    "with `dict` that indicates the distribution that we want to use for each column.\n",
     "\n",
     "Possible values for the distribution argument are:\n",
     "\n",
@@ -2543,7 +2543,7 @@
     "\n",
     "model = GaussianCopula(\n",
     "    primary_key='student_id',\n",
-    "    distribution={\n",
+    "    field_distributions={\n",
     "        'experience_years': 'gamma'\n",
     "    }\n",
     ")\n",
@@ -2702,7 +2702,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Resolve #237 

GaussianCopula `distribution` argument is renamed to `field_distributions` to follow the `rdt` and `CopulaGAN` convention.