### PR TITLE
sdv-440: Conditionally sampling on variable in constraint should have variety for other variables

### DIFF
--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -365,8 +365,8 @@ class BaseTabularModel:
                      f'be sampled within {max_retries} trials.')
 
         if len(sampled_rows) > 0:
-            sampled_rows[COND_IDX] = \
-                dataframe[COND_IDX].values[:len(sampled_rows)]
+            sampled_rows[COND_IDX] = dataframe[COND_IDX].values[:len(sampled_rows)]
+
         return sampled_rows
 
     def sample(self, num_rows=None, max_retries=100, max_rows_multiplier=10,

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -335,8 +335,8 @@ class BaseTabularModel:
         return conditions.copy()
 
     def _conditionally_sample_rows(self, dataframe, max_retries, max_rows_multiplier,
-                                  condition, transformed_condition, float_rtol,
-                                  graceful_reject_sampling):
+                                   condition, transformed_condition, float_rtol,
+                                   graceful_reject_sampling):
         sampled_rows = self._sample_batch(
             len(dataframe),
             max_retries,
@@ -358,7 +358,7 @@ class BaseTabularModel:
 
             else:
                 warn(f'Only {len(sampled_rows)} rows could '
-                    f'be sampled within {max_retries} trials.')
+                     f'be sampled within {max_retries} trials.')
 
         if len(sampled_rows) > 0:
             sampled_rows['__condition_idx__'] = \
@@ -418,7 +418,7 @@ class BaseTabularModel:
 
         transformed_conditions = self._metadata.transform(conditions, on_missing_column='drop')
         condition_columns = list(conditions.columns)
-        transformed_condition_columns = list(transformed_conditions.columns)
+        transformed_columns = list(transformed_conditions.columns)
         conditions.index.name = '__condition_idx__'
         conditions.reset_index(inplace=True)
         grouped_conditions = conditions.groupby(condition_columns)
@@ -445,9 +445,9 @@ class BaseTabularModel:
                 all_sampled_rows.append(sampled_rows)
             else:
                 transformed_conditions_in_group = transformed_conditions.loc[condition_indices]
-                transformed_groups = transformed_conditions_in_group.groupby(transformed_condition_columns)
+                transformed_groups = transformed_conditions_in_group.groupby(transformed_columns)
                 for transformed_group, transformed_dataframe in transformed_groups:
-                    transformed_condition = dict(zip(transformed_condition_columns, transformed_group))
+                    transformed_condition = dict(zip(transformed_columns, transformed_group))
                     sampled_rows = self._conditionally_sample_rows(
                         transformed_dataframe,
                         max_retries,

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -421,6 +421,8 @@ class BaseTabularModel:
         transformed_columns = list(transformed_conditions.columns)
         conditions.index.name = '__condition_idx__'
         conditions.reset_index(inplace=True)
+        transformed_conditions.index.name = '__condition_idx__'
+        transformed_conditions.reset_index(inplace=True)
         grouped_conditions = conditions.groupby(condition_columns)
 
         # sample
@@ -447,6 +449,8 @@ class BaseTabularModel:
                 transformed_conditions_in_group = transformed_conditions.loc[condition_indices]
                 transformed_groups = transformed_conditions_in_group.groupby(transformed_columns)
                 for transformed_group, transformed_dataframe in transformed_groups:
+                    if not isinstance(transformed_group, tuple):
+                        transformed_group = [transformed_group]
                     transformed_condition = dict(zip(transformed_columns, transformed_group))
                     sampled_rows = self._conditionally_sample_rows(
                         transformed_dataframe,

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -2,6 +2,7 @@
 
 import logging
 import pickle
+import uuid
 from warnings import warn
 
 import numpy as np
@@ -10,6 +11,7 @@ import pandas as pd
 from sdv.metadata import Table
 
 LOGGER = logging.getLogger(__name__)
+COND_IDX = str(uuid.uuid4())
 
 
 class NonParametricError(Exception):
@@ -337,16 +339,18 @@ class BaseTabularModel:
     def _conditionally_sample_rows(self, dataframe, max_retries, max_rows_multiplier,
                                    condition, transformed_condition, float_rtol,
                                    graceful_reject_sampling):
+        num_rows = len(dataframe)
         sampled_rows = self._sample_batch(
-            len(dataframe),
+            num_rows,
             max_retries,
             max_rows_multiplier,
             condition,
             transformed_condition,
             float_rtol
         )
+        num_sampled_rows = len(sampled_rows)
 
-        if len(sampled_rows) < len(dataframe):
+        if num_sampled_rows < num_rows:
             # Didn't get enough rows.
             if len(sampled_rows) == 0:
                 error = 'No valid rows could be generated with the given conditions.'
@@ -361,8 +365,8 @@ class BaseTabularModel:
                      f'be sampled within {max_retries} trials.')
 
         if len(sampled_rows) > 0:
-            sampled_rows['__condition_idx__'] = \
-                dataframe['__condition_idx__'].values[:len(sampled_rows)]
+            sampled_rows[COND_IDX] = \
+                dataframe[COND_IDX].values[:len(sampled_rows)]
         return sampled_rows
 
     def sample(self, num_rows=None, max_retries=100, max_rows_multiplier=10,
@@ -419,9 +423,9 @@ class BaseTabularModel:
         transformed_conditions = self._metadata.transform(conditions, on_missing_column='drop')
         condition_columns = list(conditions.columns)
         transformed_columns = list(transformed_conditions.columns)
-        conditions.index.name = '__condition_idx__'
+        conditions.index.name = COND_IDX
         conditions.reset_index(inplace=True)
-        transformed_conditions.index.name = '__condition_idx__'
+        transformed_conditions.index.name = COND_IDX
         transformed_conditions.reset_index(inplace=True)
         grouped_conditions = conditions.groupby(condition_columns)
 
@@ -432,7 +436,7 @@ class BaseTabularModel:
             if not isinstance(group, tuple):
                 group = [group]
 
-            condition_indices = dataframe['__condition_idx__']
+            condition_indices = dataframe[COND_IDX]
             condition = dict(zip(condition_columns, group))
             if transformed_conditions.empty:
                 sampled_rows = self._conditionally_sample_rows(
@@ -451,6 +455,7 @@ class BaseTabularModel:
                 for transformed_group, transformed_dataframe in transformed_groups:
                     if not isinstance(transformed_group, tuple):
                         transformed_group = [transformed_group]
+
                     transformed_condition = dict(zip(transformed_columns, transformed_group))
                     sampled_rows = self._conditionally_sample_rows(
                         transformed_dataframe,
@@ -464,7 +469,7 @@ class BaseTabularModel:
                     all_sampled_rows.append(sampled_rows)
 
         all_sampled_rows = pd.concat(all_sampled_rows)
-        all_sampled_rows = all_sampled_rows.set_index('__condition_idx__')
+        all_sampled_rows = all_sampled_rows.set_index(COND_IDX)
         all_sampled_rows.index.name = conditions.index.name
         all_sampled_rows = all_sampled_rows.sort_index()
         all_sampled_rows = self._metadata.make_ids_unique(all_sampled_rows)

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -94,8 +94,6 @@ def test_sample_empty_transformed_conditions():
     assert kwargs['on_missing_column'] == 'drop'
     model._metadata.transform.assert_called_once()
     model._sample_batch.assert_called_with(5, 100, 10, conditions, None, 0.01)
-    print(output)
-    print(expected_output)
     pd.testing.assert_frame_equal(output, expected_output)
 
 


### PR DESCRIPTION
This PR changes the way we sample conditions to not only group by the conditions passed by the user, but also by the transformed conditions that result from them. This is to ensure variety in the other columns that result in the transformed conditions. 

For example, if we have a `GreaterThan` constraint with a high and low column, and a condition on the high column, the sampled data should have varying values for the low column