### PR TITLE
Issue 214 hma1 default to categorical fuzzy

### DIFF
--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -631,8 +631,9 @@ class Table:
                 Dict metadata to load.
         """
         instance = cls()
-        instance._fields_metadata = copy.deepcopy(metadata_dict['fields'])
-        instance._field_names = list(instance._fields_metadata.keys())
+        fields = metadata_dict['fields']
+        instance._fields_metadata = copy.deepcopy(fields)
+        instance._field_names = list(fields.keys()) if fields else None
         instance._constraints = copy.deepcopy(metadata_dict.get('constraints', []))
         instance._model_kwargs = copy.deepcopy(metadata_dict.get('model_kwargs', {}))
         instance._primary_key = metadata_dict.get('primary_key')

--- a/sdv/relational/hma.py
+++ b/sdv/relational/hma.py
@@ -32,11 +32,8 @@ class HMA1(BaseRelationalModel):
 
     DEFAULT_MODEL = GaussianCopula
     DEFAULT_MODEL_KWARGS = {
-        'model': GaussianCopula,
-        'model_kwargs': {
-            'default_distribution': 'gaussian',
-            'categorical_transformer': 'categorical_fuzzy',
-        }
+        'default_distribution': 'gaussian',
+        'categorical_transformer': 'categorical_fuzzy',
     }
 
     def __init__(self, metadata, root_path=None, model=None, model_kwargs=None):

--- a/sdv/relational/hma.py
+++ b/sdv/relational/hma.py
@@ -9,7 +9,6 @@ from sdv.relational.base import BaseRelationalModel
 from sdv.tabular.copulas import GaussianCopula
 
 LOGGER = logging.getLogger(__name__)
-DEFAULT_MODEL = GaussianCopula
 
 
 class HMA1(BaseRelationalModel):
@@ -26,16 +25,32 @@ class HMA1(BaseRelationalModel):
             Class of the ``copula`` to use. Defaults to
             ``sdv.models.copulas.GaussianCopula``.
         model_kwargs (dict):
-            Keyword arguments to pass to the model. Defaults to ``None``.
+            Keyword arguments to pass to the model. If the default model is used, this
+            defaults to using a ``gaussian`` distribution and a ``categorical_fuzzy``
+            transformer.
     """
 
-    def __init__(self, metadata, root_path=None, model=DEFAULT_MODEL, model_kwargs=None):
+    DEFAULT_MODEL = GaussianCopula
+    DEFAULT_MODEL_KWARGS = {
+        'model': GaussianCopula,
+        'model_kwargs': {
+            'default_distribution': 'gaussian',
+            'categorical_transformer': 'categorical_fuzzy',
+        }
+    }
+
+    def __init__(self, metadata, root_path=None, model=None, model_kwargs=None):
         super().__init__(metadata, root_path)
 
-        self._model = model or DEFAULT_MODEL
-        self._model_kwargs = model_kwargs or dict()
-        self._models = dict()
-        self._table_sizes = dict()
+        if model is None:
+            model = self.DEFAULT_MODEL
+            if model_kwargs is None:
+                model_kwargs = self.DEFAULT_MODEL_KWARGS
+
+        self._model = model
+        self._model_kwargs = model_kwargs or {}
+        self._models = {}
+        self._table_sizes = {}
 
     # ######## #
     # MODELING #

--- a/sdv/sdv.py
+++ b/sdv/sdv.py
@@ -20,7 +20,8 @@ class SDV:
             Class of the model to use. Defaults to ``sdv.relational.HMA1``.
         model_kwargs (dict):
             Keyword arguments to pass to the model. If no ``model`` is given,
-            this defaults to using a ``GaussianCopula`` with ``gaussian`` distribution.
+            this defaults to using a ``GaussianCopula`` with ``gaussian`` distribution
+            and ``categorical_fuzzy`` categorical transformer.
     """
 
     _model_instance = None
@@ -29,6 +30,7 @@ class SDV:
         'model': GaussianCopula,
         'model_kwargs': {
             'default_distribution': 'gaussian',
+            'categorical_transformer': 'categorical_fuzzy',
         }
     }
 

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -83,6 +83,8 @@ class BaseTabularModel:
             if isinstance(table_metadata, dict):
                 table_metadata = Table.from_dict(table_metadata)
 
+            table_metadata._dtype_transformers.update(self._DTYPE_TRANSFORMERS)
+
             self._metadata = table_metadata
             self._metadata_fitted = table_metadata.fitted
 

--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -212,9 +212,8 @@ class GaussianCopula(BaseTabularModel):
             self._validate_distribution(default_distribution) or self._DEFAULT_DISTRIBUTION
         )
 
-        categorical_transformer = categorical_transformer or self._DEFAULT_TRANSFORMER
-        self._categorical_transformer = categorical_transformer
-        self._DTYPE_TRANSFORMERS = {'O': categorical_transformer}
+        self._categorical_transformer = categorical_transformer or self._DEFAULT_TRANSFORMER
+        self._DTYPE_TRANSFORMERS = {'O': self._categorical_transformer}
 
         super().__init__(
             field_names=field_names,
@@ -225,6 +224,12 @@ class GaussianCopula(BaseTabularModel):
             constraints=constraints,
             table_metadata=table_metadata,
         )
+
+        self._metadata.set_model_kwargs(self.__class__.__name__, {
+            'field_distributions': field_distributions,
+            'default_distribution': default_distribution,
+            'categorical_transformer': categorical_transformer,
+        })
 
     def get_distributions(self):
         """Get the marginal distributions used by this copula.
@@ -252,14 +257,12 @@ class GaussianCopula(BaseTabularModel):
             - categorical_transformer
         """
         class_name = self.__class__.__name__
-        model_kwargs = self._metadata.get_model_kwargs(class_name)
-        if not model_kwargs:
-            distributions = self.get_distributions()
-            self._metadata.set_model_kwargs(class_name, {
-                'field_distributions': distributions,
-                'default_distribution': self._default_distribution,
-                'categorical_transformer': self._categorical_transformer,
-            })
+        distributions = self.get_distributions()
+        self._metadata.set_model_kwargs(class_name, {
+            'field_distributions': distributions,
+            'default_distribution': self._default_distribution,
+            'categorical_transformer': self._categorical_transformer,
+        })
 
     def _fit(self, table_data):
         """Fit the model to the table.

--- a/tests/integration/relational/test_hma.py
+++ b/tests/integration/relational/test_hma.py
@@ -1,0 +1,28 @@
+import rdt
+from copulas.univariate import BetaUnivariate
+
+from sdv.demo import load_demo
+from sdv.relational import HMA1
+from sdv.tabular import GaussianCopula
+
+
+def test_sdv_model_kwargs():
+    metadata, tables = load_demo(metadata=True)
+    tables = {'users': tables['users']}
+    metadata = metadata.to_dict()
+    del metadata['tables']['sessions']
+    del metadata['tables']['transactions']
+
+    hma = HMA1(metadata, model=GaussianCopula, model_kwargs={
+        'default_distribution': 'beta',
+        'categorical_transformer': 'label_encoding',
+    })
+    hma.fit(tables)
+
+    model = hma._models['users']
+    assert model._default_distribution == BetaUnivariate
+    assert model._DTYPE_TRANSFORMERS['O'] == 'label_encoding'
+    assert isinstance(
+        model._metadata._hyper_transformer._transformers['gender'],
+        rdt.transformers.categorical.LabelEncodingTransformer
+    )

--- a/tests/integration/tabular/test_copulas.py
+++ b/tests/integration/tabular/test_copulas.py
@@ -113,3 +113,16 @@ def test_integer_categoricals():
 
     assert users['age'].dtype == np.int64
     assert sampled['age'].dtype == np.int64
+
+
+def test_parameters():
+    gc = GaussianCopula(
+        field_distributions={'foo': 'beta'},
+        default_distribution='gaussian_kde',
+        categorical_transformer='label_encoding'
+    )
+    new_gc = GaussianCopula(
+        table_metadata=gc.get_metadata().to_dict()
+    )
+
+    assert new_gc._metadata._dtype_transformers['O'] == 'label_encoding'


### PR DESCRIPTION
Resolve #214 

Make the HMA1 and SDV classes use the `categorical_fuzzy` transformer by default.
Also use the `gaussian` distribution by default on HMA1 and ensure that passed model arguments are properly passed down the tabular models.