### PR TITLE
Issue 286: UniqueCombinations pickle error

### DIFF
--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -122,7 +122,7 @@ class UniqueCombinations(Constraint):
             self._separator += '#'
 
         self._joint_column = self._separator.join(self._columns)
-        self._combinations = set(table_data[self._columns].itertuples(index=False))
+        self._combinations = table_data[self._columns].drop_duplicates().copy()
 
     def is_valid(self, table_data):
         """Say whether the column values are within the original combinations.
@@ -135,11 +135,13 @@ class UniqueCombinations(Constraint):
             pandas.Series:
                 Whether each row is valid.
         """
-        tuples = pd.Series(
-            table_data[self._columns].itertuples(index=False),
-            index=table_data.index
+        merged = table_data.merge(
+            self._combinations,
+            how='left',
+            on=self._columns,
+            indicator=self._joint_column
         )
-        return tuples.isin(self._combinations)
+        return merged[self._joint_column] == 'both'
 
     def transform(self, table_data):
         """Transform the table data.

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
 ignore = D105, D107, SFS2  # SFS2 can be changed to SFS3 if supporting >=3.6 only
 
 [isort]
-include_trailing_comment = True
 line_length = 99
 lines_between_types = 0
 multi_line_output = 4

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires = [
     'copulas>=0.3.3,<0.4',
     'rdt>=0.2.10,<0.3',
     'sdmetrics>=0.1.1,<0.2.0',
-    'deepecho==0.1.3',
+    'deepecho>=0.1.3,<0.2',
 ]
 
 setup_requires = [

--- a/tests/integration/test_constraints.py
+++ b/tests/integration/test_constraints.py
@@ -7,7 +7,7 @@ def years_in_the_company(data):
     return data['age'] - data['age_when_joined']
 
 
-def test_constraints():
+def test_constraints(tmpdir):
 
     employees = load_tabular_demo()
 
@@ -35,4 +35,6 @@ def test_constraints():
     ]
     gc = GaussianCopula(constraints=constraints)
     gc.fit(employees)
+    gc.save(tmpdir / 'test.pkl')
+    gc = gc.load(tmpdir / 'test.pkl')
     gc.sample(10)

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -172,10 +172,13 @@ class TestUniqueCombinations():
         instance.fit(table_data)
 
         # Asserts
-        expected_combinations = set(table_data[columns].itertuples(index=False))
+        expected_combinations = pd.DataFrame({
+            'b': ['d', 'e', 'f'],
+            'c': ['g', 'h', 'i']
+        })
         assert instance._separator == '#'
         assert instance._joint_column == 'b#c'
-        assert instance._combinations == expected_combinations
+        pd.testing.assert_frame_equal(instance._combinations, expected_combinations)
 
     def test_is_valid_true(self):
         """Test the ``UniqueCombinations.is_valid`` method.
@@ -203,8 +206,7 @@ class TestUniqueCombinations():
         # Run
         out = instance.is_valid(table_data)
 
-        # Assert
-        expected_out = pd.Series([True, True, True])
+        expected_out = pd.Series([True, True, True], name='b#c')
         pd.testing.assert_series_equal(expected_out, out)
 
     def test_is_valid_false(self):
@@ -239,7 +241,7 @@ class TestUniqueCombinations():
         out = instance.is_valid(incorrect_table)
 
         # Assert
-        expected_out = pd.Series([False, False, False])
+        expected_out = pd.Series([False, False, False], name='b#c')
         pd.testing.assert_series_equal(expected_out, out)
 
     def test_transform(self):


### PR DESCRIPTION
Resolve #286: Change the way combinations are stored within the constraint class to avoid a pickle error on save.