### PR TITLE
Avoid reject sampling crash if 0 rows are valid

### DIFF
--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -155,17 +155,17 @@ class BaseTabularModel:
         num_valid = len(sampled)
 
         counter = 0
+        total_sampled = num_to_sample
         while num_valid < num_rows:
             counter += 1
             if counter >= max_retries:
                 raise ValueError('Could not get enough valid rows within %s trials', max_retries)
 
-            invalid = num_rows - num_valid
             remaining = num_rows - num_valid
-            proportion = counter * num_rows / num_valid
-            num_to_sample = int(remaining * proportion)
+            valid_ratio = num_valid / total_sampled
+            num_to_sample = int(counter * remaining / (valid_ratio if valid_ratio != 0 else 1))
 
-            LOGGER.info('%s invalid rows found. Resampling %s rows', invalid, num_to_sample)
+            LOGGER.info('%s valid rows remaining. Resampling %s rows', remaining, num_to_sample)
             resampled = self._sample(num_to_sample)
             resampled = self._metadata.reverse_transform(resampled)
 

--- a/tests/integration/test_constraints.py
+++ b/tests/integration/test_constraints.py
@@ -1,4 +1,6 @@
-from sdv.constraints import ColumnFormula, GreaterThan, UniqueCombinations
+import pandas as pd
+
+from sdv.constraints import ColumnFormula, CustomConstraint, GreaterThan, UniqueCombinations
 from sdv.demo import load_tabular_demo
 from sdv.tabular import GaussianCopula
 
@@ -37,4 +39,30 @@ def test_constraints(tmpdir):
     gc.fit(employees)
     gc.save(tmpdir / 'test.pkl')
     gc = gc.load(tmpdir / 'test.pkl')
+    gc.sample(10)
+
+
+_IS_VALID_CALLED = []
+
+
+def _is_valid(rows):
+    if not _IS_VALID_CALLED:
+        _IS_VALID_CALLED.append(True)
+        return pd.Series([False] * len(rows), index=rows.index)
+
+    return pd.Series([True] * len(rows), index=rows.index)
+
+
+def test_constraints_reject_sampling_zero_valid():
+    """Ensure everything works if no rows are valid on the first try.
+
+    See https://github.com/sdv-dev/SDV/issues/285
+    """
+    employees = load_tabular_demo()
+
+    _IS_VALID_CALLED.clear()
+    constraint = CustomConstraint(is_valid=_is_valid)
+
+    gc = GaussianCopula(constraints=[constraint])
+    gc.fit(employees)
     gc.sample(10)


### PR DESCRIPTION
Resolve #285: Avoid ZeroDivision error when `reject_sampling` strategy is used and 0 rows are valid during the first sampling attempts.