### PR TITLE
Fix dependency error 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - if: matrix.os == 'windows-latest'
       name: Install dependencies - Windows
-      run: pip install 'torch>=1,<2' -f https://download.pytorch.org/whl/torch_stable.html
+      run: pip install torch==1.7.0+cpu torchvision==0.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
     - name: Install package
       run: pip install invoke .[dev]
     - name: invoke lint
@@ -58,7 +58,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - if: matrix.os == 'windows-latest'
       name: Install dependencies - Windows
-      run: pip install 'torch>=1,<2' -f https://download.pytorch.org/whl/torch_stable.html
+      run: pip install torch==1.7.0+cpu torchvision==0.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
     - name: Install package and dependencies
       run: pip install invoke .[test]
     - name: invoke pytest


### PR DESCRIPTION
The current version on master runs into dependency issues on Windows with the future library which is required by torch/torchvision. This PR pins the torch/torchvision libraries to a version that we know works on Windows (i.e. there is a compatible version of the future library). This change can be undone when the upstream repositories are fixed.