### PR TITLE
Add dtype_transformers to Table.from_dict

### DIFF
--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -633,6 +633,8 @@ class Table:
         Args:
             metadata_dict (dict):
                 Dict metadata to load.
+            dtype_transformers (dict):
+                If passed, set the dtype_transformers on the new instance.
         """
         metadata_dict = copy.deepcopy(metadata_dict)
         fields = metadata_dict['fields'] or {}

--- a/sdv/timeseries/base.py
+++ b/sdv/timeseries/base.py
@@ -115,7 +115,10 @@ class BaseTimeseriesModel:
                         'If table_metadata is given {} must be None'.format(arg.__name__))
 
             if isinstance(table_metadata, dict):
-                table_metadata = Table.from_dict(table_metadata)
+                table_metadata = Table.from_dict(
+                    table_metadata,
+                    dtype_transformers=self._DTYPE_TRANSFORMERS,
+                )
 
             self._metadata = table_metadata
             self._metadata_fitted = table_metadata.fitted

--- a/tasks.py
+++ b/tasks.py
@@ -41,7 +41,7 @@ def install_minimum(c):
 def minimum(c):
     install_minimum(c)
     c.run('python -m pip check')
-    c.run('python -m pytest')
+    c.run('python -m pytest --reruns 5')
 
 
 @task

--- a/tests/integration/tabular/test_copulagan.py
+++ b/tests/integration/tabular/test_copulagan.py
@@ -52,3 +52,34 @@ def test_copulagan():
         'model_kwargs': {},
         'name': None
     }
+
+
+def test_recreate():
+    data = load_demo(metadata=False)['users']
+
+    # If distribution is non parametric, get_parameters fails
+    model = CopulaGAN(epochs=1)
+    model.fit(data)
+    sampled = model.sample()
+
+    assert sampled.shape == data.shape
+    assert (sampled.dtypes == data.dtypes).all()
+    assert (sampled.notnull().sum(axis=1) != 0).all()
+
+    # Metadata
+    model_meta = CopulaGAN(epochs=1, table_metadata=model.get_metadata())
+    model_meta.fit(data)
+    sampled = model_meta.sample()
+
+    assert sampled.shape == data.shape
+    assert (sampled.dtypes == data.dtypes).all()
+    assert (sampled.notnull().sum(axis=1) != 0).all()
+
+    # Metadata dict
+    model_meta_dict = CopulaGAN(epochs=1, table_metadata=model.get_metadata().to_dict())
+    model_meta_dict.fit(data)
+    sampled = model_meta_dict.sample()
+
+    assert sampled.shape == data.shape
+    assert (sampled.dtypes == data.dtypes).all()
+    assert (sampled.notnull().sum(axis=1) != 0).all()

--- a/tests/integration/tabular/test_copulas.py
+++ b/tests/integration/tabular/test_copulas.py
@@ -126,3 +126,34 @@ def test_parameters():
     )
 
     assert new_gc._metadata._dtype_transformers['O'] == 'label_encoding'
+
+
+def test_recreate():
+    data = load_demo(metadata=False)['users']
+
+    # If distribution is non parametric, get_parameters fails
+    model = GaussianCopula()
+    model.fit(data)
+    sampled = model.sample()
+
+    assert sampled.shape == data.shape
+    assert (sampled.dtypes == data.dtypes).all()
+    assert (sampled.notnull().sum(axis=1) != 0).all()
+
+    # Metadata
+    model_meta = GaussianCopula(table_metadata=model.get_metadata())
+    model_meta.fit(data)
+    sampled = model_meta.sample()
+
+    assert sampled.shape == data.shape
+    assert (sampled.dtypes == data.dtypes).all()
+    assert (sampled.notnull().sum(axis=1) != 0).all()
+
+    # Metadata dict
+    model_meta_dict = GaussianCopula(table_metadata=model.get_metadata().to_dict())
+    model_meta_dict.fit(data)
+    sampled = model_meta_dict.sample()
+
+    assert sampled.shape == data.shape
+    assert (sampled.dtypes == data.dtypes).all()
+    assert (sampled.notnull().sum(axis=1) != 0).all()

--- a/tests/integration/tabular/test_ctgan.py
+++ b/tests/integration/tabular/test_ctgan.py
@@ -49,3 +49,34 @@ def test_ctgan():
         'name': None
     }
     assert ctgan.get_metadata().to_dict() == expected_metadata
+
+
+def test_recreate():
+    data = load_demo(metadata=False)['users']
+
+    # If distribution is non parametric, get_parameters fails
+    model = CTGAN(epochs=1)
+    model.fit(data)
+    sampled = model.sample()
+
+    assert sampled.shape == data.shape
+    assert (sampled.dtypes == data.dtypes).all()
+    assert (sampled.notnull().sum(axis=1) != 0).all()
+
+    # Metadata
+    model_meta = CTGAN(epochs=1, table_metadata=model.get_metadata())
+    model_meta.fit(data)
+    sampled = model_meta.sample()
+
+    assert sampled.shape == data.shape
+    assert (sampled.dtypes == data.dtypes).all()
+    assert (sampled.notnull().sum(axis=1) != 0).all()
+
+    # Metadata dict
+    model_meta_dict = CTGAN(epochs=1, table_metadata=model.get_metadata().to_dict())
+    model_meta_dict.fit(data)
+    sampled = model_meta_dict.sample()
+
+    assert sampled.shape == data.shape
+    assert (sampled.dtypes == data.dtypes).all()
+    assert (sampled.notnull().sum(axis=1) != 0).all()

--- a/tests/integration/timeseries/test_par.py
+++ b/tests/integration/timeseries/test_par.py
@@ -1,0 +1,49 @@
+import pandas as pd
+from deepecho import load_demo
+
+from sdv.timeseries.deepecho import PAR
+
+
+def test_par():
+    data = load_demo()
+    data['date'] = pd.to_datetime(data['date'])
+
+    model = PAR(
+        entity_columns=['store_id'],
+        context_columns=['region'],
+        sequence_index='date',
+        epochs=1,
+    )
+    model.fit(data)
+
+    sampled = model.sample()
+
+    assert sampled.shape == data.shape
+    assert (sampled.dtypes == data.dtypes).all()
+    assert (sampled.notnull().sum(axis=1) != 0).all()
+
+    # Metadata
+    model_meta = PAR(
+        table_metadata=model.get_metadata(),
+        epochs=1,
+    )
+    model_meta.fit(data)
+
+    sampled = model_meta.sample()
+
+    assert sampled.shape == data.shape
+    assert (sampled.dtypes == data.dtypes).all()
+    assert (sampled.notnull().sum(axis=1) != 0).all()
+
+    # Metadata dict
+    model_meta_dict = PAR(
+        table_metadata=model.get_metadata().to_dict(),
+        epochs=1,
+    )
+    model_meta_dict.fit(data)
+
+    sampled = model_meta_dict.sample()
+
+    assert sampled.shape == data.shape
+    assert (sampled.dtypes == data.dtypes).all()
+    assert (sampled.notnull().sum(axis=1) != 0).all()


### PR DESCRIPTION
Add a `dtype_transformers` argument to the `Table.from_dict` method to facilitate the setup of the `Table` object as required for different models.
Also add integration tests to verify that this is actually working on all the tabular models.