### PR TITLE
Multi-parent re-model and re-sample issue

### DIFF
--- a/sdv/metadata/visualization.py
+++ b/sdv/metadata/visualization.py
@@ -56,8 +56,8 @@ def _add_nodes(metadata, digraph):
 
         parents = metadata.get_parents(table)
         for parent in parents:
-            foreign_key = metadata.get_foreign_key(parent, table)
-            extras.append('Foreign key ({}): {}'.format(parent, foreign_key))
+            for foreign_key in metadata.get_foreign_keys(parent, table):
+                extras.append('Foreign key ({}): {}'.format(parent, foreign_key))
 
         path = metadata.get_table_meta(table).get('path')
         if path is not None:
@@ -80,13 +80,17 @@ def _add_edges(metadata, digraph):
     """
     for table in metadata.get_tables():
         for parent in list(metadata.get_parents(table)):
+            label = '\n'.join([
+                '   {}.{} -> {}.{}'.format(
+                    table, foreign_key,
+                    parent, metadata.get_primary_key(parent)
+                )
+                for foreign_key in metadata.get_foreign_keys(parent, table)
+            ])
             digraph.edge(
                 parent,
                 table,
-                label='   {}.{} -> {}.{}'.format(
-                    table, metadata.get_foreign_key(parent, table),
-                    parent, metadata.get_primary_key(parent)
-                ),
+                label=label,
                 arrowhead='oinv'
             )
 

--- a/sdv/relational/hma.py
+++ b/sdv/relational/hma.py
@@ -90,7 +90,7 @@ class HMA1(BaseRelationalModel):
             model.fit(child_rows.reset_index(drop=True))
             row = model.get_parameters()
             row = pd.Series(row)
-            row.index = '__' + child_name + '__' + row.index
+            row.index = f'__{child_name}__{foreign_key}__' + row.index
             extension_rows.append(row)
 
         return pd.DataFrame(extension_rows, index=foreign_key_values)
@@ -107,15 +107,16 @@ class HMA1(BaseRelationalModel):
     def _extend_table(self, table, tables, table_name):
         LOGGER.info('Computing extensions for table %s', table_name)
         for child_name in self.metadata.get_children(table_name):
-            child_key = self.metadata.get_foreign_key(table_name, child_name)
             if child_name not in self._models:
                 child_table = self._model_table(child_name, tables)
             else:
                 child_table = tables[child_name]
 
-            extension = self._get_extension(child_name, child_table, child_key)
-            table = table.merge(extension, how='left', right_index=True, left_index=True)
-            table['__' + child_name + '__num_rows'].fillna(0, inplace=True)
+            foreign_keys = self.metadata.get_foreign_keys(table_name, child_name)
+            for index, foreign_key in enumerate(foreign_keys):
+                extension = self._get_extension(child_name, child_table, foreign_key)
+                table = table.merge(extension, how='left', right_index=True, left_index=True)
+                table[f'__{child_name}__{foreign_key}__num_rows'].fillna(0, inplace=True)
 
         return table
 
@@ -238,18 +239,22 @@ class HMA1(BaseRelationalModel):
             parents = self.metadata.get_parents(table_name)
             if parents:
                 for parent_name in parents:
-                    foreign_key = self.metadata.get_foreign_key(parent_name, table_name)
-                    if foreign_key not in table_rows:
-                        parent_ids = self._find_parent_ids(table_name, parent_name, sampled_data)
-                        table_rows[foreign_key] = parent_ids
+                    foreign_keys = self.metadata.get_foreign_keys(parent_name, table_name)
+                    for foreign_key in foreign_keys:
+                        if foreign_key not in table_rows:
+                            parent_ids = self._find_parent_ids(
+                                table_name, parent_name, foreign_key, sampled_data)
+                            table_rows[foreign_key] = parent_ids
 
-            fields = self.metadata.get_fields(table_name)
+            dtypes = self.metadata.get_dtypes(table_name, ids=True)
+            for name, dtype in dtypes.items():
+                table_rows[name] = table_rows[name].dropna().astype(dtype)
 
-            final_data[table_name] = table_rows[list(fields.keys())]
+            final_data[table_name] = table_rows[list(dtypes.keys())]
 
         return final_data
 
-    def _extract_parameters(self, parent_row, table_name):
+    def _extract_parameters(self, parent_row, table_name, foreign_key):
         """Get the params from a generated parent row.
 
         Args:
@@ -257,8 +262,11 @@ class HMA1(BaseRelationalModel):
                 A generated parent row.
             table_name (str):
                 Name of the table to make the model for.
+            foreign_key (str):
+                Name of the foreign key used to form this
+                parent child relationship.
         """
-        prefix = '__{}__'.format(table_name)
+        prefix = f'__{table_name}__{foreign_key}__'
         keys = [key for key in parent_row.keys() if key.startswith(prefix)]
         new_keys = {key: key[len(prefix):] for key in keys}
         flat_parameters = parent_row[keys]
@@ -295,7 +303,8 @@ class HMA1(BaseRelationalModel):
                     self._sample_child_rows(child_name, table_name, row, sampled_data)
 
     def _sample_child_rows(self, table_name, parent_name, parent_row, sampled_data):
-        parameters = self._extract_parameters(parent_row, table_name)
+        foreign_key = self.metadata.get_foreign_keys(parent_name, table_name)[0]
+        parameters = self._extract_parameters(parent_row, table_name, foreign_key)
 
         table_meta = self._models[table_name].get_metadata()
         model = self._model(table_metadata=table_meta)
@@ -304,7 +313,6 @@ class HMA1(BaseRelationalModel):
         table_rows = self._sample_rows(model, table_name)
         if not table_rows.empty:
             parent_key = self.metadata.get_primary_key(parent_name)
-            foreign_key = self.metadata.get_foreign_key(parent_name, table_name)
             table_rows[foreign_key] = parent_row[parent_key]
 
             previous = sampled_data.get(table_name)
@@ -336,10 +344,10 @@ class HMA1(BaseRelationalModel):
 
         return np.random.choice(likelihoods.index, p=weights)
 
-    def _get_likelihoods(self, table_rows, parent_rows, table_name):
+    def _get_likelihoods(self, table_rows, parent_rows, table_name, foreign_key):
         likelihoods = dict()
         for parent_id, row in parent_rows.iterrows():
-            parameters = self._extract_parameters(row, table_name)
+            parameters = self._extract_parameters(row, table_name, foreign_key)
             table_meta = self._models[table_name].get_metadata()
             model = self._model(table_metadata=table_meta)
             model.set_parameters(parameters)
@@ -350,7 +358,7 @@ class HMA1(BaseRelationalModel):
 
         return pd.DataFrame(likelihoods, index=table_rows.index)
 
-    def _find_parent_ids(self, table_name, parent_name, sampled_data):
+    def _find_parent_ids(self, table_name, parent_name, foreign_key, sampled_data):
         table_rows = sampled_data[table_name]
         if parent_name in sampled_data:
             parent_rows = sampled_data[parent_name]
@@ -362,9 +370,9 @@ class HMA1(BaseRelationalModel):
 
         primary_key = self.metadata.get_primary_key(parent_name)
         parent_rows = parent_rows.set_index(primary_key)
-        num_rows = parent_rows['__' + table_name + '__num_rows'].fillna(0).clip(0)
+        num_rows = parent_rows[f'__{table_name}__{foreign_key}__num_rows'].fillna(0).clip(0)
 
-        likelihoods = self._get_likelihoods(table_rows, parent_rows, table_name)
+        likelihoods = self._get_likelihoods(table_rows, parent_rows, table_name, foreign_key)
         return likelihoods.apply(self._find_parent_id, axis=1, num_rows=num_rows)
 
     def _sample_table(self, table_name, num_rows=None, sample_children=True, sampled_data=None):

--- a/tests/integration/datasets.py
+++ b/tests/integration/datasets.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+from sdv import Metadata
+
+
+def load_multi_foreign_key():
+    parent = pd.DataFrame({
+        'parent_id': range(10),
+        'value': range(10)
+    })
+    child = pd.DataFrame({
+        'parent_1_id': range(10),
+        'parent_2_id': range(10),
+        'value': range(10)
+    })
+
+    metadata = Metadata()
+    metadata.add_table('parent', parent, primary_key='parent_id')
+    metadata.add_table('child', child, parent='parent', foreign_key='parent_1_id')
+    metadata.add_relationship('parent', 'child', 'parent_2_id')
+
+    return metadata, {'parent': parent, 'child': child}

--- a/tests/integration/test_sdv.py
+++ b/tests/integration/test_sdv.py
@@ -1,4 +1,5 @@
 from sdv import SDV, load_demo
+from tests.integration import datasets
 
 
 def test_sdv():
@@ -70,6 +71,24 @@ def test_sdv_multiparent():
 
     assert character_families.shape == tables['character_families'].shape
     assert set(character_families.columns) == set(tables['character_families'].columns)
+
+
+def test_sdv_multi_foreign_key():
+    """Ensure multi-foreign-key datasets are properly covered.
+
+    Multi-foreign-key datasets are those that have one table with
+    2 foreign keys to the same parent.
+    """
+    metadata, tables = datasets.load_multi_foreign_key()
+
+    sdv = SDV()
+    sdv.fit(metadata, tables)
+
+    # Sample all
+    sampled = sdv.sample()
+
+    assert set(sampled.keys()) == {'parent', 'child'}
+    assert len(sampled['parent']) == 10
 
 
 def test_integer_categoricals():

--- a/tests/integration/test_sdv.py
+++ b/tests/integration/test_sdv.py
@@ -1,3 +1,5 @@
+from operator import attrgetter
+
 from sdv import SDV, load_demo
 from tests.integration import datasets
 
@@ -107,5 +109,6 @@ def test_integer_categoricals():
     sdv.fit(metadata, tables)
     sampled = sdv.sample()
 
+    kind = attrgetter('kind')
     for name, table in tables.items():
-        assert (sampled[name].dtypes == table.dtypes).all()
+        assert (sampled[name].dtypes.apply(kind) == table.dtypes.apply(kind)).all()

--- a/tests/unit/metadata/test_dataset.py
+++ b/tests/unit/metadata/test_dataset.py
@@ -590,27 +590,45 @@ class TestMetadata(TestCase):
         assert result == 'a_primary_key'
         metadata.get_table_meta.assert_called_once_with('test')
 
-    def test_get_foreign_key(self):
+    def test_get_foreign_keys(self):
         """Test get foreign key"""
         # Setup
-        fields = {
-            'a_field': {
-                'ref': {
-                    'table': 'parent',
-                    'field': 'a_primary_key'
+        metadata = Metadata({
+            'tables': {
+                'parent': {
+                    'fields': {
+                        'parent_id': {
+                            'type': 'id',
+                        }
+                    },
+                    'primary_key': 'parent_id'
                 },
-                'name': 'a_field'
+                'child': {
+                    'fields': {
+                        'parent_id': {
+                            'type': 'id',
+                            'ref': {
+                                'table': 'parent',
+                                'field': 'id'
+                            }
+                        },
+                        'parent_id_2': {
+                            'type': 'id',
+                            'ref': {
+                                'table': 'parent',
+                                'field': 'id'
+                            }
+                        },
+                    }
+                }
             }
-        }
-        metadata = Mock(spec_set=Metadata)
-        metadata.get_fields.return_value = fields
+        })
 
         # Run
-        result = Metadata.get_foreign_key(metadata, 'parent', 'child')
+        result = Metadata.get_foreign_keys(metadata, 'parent', 'child')
 
         # Asserts
-        assert result == 'a_field'
-        metadata.get_fields.assert_called_once_with('child')
+        assert result == ['parent_id', 'parent_id_2']
 
     def test_reverse_transform(self):
         """Test reverse transform"""

--- a/tests/unit/metadata/test_visualization.py
+++ b/tests/unit/metadata/test_visualization.py
@@ -54,7 +54,7 @@ def test__add_nodes():
 
     metadata.get_primary_key.return_value = 'b_field'
     metadata.get_parents.return_value = set(['other'])
-    metadata.get_foreign_key.return_value = 'c_field'
+    metadata.get_foreign_keys.return_value = ['c_field']
 
     metadata.get_table_meta.return_value = {'path': None}
 
@@ -72,7 +72,7 @@ def test__add_nodes():
     metadata.get_primary_key.assert_called_once_with('demo')
     metadata.get_parents.assert_called_once_with('demo')
     metadata.get_table_meta.assert_called_once_with('demo')
-    metadata.get_foreign_key.assert_called_once_with('other', 'demo')
+    metadata.get_foreign_keys.assert_called_once_with('other', 'demo')
     metadata.get_table_meta.assert_called_once_with('demo')
 
     plot.node.assert_called_once_with('demo', label=expected_node_label)
@@ -86,7 +86,7 @@ def test__add_edges():
     metadata.get_tables.return_value = ['demo', 'other']
     metadata.get_parents.side_effect = [set(['other']), set()]
 
-    metadata.get_foreign_key.return_value = 'fk'
+    metadata.get_foreign_keys.return_value = ['fk']
     metadata.get_primary_key.return_value = 'pk'
 
     plot = Mock()
@@ -98,7 +98,7 @@ def test__add_edges():
     expected_edge_label = '   {}.{} -> {}.{}'.format('demo', 'fk', 'other', 'pk')
 
     metadata.get_tables.assert_called_once_with()
-    metadata.get_foreign_key.assert_called_once_with('other', 'demo')
+    metadata.get_foreign_keys.assert_called_once_with('other', 'demo')
     metadata.get_primary_key.assert_called_once_with('other')
     assert metadata.get_parents.call_args_list == [call('demo'), call('other')]
 


### PR DESCRIPTION
This PR fixes a situation that happens in the multi-parent scenarios where the child tables are modeled and sampled multiple times, once per parent, increasing modeling and sampling times and also potentially breaking referential integrity if the `sample` method is called more than once without re-setting the primary key generators.

Also, as a consequence of the changes introduced in this PR, situations in which two foreign keys exists between one child and one parent (a situation like the one explained [here](https://github.com/sdv-dev/SDV/issues/185#issuecomment-692173794)), is now fully covered.