### PR TITLE
sdv-379-p1: Augment base constraint class to raise unique error for conditional sampling

### DIFF
--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -124,6 +124,19 @@ class Constraint(metaclass=ConstraintMeta):
     def _transform(self, table_data):
         return table_data
 
+    def _validate_constraint_columns(self, table_data):
+        """Validate the columns in ``table_data``.
+
+        If any columns in ``_constraint_columns`` are not present in ``table_data``,
+        this method will raise a ``MissingConstraintColumnError``.
+
+        Args:
+            table_data (pandas.DataFrame):
+                Table data.
+        """
+        if any(col not in table_data.columns for col in self._constraint_columns):
+            raise MissingConstraintColumnError()
+
     def transform(self, table_data):
         """Perform necessary transformations needed by constraint.
 
@@ -211,19 +224,6 @@ class Constraint(metaclass=ConstraintMeta):
                          self.__class__.__name__, sum(~valid), len(valid))
 
         return table_data[valid]
-
-    def _validate_constraint_columns(self, table_data):
-        """Validate the columns in ``table_data``.
-
-        If any columns in ``_constraint_columns`` are not present in ``table_data``,
-        this method will raise a ``MissingConstraintColumnError``.
-
-        Args:
-            table_data (pandas.DataFrame):
-                Table data.
-        """
-        if not all(col in table_data.columns for col in self._constraint_columns):
-            raise MissingConstraintColumnError()
 
     @classmethod
     def from_dict(cls, constraint_dict):

--- a/sdv/constraints/errors.py
+++ b/sdv/constraints/errors.py
@@ -1,0 +1,5 @@
+"""Constraint Exceptions."""
+
+
+class MissingConstraintColumnError(Exception):
+    """Error to use when constraint is provided a table with missing columns."""

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -76,6 +76,7 @@ class UniqueCombinations(Constraint):
 
     def __init__(self, columns, handling_strategy='transform'):
         self._columns = columns
+        self._constraint_columns = tuple(columns)
         super().__init__(handling_strategy)
 
     def _valid_separator(self, table_data):
@@ -143,7 +144,7 @@ class UniqueCombinations(Constraint):
         )
         return merged[self._joint_column] == 'both'
 
-    def transform(self, table_data):
+    def _transform(self, table_data):
         """Transform the table data.
 
         The transformation consist on removing all the ``self._columns`` from
@@ -214,6 +215,7 @@ class GreaterThan(Constraint):
         self._low = low
         self._high = high
         self._strict = strict
+        self._constraint_columns = (low, high)
         super().__init__(handling_strategy)
 
     def fit(self, table_data):
@@ -241,7 +243,7 @@ class GreaterThan(Constraint):
 
         return table_data[self._high] >= table_data[self._low]
 
-    def transform(self, table_data):
+    def _transform(self, table_data):
         """Transform the table data.
 
         The transformation consist on replacing the ``high`` value with difference

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -2,7 +2,9 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 
+from sdv.constraints.errors import MissingConstraintColumnError
 from sdv.constraints.tabular import (
     ColumnFormula, CustomConstraint, GreaterThan, UniqueCombinations)
 
@@ -278,6 +280,31 @@ class TestUniqueCombinations():
             'b#c': ['d#g', 'e#h', 'f#i']
         })
         pd.testing.assert_frame_equal(expected_out, out)
+
+    def test_transform_not_all_columns_provided(self):
+        """Test the ``UniqueCombinations.transform`` method.
+
+        If some of the columns needed for the transform are missing, it will raise
+        a ``MissingConstraintColumnError``.
+
+        Input:
+        - Table data (pandas.DataFrame)
+        Output:
+        - Raises ``MissingConstraintColumnError``.
+        """
+        # Setup
+        table_data = pd.DataFrame({
+            'a': ['a', 'b', 'c'],
+            'b': ['d', 'e', 'f'],
+            'c': ['g', 'h', 'i']
+        })
+        columns = ['b', 'c']
+        instance = UniqueCombinations(columns=columns)
+        instance.fit(table_data)
+
+        # Run/Assert
+        with pytest.raises(MissingConstraintColumnError):
+            instance.transform(pd.DataFrame({'a': ['a', 'b', 'c']}))
 
     def reverse_transform(self):
         """Test the ``UniqueCombinations.reverse_transform`` method.
@@ -587,6 +614,24 @@ class TestGreaterThan():
             'c': [1, 2],
         })
         pd.testing.assert_frame_equal(out, expected_out)
+
+    def test_transform_not_all_columns_provided(self):
+        """Test the ``GreaterThan.transform`` method.
+
+        If some of the columns needed for the transform are missing, it will raise
+        a ``MissingConstraintColumnError``.
+
+        Input:
+        - Table data (pandas.DataFrame)
+        Output:
+        - Raises ``MissingConstraintColumnError``.
+        """
+        # Setup
+        instance = GreaterThan(low='a', high='b', strict=True)
+
+        # Run/Assert
+        with pytest.raises(MissingConstraintColumnError):
+            instance.transform(pd.DataFrame({'a': ['a', 'b', 'c']}))
 
     def test_reverse_transform_int(self):
         """Test the ``GreaterThan.reverse_transform`` method for dtype int.


### PR DESCRIPTION
This PR does the following:

- Adds `_validate_constraint_columns` to base class
- Calls that method in `transform` and then calls subclass' `_transform`
- Adds `_transform` method to subclasses that need it
- Adds `_constraint_columns` variable to keep track of columns necessary to do constraint transformation
- Raises `MissingConstraintColumnError` if `_validate_constraint_columns` fails

This PR the first part of the work required for #379 