### PR TITLE
Expand UniqueCombinations constraint to handle non-strings

### DIFF
--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -17,6 +17,8 @@ Currently implemented constraints are:
       on the other columns of the table.
 """
 
+import uuid
+
 import numpy as np
 import pandas as pd
 
@@ -74,6 +76,8 @@ class UniqueCombinations(Constraint):
 
     _separator = None
     _joint_column = None
+    _combination_map = None
+    _unique_value_map = None
 
     def __init__(self, columns, handling_strategy='transform', fit_columns_model=True):
         self._columns = columns
@@ -86,7 +90,7 @@ class UniqueCombinations(Constraint):
 
         The fit process consists on:
 
-            - Finding a separtor that works for the
+            - Finding a separator that works for the
               current data by iteratively adding `#` to it.
             - Generating the joint column name by concatenating
               the names of ``self._columns`` with the separator.
@@ -138,8 +142,25 @@ class UniqueCombinations(Constraint):
                 Transformed data.
         """
         lists_series = pd.Series(table_data[self._columns].values.tolist())
+
+        non_string_cols = [dt for x, dt in table_data.dtypes[
+            self._columns].items() if dt != object]
+        if len(non_string_cols) > 0:
+            u_lists_series = []
+            self._combination_map = {}
+            self._unique_value_map = {}
+
+            for ls in lists_series:
+                u = str(uuid.uuid4())
+                self._combination_map[tuple(ls)] = u
+                self._unique_value_map[u] = ls
+                u_lists_series.append(u)
+
+            lists_series = pd.Series(u_lists_series)
+
         table_data = table_data.drop(self._columns, axis=1)
-        table_data[self._joint_column] = lists_series.str.join(self._separator)
+        table_data[self._joint_column] = lists_series.str.join(
+            self._separator) if self._combination_map is None else lists_series
 
         return table_data
 
@@ -160,7 +181,17 @@ class UniqueCombinations(Constraint):
                 Transformed data.
         """
         table_data = table_data.copy()
-        columns = table_data.pop(self._joint_column).str.split(self._separator)
+
+        if self._combination_map is None:
+            columns = table_data.pop(self._joint_column).str.split(self._separator)
+        else:
+            uuids = table_data.pop(self._joint_column)
+            combinations = []
+            for u in uuids:
+                combinations.append(self._unique_value_map[u])
+
+            columns = pd.Series(combinations, name=self._joint_column)
+
         for index, column in enumerate(self._columns):
             table_data[column] = columns.str[index]
 

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -76,8 +76,8 @@ class UniqueCombinations(Constraint):
 
     _separator = None
     _joint_column = None
-    _combination_map = None
-    _unique_value_map = None
+    _combinations_to_uuids = None
+    _uuids_to_combinations = None
 
     def __init__(self, columns, handling_strategy='transform', fit_columns_model=True):
         self._columns = columns
@@ -94,17 +94,25 @@ class UniqueCombinations(Constraint):
               current data by iteratively adding `#` to it.
             - Generating the joint column name by concatenating
               the names of ``self._columns`` with the separator.
+            - Generating a mapping of the unique combinations
+              to a unique identifier.
 
         Args:
             table_data (pandas.DataFrame):
                 Table data.
         """
         self._separator = '#'
-        while not self._valid_separator(table_data, self._separator, self._columns):
+        while self._separator.join(self._columns) in table_data:
             self._separator += '#'
 
         self._joint_column = self._separator.join(self._columns)
         self._combinations = table_data[self._columns].drop_duplicates().copy()
+        self._combinations_to_uuids = {}
+        self._uuids_to_combinations = {}
+        for combination in self._combinations.itertuples(index=False, name=None):
+            uuid_str = str(uuid.uuid4())
+            self._combinations_to_uuids[combination] = uuid_str
+            self._uuids_to_combinations[uuid_str] = combination
 
     def is_valid(self, table_data):
         """Say whether the column values are within the original combinations.
@@ -129,9 +137,9 @@ class UniqueCombinations(Constraint):
         """Transform the table data.
 
         The transformation consist on removing all the ``self._columns`` from
-        the dataframe, concatenating them using the found separator, and
-        setting them back to the data as a single name with the previously
-        computed name.
+        the dataframe, and replacing them with a unique identifier that maps to
+        that unique combination of column values under the previously computed
+        combined column name.
 
         Args:
             table_data (pandas.DataFrame):
@@ -141,35 +149,18 @@ class UniqueCombinations(Constraint):
             pandas.DataFrame:
                 Transformed data.
         """
-        lists_series = pd.Series(table_data[self._columns].values.tolist())
-
-        non_string_cols = [dt for x, dt in table_data.dtypes[
-            self._columns].items() if dt != object]
-        if non_string_cols:
-            u_lists_series = []
-            self._combination_map = {}
-            self._unique_value_map = {}
-
-            for ls in lists_series:
-                u = str(uuid.uuid4())
-                self._combination_map[tuple(ls)] = u
-                self._unique_value_map[u] = ls
-                u_lists_series.append(u)
-
-            lists_series = pd.Series(u_lists_series)
-
-        table_data = table_data.drop(self._columns, axis=1)
-        table_data[self._joint_column] = lists_series.str.join(
-            self._separator) if self._combination_map is None else lists_series
-
-        return table_data
+        table_data = table_data.copy()
+        combinations = table_data[self._columns].itertuples(index=False, name=None)
+        uuids = map(self._combinations_to_uuids.get, combinations)
+        table_data[self._joint_column] = list(uuids)
+        return table_data.drop(self._columns, axis=1)
 
     def reverse_transform(self, table_data):
         """Reverse transform the table data.
 
         The transformation is reversed by popping the joint column from
-        the table, splitting it by the previously found separator and
-        then setting all the columns back to the table with the original
+        the table, mapping it back to the original combination of column values,
+        and then setting all the columns back to the table with the original
         names.
 
         Args:
@@ -181,16 +172,7 @@ class UniqueCombinations(Constraint):
                 Transformed data.
         """
         table_data = table_data.copy()
-
-        if self._unique_value_map is None:
-            columns = table_data.pop(self._joint_column).str.split(self._separator)
-        else:
-            uuids = table_data.pop(self._joint_column)
-            combinations = []
-            for u in uuids:
-                combinations.append(self._unique_value_map[u])
-
-            columns = pd.Series(combinations, name=self._joint_column)
+        columns = table_data.pop(self._joint_column).map(self._uuids_to_combinations)
 
         for index, column in enumerate(self._columns):
             table_data[column] = columns.str[index]

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -145,7 +145,7 @@ class UniqueCombinations(Constraint):
 
         non_string_cols = [dt for x, dt in table_data.dtypes[
             self._columns].items() if dt != object]
-        if len(non_string_cols) > 0:
+        if non_string_cols:
             u_lists_series = []
             self._combination_map = {}
             self._unique_value_map = {}
@@ -182,7 +182,7 @@ class UniqueCombinations(Constraint):
         """
         table_data = table_data.copy()
 
-        if self._combination_map is None:
+        if self._unique_value_map is None:
             columns = table_data.pop(self._joint_column).str.split(self._separator)
         else:
             uuids = table_data.pop(self._joint_column)

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -344,13 +344,14 @@ class TestUniqueCombinations():
         out = instance.transform(table_data)
 
         # Assert
-        assert instance._combination_map is None
-        assert instance._unique_value_map is None
-        expected_out = pd.DataFrame({
-            'a': ['a', 'b', 'c'],
-            'b#c': ['d#g', 'e#h', 'f#i']
-        })
-        pd.testing.assert_frame_equal(expected_out, out)
+        assert instance._combinations_to_uuids is not None
+        assert instance._uuids_to_combinations is not None
+        expected_out_a = pd.Series(['a', 'b', 'c'], name='a')
+        pd.testing.assert_series_equal(expected_out_a, out['a'])
+        try:
+            [uuid.UUID(u) for c, u in out['b#c'].items()]
+        except ValueError:
+            assert False
 
     def test_transform_non_string(self):
         """Test the ``UniqueCombinations.transform`` method with non strings.
@@ -380,8 +381,8 @@ class TestUniqueCombinations():
         out = instance.transform(table_data)
 
         # Assert
-        assert instance._combination_map is not None
-        assert instance._unique_value_map is not None
+        assert instance._combinations_to_uuids is not None
+        assert instance._uuids_to_combinations is not None
         expected_out_a = pd.Series(['a', 'b', 'c'], name='a')
         pd.testing.assert_series_equal(expected_out_a, out['a'])
         try:
@@ -433,20 +434,17 @@ class TestUniqueCombinations():
             'b': ['d', 'e', 'f'],
             'c': ['g', 'h', 'i']
         })
-        transformed_data = pd.DataFrame({
-            'a': ['a', 'b', 'c'],
-            'b#c': ['d#g', 'e#h', 'f#i']
-        })
         columns = ['b', 'c']
         instance = UniqueCombinations(columns=columns)
         instance.fit(table_data)
 
         # Run
+        transformed_data = instance.transform(table_data)
         out = instance.reverse_transform(transformed_data)
 
         # Assert
-        assert instance._combination_map is None
-        assert instance._unique_value_map is None
+        assert instance._combinations_to_uuids is not None
+        assert instance._uuids_to_combinations is not None
         expected_out = pd.DataFrame({
             'a': ['a', 'b', 'c'],
             'b': ['d', 'e', 'f'],
@@ -483,8 +481,8 @@ class TestUniqueCombinations():
         out = instance.reverse_transform(transformed_data)
 
         # Assert
-        assert instance._combination_map is not None
-        assert instance._unique_value_map is not None
+        assert instance._combinations_to_uuids is not None
+        assert instance._uuids_to_combinations is not None
         expected_out = pd.DataFrame({
             'a': ['a', 'b', 'c'],
             'b': [1, 2, 3],

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -250,6 +250,73 @@ class TestUniqueCombinations():
         expected_out = pd.Series([False, False, False], name='b#c')
         pd.testing.assert_series_equal(expected_out, out)
 
+    def test_is_valid_non_string_true(self):
+        """Test the ``UniqueCombinations.is_valid`` method with non string columns.
+
+        If the input data satisfies the constraint, result is a series of ``True`` values.
+
+        Input:
+        - Table data (pandas.DataFrame), satisfying the constraint.
+        Output:
+        - Series of ``True`` values (pandas.Series)
+        Side effects:
+        - Since the ``is_valid`` method needs ``self._combinations``, method ``fit``
+        must be called as well.
+        """
+        # Setup
+        table_data = pd.DataFrame({
+            'a': ['a', 'b', 'c'],
+            'b': [1, 2, 3],
+            'c': ['g', 'h', 'i'],
+            'd': [2.4, 1.23, 5.6]
+        })
+        columns = ['b', 'c', 'd']
+        instance = UniqueCombinations(columns=columns)
+        instance.fit(table_data)
+
+        # Run
+        out = instance.is_valid(table_data)
+
+        expected_out = pd.Series([True, True, True], name='b#c#d')
+        pd.testing.assert_series_equal(expected_out, out)
+
+    def test_is_valid_non_string_false(self):
+        """Test the ``UniqueCombinations.is_valid`` method with non string columns.
+
+        If the input data doesn't satisfy the constraint, result is a series of ``False`` values.
+
+        Input:
+        - Table data (pandas.DataFrame), which does not satisfy the constraint.
+        Output:
+        - Series of ``False`` values (pandas.Series)
+        Side effects:
+        - Since the ``is_valid`` method needs ``self._combinations``, method ``fit``
+        must be called as well.
+        """
+        # Setup
+        table_data = pd.DataFrame({
+            'a': ['a', 'b', 'c'],
+            'b': [1, 2, 3],
+            'c': ['g', 'h', 'i'],
+            'd': [2.4, 1.23, 5.6]
+        })
+        columns = ['b', 'c', 'd']
+        instance = UniqueCombinations(columns=columns)
+        instance.fit(table_data)
+
+        # Run
+        incorrect_table = pd.DataFrame({
+            'a': ['a', 'b', 'c'],
+            'b': [6, 7, 8],
+            'c': ['g', 'h', 'i'],
+            'd': [2.4, 1.23, 5.6]
+        })
+        out = instance.is_valid(incorrect_table)
+
+        # Assert
+        expected_out = pd.Series([False, False, False], name='b#c#d')
+        pd.testing.assert_series_equal(expected_out, out)
+
     def test_transform(self):
         """Test the ``UniqueCombinations.transform`` method.
 
@@ -277,6 +344,8 @@ class TestUniqueCombinations():
         out = instance.transform(table_data)
 
         # Assert
+        assert instance._combination_map is None
+        assert instance._unique_value_map is None
         expected_out = pd.DataFrame({
             'a': ['a', 'b', 'c'],
             'b#c': ['d#g', 'e#h', 'f#i']
@@ -300,9 +369,10 @@ class TestUniqueCombinations():
         table_data = pd.DataFrame({
             'a': ['a', 'b', 'c'],
             'b': [1, 2, 3],
-            'c': ['g', 'h', 'i']
+            'c': ['g', 'h', 'i'],
+            'd': [2.4, 1.23, 5.6]
         })
-        columns = ['b', 'c']
+        columns = ['b', 'c', 'd']
         instance = UniqueCombinations(columns=columns)
         instance.fit(table_data)
 
@@ -310,10 +380,12 @@ class TestUniqueCombinations():
         out = instance.transform(table_data)
 
         # Assert
+        assert instance._combination_map is not None
+        assert instance._unique_value_map is not None
         expected_out_a = pd.Series(['a', 'b', 'c'], name='a')
         pd.testing.assert_series_equal(expected_out_a, out['a'])
         try:
-            [uuid.UUID(u) for c, u in out['b#c'].items()]
+            [uuid.UUID(u) for c, u in out['b#c#d'].items()]
         except ValueError:
             assert False
 
@@ -373,6 +445,8 @@ class TestUniqueCombinations():
         out = instance.reverse_transform(transformed_data)
 
         # Assert
+        assert instance._combination_map is None
+        assert instance._unique_value_map is None
         expected_out = pd.DataFrame({
             'a': ['a', 'b', 'c'],
             'b': ['d', 'e', 'f'],
@@ -397,9 +471,10 @@ class TestUniqueCombinations():
         table_data = pd.DataFrame({
             'a': ['a', 'b', 'c'],
             'b': [1, 2, 3],
-            'c': ['g', 'h', 'i']
+            'c': ['g', 'h', 'i'],
+            'd': [2.4, 1.23, 5.6]
         })
-        columns = ['b', 'c']
+        columns = ['b', 'c', 'd']
         instance = UniqueCombinations(columns=columns)
         instance.fit(table_data)
 
@@ -408,10 +483,13 @@ class TestUniqueCombinations():
         out = instance.reverse_transform(transformed_data)
 
         # Assert
+        assert instance._combination_map is not None
+        assert instance._unique_value_map is not None
         expected_out = pd.DataFrame({
             'a': ['a', 'b', 'c'],
             'b': [1, 2, 3],
-            'c': ['g', 'h', 'i']
+            'c': ['g', 'h', 'i'],
+            'd': [2.4, 1.23, 5.6]
         })
         pd.testing.assert_frame_equal(expected_out, out)
 


### PR DESCRIPTION
Expand UniqueCombinations constraint to handle non-strings, and add unit tests

Resolves #196 