### PR TITLE
Ensure that field dtype is preserved

### DIFF
--- a/tests/integration/tabular/test_copulas.py
+++ b/tests/integration/tabular/test_copulas.py
@@ -88,3 +88,25 @@ def test_gaussian_copula():
 
     assert 'model_kwargs' in metadata
     assert 'GaussianCopula' in metadata['model_kwargs']
+
+
+def test_integer_categoricals():
+    """Ensure integer categoricals are still sampled as integers.
+
+    The origin of this tests can be found in the github issue #194:
+    https://github.com/sdv-dev/SDV/issues/194
+    """
+    users = load_demo(metadata=False)['users']
+
+    field_types = {
+        'age': {
+            'type': 'categorical',
+        },
+    }
+    gc = GaussianCopula(field_types=field_types, categorical_transformer='categorical')
+    gc.fit(users)
+
+    sampled = gc.sample()
+
+    assert  users['age'].dtype == 'int'
+    assert  sampled['age'].dtype == 'int'

--- a/tests/integration/tabular/test_copulas.py
+++ b/tests/integration/tabular/test_copulas.py
@@ -108,5 +108,5 @@ def test_integer_categoricals():
 
     sampled = gc.sample()
 
-    assert  users['age'].dtype == 'int'
-    assert  sampled['age'].dtype == 'int'
+    assert users['age'].dtype == 'int'
+    assert sampled['age'].dtype == 'int'

--- a/tests/integration/test_sdv.py
+++ b/tests/integration/test_sdv.py
@@ -1,6 +1,4 @@
-import pandas as pd
-
-from sdv import SDV, Metadata, load_demo
+from sdv import SDV, load_demo
 
 
 def test_sdv():

--- a/tests/integration/test_sdv.py
+++ b/tests/integration/test_sdv.py
@@ -1,4 +1,6 @@
-from sdv import SDV, load_demo
+import pandas as pd
+
+from sdv import SDV, Metadata, load_demo
 
 
 def test_sdv():
@@ -70,3 +72,23 @@ def test_sdv_multiparent():
 
     assert character_families.shape == tables['character_families'].shape
     assert set(character_families.columns) == set(tables['character_families'].columns)
+
+
+def test_integer_categoricals():
+    """Ensure integer categoricals are still sampled as integers.
+
+    The origin of this tests can be found in the github issue #194:
+    https://github.com/sdv-dev/SDV/issues/194
+    """
+    metadata, tables = load_demo(metadata=True)
+    metadata_dict = metadata.to_dict()
+    metadata_dict['tables']['users']['fields']['age'] = {
+        'type': 'categorical'
+    }
+
+    sdv = SDV()
+    sdv.fit(metadata, tables)
+    sampled = sdv.sample()
+
+    for name, table in tables.items():
+        assert (sampled[name].dtypes == table.dtypes).all()


### PR DESCRIPTION
Ensure that the field dtypes is preserved after sampling, independently from the type of field

Resolve #194 