### PR TITLE
Ensure tables that contain nothing but ids can be modeled

### DIFF
--- a/sdv/relational/hma.py
+++ b/sdv/relational/hma.py
@@ -311,7 +311,7 @@ class HMA1(BaseRelationalModel):
         model.set_parameters(parameters)
 
         table_rows = self._sample_rows(model, table_name)
-        if not table_rows.empty:
+        if len(table_rows):
             parent_key = self.metadata.get_primary_key(parent_name)
             table_rows[foreign_key] = parent_row[parent_key]
 
@@ -353,7 +353,7 @@ class HMA1(BaseRelationalModel):
             model.set_parameters(parameters)
             try:
                 likelihoods[parent_id] = model.get_likelihood(table_rows)
-            except np.linalg.LinAlgError:
+            except (AttributeError, np.linalg.LinAlgError):
                 likelihoods[parent_id] = None
 
         return pd.DataFrame(likelihoods, index=table_rows.index)

--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -6,7 +6,6 @@ import copulas
 import copulas.multivariate
 import copulas.univariate
 import numpy as np
-import pandas as pd
 
 from sdv.metadata import Table
 from sdv.tabular.base import BaseTabularModel, NonParametricError
@@ -302,7 +301,7 @@ class GaussianCopula(BaseTabularModel):
         transformed = self._metadata.transform(table_data)
         return self._model.probability_density(transformed)
 
-    def get_parameters(self):
+    def _get_parameters(self):
         """Get copula model parameters.
 
         Compute model ``covariance`` and ``distribution.std``
@@ -342,7 +341,6 @@ class GaussianCopula(BaseTabularModel):
                 univariate['scale'] = np.log(scale)
 
         params['univariates'] = univariates
-        params['num_rows'] = self._num_rows
 
         return flatten_dict(params)
 
@@ -401,7 +399,7 @@ class GaussianCopula(BaseTabularModel):
 
         return model_parameters
 
-    def set_parameters(self, parameters):
+    def _set_parameters(self, parameters):
         """Set copula model parameters.
 
         Args:
@@ -411,6 +409,4 @@ class GaussianCopula(BaseTabularModel):
         parameters = unflatten_dict(parameters)
         parameters = self._rebuild_gaussian_copula(parameters)
 
-        num_rows = parameters.pop('num_rows')
-        self._num_rows = 0 if pd.isnull(num_rows) else max(0, int(round(num_rows)))
         self._model = copulas.multivariate.GaussianMultivariate.from_dict(parameters)

--- a/tests/integration/tabular/test_copulas.py
+++ b/tests/integration/tabular/test_copulas.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 from sdv.demo import load_demo
@@ -157,3 +158,25 @@ def test_recreate():
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
     assert (sampled.notnull().sum(axis=1) != 0).all()
+
+
+def test_ids_only():
+    """Ensure that tables that do not contain anything other than id fields can be modeled."""
+    ids_only = pd.DataFrame({
+        'id': range(10),
+        'other_id': range(10),
+    })
+
+    model = GaussianCopula(field_types={
+        'id': {
+            'type': 'id'
+        },
+        'other_id': {
+            'type': 'id'
+        }
+    })
+    model.fit(ids_only)
+    sampled = model.sample()
+
+    assert sampled.shape == ids_only.shape
+    assert ids_only.equals(sampled)

--- a/tests/unit/tabular/test_copulas.py
+++ b/tests/unit/tabular/test_copulas.py
@@ -268,7 +268,7 @@ class TestGaussianCopula:
     def test_get_parameters(self):
         """Test the ``get_parameters`` method when model is parametric.
 
-        If all the distributions are parametric, ``get_parameters``
+        If all the distributions are parametric, ``_get_parameters``
         should return a flattened version of the parameters returned
         by the ``GaussianMultivariate`` instance.
 
@@ -301,8 +301,8 @@ class TestGaussianCopula:
             - ``np.log`` applied to the other ``scale`` parameter.
         """
 
-    def test_get_parameters_non_parametric(self):
-        """Test the ``get_parameters`` method when model is parametric.
+    def test__get_parameters_non_parametric(self):
+        """Test the ``_get_parameters`` method when model is parametric.
 
         If there is at least one distributions in the model that is not
         parametric, a NonParametricError should be raised.
@@ -323,7 +323,7 @@ class TestGaussianCopula:
 
         # Run, Assert
         with pytest.raises(NonParametricError):
-            GaussianCopula.get_parameters(gc)
+            GaussianCopula._get_parameters(gc)
 
     def test__rebuild_covariance_matrix_positive_definite(self):
         """Test the ``_rebuild_covariance_matrix``
@@ -420,15 +420,14 @@ class TestGaussianCopula:
         }
         assert result == expected
 
-    def test_set_parameters(self):
-        """Test the ``set_parameters`` method with positive num_rows.
+    def test__set_parameters(self):
+        """Test the ``_set_parameters`` method with positive num_rows.
 
-        The ``GaussianCopula.set_parameters`` method is expected to:
+        The ``GaussianCopula._set_parameters`` method is expected to:
         - Transform a flattened dict into its original form with
           the unflatten_dict function.
         - pass the unflattended dict to the ``self._rebuild_gaussian_copula``
           method.
-        - Store the number of rows in the `self._num_rows` attribute.
         - Create a GaussianMultivariate instance from the params dict
           and store it in the 'self._model' attribute.
 
@@ -440,7 +439,6 @@ class TestGaussianCopula:
 
         Side Effects:
         - Call ``_rebuild_gaussian_copula`` with the unflatted dict.
-        - ``self._num_rows`` gets the given value.
         - ``GaussianMultivariate`` is called
         - ``GaussianMultivariate`` return value is stored as `self._model`
         """
@@ -469,7 +467,7 @@ class TestGaussianCopula:
             'covariance__1__1': 0.1,
             'num_rows': 3
         }
-        GaussianCopula.set_parameters(gaussian_copula, flatten_parameters)
+        GaussianCopula._set_parameters(gaussian_copula, flatten_parameters)
 
         # Asserts
         expected = {
@@ -483,21 +481,19 @@ class TestGaussianCopula:
             }
         }
         gaussian_copula._rebuild_gaussian_copula.assert_called_once_with(expected)
-        assert gaussian_copula._num_rows == 3
         assert isinstance(gaussian_copula._model, GaussianMultivariate)
 
-    def test_set_parameters_negative_max_rows(self):
-        """Test the ``set_parameters`` method with negative num_rows.
+    def test__set_parameters_negative_max_rows(self):
+        """Test the ``_set_parameters`` method with negative num_rows.
 
         If the max rows value is negative, it is expected to be set
         to zero.
 
-        The ``GaussianCopula.set_parameters`` method is expected to:
+        The ``GaussianCopula._set_parameters`` method is expected to:
         - Transform a flattened dict into its original form with
           the unflatten_dict function.
         - pass the unflattended dict to the ``self._rebuild_gaussian_copula``
           method.
-        - Store ``0`` in the `self._num_rows` attribute.
         - Create a GaussianMultivariate instance from the params dict
           and store it in the 'self._model' attribute.
 
@@ -509,7 +505,6 @@ class TestGaussianCopula:
 
         Side Effects:
         - Call ``_rebuild_gaussian_copula`` with the unflatted dict.
-        - ``self._num_rows`` is set to ``0``.
         - ``GaussianMultivariate`` is called
         - ``GaussianMultivariate`` return value is stored as `self._model`
         """
@@ -538,7 +533,7 @@ class TestGaussianCopula:
             'covariance__1__1': 0.1,
             'num_rows': -3
         }
-        GaussianCopula.set_parameters(gaussian_copula, flatten_parameters)
+        GaussianCopula._set_parameters(gaussian_copula, flatten_parameters)
 
         # Asserts
         expected = {
@@ -552,7 +547,6 @@ class TestGaussianCopula:
             }
         }
         gaussian_copula._rebuild_gaussian_copula.assert_called_once_with(expected)
-        assert gaussian_copula._num_rows == 0
         assert isinstance(gaussian_copula._model, GaussianMultivariate)
 
     def test__validate_distribution_none(self):


### PR DESCRIPTION
When a table contains no data columns (so all the columns have `id` type), the modeling crashes. This happens on both single-table and multi-table scenarios.

This PR fixes this situation by identifying it and then skipping the internal modeling.