### PR TITLE
Fix conda issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ pip install sdv
 **Using `conda`:**
 
 ```bash
-conda install -c sdv-dev -c conda-forge sdv
+conda install -c sdv-dev -c pytorch -c conda-forge sdv
 ```
 
 For more installation options please visit the [SDV installation Guide](

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -44,7 +44,7 @@ about:
   home: "https://sdv.dev"
   license: MIT
   license_family: MIT
-  license_file: "https://github.com/sdv-dev/SDV/blob/master/LICENSE"
+  license_file: "LICENSE"
   summary: "Synthetic Data Generation for tabular, relational and time series data."
   doc_url: "https://sdv.dev/SDV"
   dev_url: "https://github.com/sdv-dev/SDV"


### PR DESCRIPTION
Adds pytorch to the channels required when installing using conda, since it's required by ctgan which is a dependency of sdv. It also fixes passes the license in the write format.