### PR TITLE
Add TVAE to api_reference and models index

### DIFF
--- a/docs/api_reference/tabular.rst
+++ b/docs/api_reference/tabular.rst
@@ -48,3 +48,16 @@ CouplaGAN
    CopulaGAN.get_distributions
    CopulaGAN.save
    CopulaGAN.load
+
+TVAE
+~~~~
+
+.. autosummary::
+   :toctree: api/
+
+   TVAE
+   TVAE.fit
+   TVAE.sample
+   TVAE.get_metadata
+   TVAE.save
+   TVAE.load

--- a/docs/user_guides/single_table/models.rst
+++ b/docs/user_guides/single_table/models.rst
@@ -9,3 +9,4 @@ Models
     gaussian_copula
     ctgan
     copulagan
+    tvae


### PR DESCRIPTION
Add TVAE model to the models index and to the API reference section of the docs.