### PR TITLE
sdv-379-p2: Catch MissingConstraintColumnError and skip conditioning on that constraint

### DIFF
--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -98,7 +98,7 @@ class Constraint(metaclass=ConstraintMeta):
             ``reject_sampling`` or ``all``.
     """
 
-    _constraint_columns = ()
+    constraint_columns = ()
 
     def _identity(self, table_data):
         return table_data
@@ -127,14 +127,14 @@ class Constraint(metaclass=ConstraintMeta):
     def _validate_constraint_columns(self, table_data):
         """Validate the columns in ``table_data``.
 
-        If any columns in ``_constraint_columns`` are not present in ``table_data``,
+        If any columns in ``constraint_columns`` are not present in ``table_data``,
         this method will raise a ``MissingConstraintColumnError``.
 
         Args:
             table_data (pandas.DataFrame):
                 Table data.
         """
-        if any(col not in table_data.columns for col in self._constraint_columns):
+        if any(col not in table_data.columns for col in self.constraint_columns):
             raise MissingConstraintColumnError()
 
     def transform(self, table_data):

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -76,7 +76,7 @@ class UniqueCombinations(Constraint):
 
     def __init__(self, columns, handling_strategy='transform'):
         self._columns = columns
-        self._constraint_columns = tuple(columns)
+        self.constraint_columns = tuple(columns)
         super().__init__(handling_strategy)
 
     def _valid_separator(self, table_data):
@@ -215,7 +215,7 @@ class GreaterThan(Constraint):
         self._low = low
         self._high = high
         self._strict = strict
-        self._constraint_columns = (low, high)
+        self.constraint_columns = (low, high)
         super().__init__(handling_strategy)
 
     def fit(self, table_data):

--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -502,10 +502,15 @@ class Table:
             except MissingConstraintColumnError:
                 if on_missing_column == 'error':
                     raise MissingConstraintColumnError()
+
                 elif on_missing_column == 'drop':
                     indices_to_drop = data.columns.isin(constraint.constraint_columns)
                     columns_to_drop = data.columns.where(indices_to_drop).dropna()
                     data = data.drop(columns_to_drop, axis=1)
+
+                else:
+                    raise ValueError('on_missing_column must be \'drop\' or \'error\'')
+
         return data
 
     def transform(self, data, on_missing_column='error'):

--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -503,8 +503,9 @@ class Table:
                 if on_missing_column == 'error':
                     raise MissingConstraintColumnError()
                 elif on_missing_column == 'drop':
-                    constraint_columns_in_data = data.columns.all(constraint.constraint_columns)
-                    data = data.drop(constraint_columns_in_data, axis=1)
+                    indices_to_drop = data.columns.isin(constraint.constraint_columns)
+                    columns_to_drop = data.columns.where(indices_to_drop).dropna()
+                    data = data.drop(columns_to_drop, axis=1)
         return data
 
     def transform(self, data, on_missing_column='error'):

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -403,6 +403,7 @@ class BaseTabularModel:
                 transformed_condition = None
             else:
                 transformed_condition = transformed_conditions.loc[condition_index].to_dict()
+
             condition = dict(zip(condition_columns, group))
             sampled_rows = self._sample_batch(
                 len(dataframe),

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -399,7 +399,10 @@ class BaseTabularModel:
                 group = [group]
 
             condition_index = dataframe['__condition_idx__'].iloc[0]
-            transformed_condition = transformed_conditions.loc[condition_index].to_dict()
+            if transformed_conditions.empty:
+                transformed_condition = None
+            else:
+                transformed_condition = transformed_conditions.loc[condition_index].to_dict()
             condition = dict(zip(condition_columns, group))
             sampled_rows = self._sample_batch(
                 len(dataframe),

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -385,7 +385,7 @@ class BaseTabularModel:
             if column not in self._metadata.get_fields():
                 raise ValueError(f'Invalid column name `{column}`')
 
-        transformed_conditions = self._metadata.transform(conditions)
+        transformed_conditions = self._metadata.transform(conditions, on_missing_column='drop')
         condition_columns = list(conditions.columns)
         conditions.index.name = '__condition_idx__'
         conditions.reset_index(inplace=True)
@@ -399,7 +399,7 @@ class BaseTabularModel:
                 group = [group]
 
             condition_index = dataframe['__condition_idx__'].iloc[0]
-            transformed_condition = transformed_conditions.loc[condition_index]
+            transformed_condition = transformed_conditions.loc[condition_index].to_dict()
             condition = dict(zip(condition_columns, group))
             sampled_rows = self._sample_batch(
                 len(dataframe),

--- a/tests/unit/constraints/test_base.py
+++ b/tests/unit/constraints/test_base.py
@@ -284,7 +284,7 @@ class TestConstraint():
         # Run
         instance = Constraint(handling_strategy='transform')
         instance._transform = lambda x: x
-        instance.constraint_columns = ('a')
+        instance.constraint_columns = ('a',)
 
         # Assert
         with pytest.raises(MissingConstraintColumnError):

--- a/tests/unit/constraints/test_base.py
+++ b/tests/unit/constraints/test_base.py
@@ -284,7 +284,7 @@ class TestConstraint():
         # Run
         instance = Constraint(handling_strategy='transform')
         instance._transform = lambda x: x
-        instance._constraint_columns = ('a')
+        instance.constraint_columns = ('a')
 
         # Assert
         with pytest.raises(MissingConstraintColumnError):

--- a/tests/unit/metadata/test_table.py
+++ b/tests/unit/metadata/test_table.py
@@ -1,6 +1,9 @@
+from unittest.mock import Mock
+
 import pandas as pd
 import pytest
 
+from sdv.constraints.errors import MissingConstraintColumnError
 from sdv.metadata import Table
 
 
@@ -18,7 +21,7 @@ class TestTable:
         with pytest.raises(ValueError):
             Table._make_ids(metadata, 20)
 
-    def test_make_ids_unique_field_not_unique(self):
+    def test__make_ids_unique_field_not_unique(self):
         """Test that id column is replaced with all unique values if not already unique."""
         metadata_dict = {
             'fields': {
@@ -38,7 +41,7 @@ class TestTable:
         assert new_data['item 1'].equals(data['item 1'])
         assert new_data['item 0'].is_unique
 
-    def test_make_ids_unique_field_already_unique(self):
+    def test__make_ids_unique_field_already_unique(self):
         """Test that id column is kept if already unique."""
         metadata_dict = {
             'fields': {
@@ -58,7 +61,7 @@ class TestTable:
         assert new_data['item 1'].equals(data['item 1'])
         assert new_data['item 0'].equals(data['item 0'])
 
-    def test_make_ids_unique_field_index_out_of_order(self):
+    def test__make_ids_unique_field_index_out_of_order(self):
         """Test that updated id column is unique even if index is out of order."""
         metadata_dict = {
             'fields': {
@@ -77,3 +80,113 @@ class TestTable:
 
         assert new_data['item 1'].equals(data['item 1'])
         assert new_data['item 0'].is_unique
+
+    def test_transform_calls__transform_constraints(self):
+        """Test that the `transform` method calls `_transform_constraints` with right parameters"""
+        # Setup
+        data = pd.DataFrame({
+            'item 0': [0, 1, 2],
+            'item 1': [True, True, False]
+        }, index=[0, 1, 2])
+        dtypes = {'item 0': 'int', 'item 1': 'bool'}
+        table_mock = Mock()
+        table_mock.get_dtypes.return_value = dtypes
+        table_mock._transform_constraints.return_value = data
+        table_mock._anonymize.return_value = data
+        table_mock._hyper_transformer.transform.return_value = data
+
+        # Run
+        Table.transform(table_mock, data, 'error')
+
+        # Assert
+        table_mock._transform_constraints.assert_called_once_with(data, 'error')
+
+    def test__transform_constraints(self):
+        """Test that method correctly transforms data based on constraints
+
+        The `_transform_constraints` method is expected to loop through constraints
+        and call each constraint's `transform` method on the data.
+
+        Input:
+        - Table data
+        Output:
+        - Transformed data
+        """
+        # Setup
+        data = pd.DataFrame({
+            'item 0': [0, 1, 2],
+            'item 1': [3, 4, 5]
+        }, index=[0, 1, 2])
+        transformed_data = pd.DataFrame({
+            'item 0': [0, 0.5, 1],
+            'item 1': [6, 8, 10]
+        }, index=[0, 1, 2])
+        first_constraint_mock = Mock()
+        second_constraint_mock = Mock()
+        first_constraint_mock.transform.return_value = transformed_data
+        second_constraint_mock.return_value = transformed_data
+        table_mock = Mock()
+        table_mock._constraints = [first_constraint_mock, second_constraint_mock]
+
+        # Run
+        result = Table._transform_constraints(table_mock, data)
+
+        # Assert
+        assert result.equals(transformed_data)
+        first_constraint_mock.transform.assert_called_once_with(data)
+        second_constraint_mock.transform.assert_called_once_with(transformed_data)
+
+    def test__transform_constraints_raises_error(self):
+        """Test that method raises error when specified.
+
+        The `_transform_constraints` method is expected to raise a `MissingConstraintColumnError`
+        if the constraint transform raises one and `on_missing_column` is set to error.
+
+        Input:
+        - Table data
+        Side Effects:
+        - MissingConstraintColumnError
+        """
+        # Setup
+        data = pd.DataFrame({
+            'item 0': [0, 1, 2],
+            'item 1': [3, 4, 5]
+        }, index=[0, 1, 2])
+        constraint_mock = Mock()
+        constraint_mock.transform.side_effect = MissingConstraintColumnError
+        table_mock = Mock()
+        table_mock._constraints = [constraint_mock]
+
+        # Run/Assert
+        with pytest.raises(MissingConstraintColumnError):
+            Table._transform_constraints(table_mock, data, 'error')
+
+    def test__transform_constraints_drops_columns(self):
+        """Test that method drops columns when specified.
+
+        The `_transform_constraints` method is expected to drop columns associated with
+        a constraint its transform raises a MissingConstraintColumnError and `on_missing_column`
+        is set to drop.
+
+        Input:
+        - Table data
+        Output:
+        - Table with dropped columns
+        """
+        # Setup
+        data = pd.DataFrame({
+            'item 0': [0, 1, 2],
+            'item 1': [3, 4, 5]
+        }, index=[0, 1, 2])
+        constraint_mock = Mock()
+        constraint_mock.transform.side_effect = MissingConstraintColumnError
+        constraint_mock.constraint_columns = ['item 0']
+        table_mock = Mock()
+        table_mock._constraints = [constraint_mock]
+        expected_result = data.drop(['item 0'], axis=1)
+
+        # Run
+        result = Table._transform_constraints(table_mock, data, 'drop')
+
+        # Assert
+        assert result.equals(expected_result)

--- a/tests/unit/metadata/test_table.py
+++ b/tests/unit/metadata/test_table.py
@@ -83,7 +83,7 @@ class TestTable:
 
     def test_transform_calls__transform_constraints(self):
         """Test that the `transform` method calls `_transform_constraints` with right parameters
-        
+
         The ``transform`` method is expected to call the ``_transform_constraints`` method
         with the data and correct value for ``on_missing_column``.
 
@@ -108,7 +108,15 @@ class TestTable:
         Table.transform(table_mock, data, 'error')
 
         # Assert
-        table_mock._transform_constraints.assert_called_once_with(data, 'error')
+        expectedData = pd.DataFrame({
+            'item 0': [0, 1, 2],
+            'item 1': [True, True, False]
+        }, index=[0, 1, 2])
+        mock_calls = table_mock._transform_constraints.mock_calls
+        args = mock_calls[0][1]
+        assert len(mock_calls) == 1
+        assert args[0].equals(expectedData)
+        assert args[1] == 'error'
 
     def test__transform_constraints(self):
         """Test that method correctly transforms data based on constraints
@@ -192,10 +200,12 @@ class TestTable:
         constraint_mock.constraint_columns = ['item 0']
         table_mock = Mock()
         table_mock._constraints = [constraint_mock]
-        expected_result = data.drop(['item 0'], axis=1)
 
         # Run
         result = Table._transform_constraints(table_mock, data, 'drop')
 
         # Assert
+        expected_result = pd.DataFrame({
+            'item 1': [3, 4, 5]
+        }, index=[0, 1, 2])
         assert result.equals(expected_result)

--- a/tests/unit/metadata/test_table.py
+++ b/tests/unit/metadata/test_table.py
@@ -82,7 +82,16 @@ class TestTable:
         assert new_data['item 0'].is_unique
 
     def test_transform_calls__transform_constraints(self):
-        """Test that the `transform` method calls `_transform_constraints` with right parameters"""
+        """Test that the `transform` method calls `_transform_constraints` with right parameters
+        
+        The ``transform`` method is expected to call the ``_transform_constraints`` method
+        with the data and correct value for ``on_missing_column``.
+
+        Input:
+        - Table data
+        Side Effects:
+        - Calls _transform_constraints
+        """
         # Setup
         data = pd.DataFrame({
             'item 0': [0, 1, 2],

--- a/tests/unit/metadata/test_table.py
+++ b/tests/unit/metadata/test_table.py
@@ -108,14 +108,14 @@ class TestTable:
         Table.transform(table_mock, data, 'error')
 
         # Assert
-        expectedData = pd.DataFrame({
+        expected_data = pd.DataFrame({
             'item 0': [0, 1, 2],
             'item 1': [True, True, False]
         }, index=[0, 1, 2])
         mock_calls = table_mock._transform_constraints.mock_calls
         args = mock_calls[0][1]
         assert len(mock_calls) == 1
-        assert args[0].equals(expectedData)
+        assert args[0].equals(expected_data)
         assert args[1] == 'error'
 
     def test__transform_constraints(self):

--- a/tests/unit/metadata/test_table.py
+++ b/tests/unit/metadata/test_table.py
@@ -104,8 +104,8 @@ class TestTable:
     def test__transform_constraints(self):
         """Test that method correctly transforms data based on constraints
 
-        The `_transform_constraints` method is expected to loop through constraints
-        and call each constraint's `transform` method on the data.
+        The ``_transform_constraints`` method is expected to loop through constraints
+        and call each constraint's ``transform`` method on the data.
 
         Input:
         - Table data
@@ -139,8 +139,8 @@ class TestTable:
     def test__transform_constraints_raises_error(self):
         """Test that method raises error when specified.
 
-        The `_transform_constraints` method is expected to raise a `MissingConstraintColumnError`
-        if the constraint transform raises one and `on_missing_column` is set to error.
+        The ``_transform_constraints`` method is expected to raise ``MissingConstraintColumnError``
+        if the constraint transform raises one and ``on_missing_column`` is set to error.
 
         Input:
         - Table data
@@ -164,8 +164,8 @@ class TestTable:
     def test__transform_constraints_drops_columns(self):
         """Test that method drops columns when specified.
 
-        The `_transform_constraints` method is expected to drop columns associated with
-        a constraint its transform raises a MissingConstraintColumnError and `on_missing_column`
+        The ``_transform_constraints`` method is expected to drop columns associated with
+        a constraint its transform raises a MissingConstraintColumnError and ``on_missing_column``
         is set to drop.
 
         Input:

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -39,3 +39,114 @@ def test_conditional_sampling_graceful_reject_sampling(model):
     assert len(output) == 2, "Only expected 2 valid rows."
     with pytest.raises(ValueError):
         model.sample(5, conditions=conditions, graceful_reject_sampling=False)
+
+
+def test_sample_empty_transformed_conditions():
+    """Test that None is passed to ``_sample_batch`` if transformed conditions are empty.
+
+    The ``Sample`` method is expected to:
+    - Return sampled data and pass None to ``sample_batch`` as the
+    ``transformed_conditions``.
+
+    Input:
+    - Number of rows to sample
+    - Conditions
+
+    Output:
+    - Sampled data
+    """
+    # Setup
+    model = GaussianCopula()
+    data = pd.DataFrame({
+        'column1': list(range(100)),
+        'column2': list(range(100)),
+        'column3': list(range(100))
+    })
+
+    conditions = {
+        'column1': 25
+    }
+    conditions_df = pd.DataFrame([
+        [0, 25], [1, 25], [2, 25], [3, 25], [4, 25]
+    ], columns=['__condition_idx__', 'column1'])
+    model._sample_batch = Mock()
+    expected_output = pd.DataFrame({
+        'column1': [28, 28],
+        'column2': [37, 37],
+        'column3': [93, 93],
+    })
+    model._sample_batch.return_value = expected_output
+    model.fit(data)
+    model._metadata = Mock()
+    model._metadata.get_fields.return_value = ['column1', 'column2', 'column3']
+    model._metadata.transform.return_value = pd.DataFrame()
+
+    # Run
+    output = model.sample(5, conditions=conditions, graceful_reject_sampling=True)
+
+    # Assert
+    func_name, args, kwargs = model._metadata.transform.mock_calls[0]
+    assert args[0].equals(conditions_df)
+    assert kwargs['on_missing_column'] == 'drop'
+    model._metadata.transform.assert_called_once()
+    model._sample_batch.assert_called_with(5, 100, 10, conditions, None, 0.01)
+    assert output.equals(expected_output)
+
+
+def test_sample_batches_transform_conditions_correctly():
+    """Test that transformed conditions are batched correctly.
+
+    The ``Sample`` method is expected to:
+    - Return sampled data and call ``_sample_batch`` for every grouped condition
+    value with the correct transformed condition.
+
+    Input:
+    - Number of rows to sample
+    - Conditions
+
+    Output:
+    - Sampled data
+    """
+    # Setup
+    model = GaussianCopula()
+    data = pd.DataFrame({
+        'column1': list(range(100)),
+        'column2': list(range(100)),
+        'column3': list(range(100))
+    })
+
+    conditions = {
+        'column1': [25, 25, 25, 30, 30]
+    }
+    conditions_df = pd.DataFrame([
+        [0, 25], [1, 25], [2, 25], [3, 30], [4, 30]
+    ], columns=['__condition_idx__', 'column1'])
+    model._sample_batch = Mock()
+    expected_output = pd.DataFrame({
+        'column1': [28, 28],
+        'column2': [37, 37],
+        'column3': [93, 93],
+    })
+    model._sample_batch.return_value = expected_output
+    model.fit(data)
+    model._metadata = Mock()
+    model._metadata.get_fields.return_value = ['column1', 'column2', 'column3']
+    model._metadata.transform.return_value = pd.DataFrame([
+        [50], [50], [50], [60], [70]
+    ], columns=['transformed_column'])
+
+    # Run
+    output = model.sample(5, conditions=conditions, graceful_reject_sampling=True)
+
+    # Assert
+    func_name, args, kwargs = model._metadata.transform.mock_calls[0]
+    assert args[0].equals(conditions_df)
+    assert kwargs['on_missing_column'] == 'drop'
+    model._metadata.transform.assert_called_once()
+    model._sample_batch.assert_any_call(
+        3, 100, 10, {'column1': 25}, {'transformed_column': 50}, 0.01
+    )
+    model._sample_batch.assert_any_call(
+        2, 100, 10, {'column1': 30}, {'transformed_column': 60}, 0.01
+    )
+    assert output.equals(expected_output)

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -85,7 +85,7 @@ def test_sample_empty_transformed_conditions():
     output = model.sample(5, conditions=conditions, graceful_reject_sampling=True)
 
     # Assert
-    func_name, args, kwargs = model._metadata.transform.mock_calls[0]
+    _, args, kwargs = model._metadata.transform.mock_calls[0]
     assert args[0].equals(conditions_df)
     assert kwargs['on_missing_column'] == 'drop'
     model._metadata.transform.assert_called_once()
@@ -139,7 +139,7 @@ def test_sample_batches_transform_conditions_correctly():
     output = model.sample(5, conditions=conditions, graceful_reject_sampling=True)
 
     # Assert
-    func_name, args, kwargs = model._metadata.transform.mock_calls[0]
+    _, args, kwargs = model._metadata.transform.mock_calls[0]
     assert args[0].equals(conditions_df)
     assert kwargs['on_missing_column'] == 'drop'
     model._metadata.transform.assert_called_once()


### PR DESCRIPTION
This PR is related to #379 

In this PR:

- The `constraint_columns` instance variable in the `Constraint` class is made public
- The metadata `Table.transform` method is changed to handle the constraint transforms differently. It now takes an optional parameter `on_missing_columns` to specify how to handle a `MissingConstraintColumnError`.
    - If the parameter is set to `error` then it will simply raise the error
    - If the parameter is set to `drop`, then it will drop all columns in the table related to the constraint
- The `sample` method is changed to now group the conditions based on the original conditions, not the transformed ones
- The sample method will pass `None` as the `transformed_condition` if the transform process drops all the columns