### PR TITLE
No longer cast categorical types as strings

### DIFF
--- a/sdv/metadata/dataset.py
+++ b/sdv/metadata/dataset.py
@@ -21,9 +21,7 @@ def _read_csv_dtypes(table_meta):
     dtypes = dict()
     for name, field in table_meta['fields'].items():
         field_type = field['type']
-        if field_type == 'categorical':
-            dtypes[name] = str
-        elif field_type == 'id' and field.get('subtype', 'integer') == 'string':
+        if field_type == 'id' and field.get('subtype', 'integer') == 'string':
             dtypes[name] = str
 
     return dtypes

--- a/tests/unit/metadata/test_dataset.py
+++ b/tests/unit/metadata/test_dataset.py
@@ -35,7 +35,7 @@ def test__read_csv_dtypes():
     result = _read_csv_dtypes(table_meta)
 
     # Asserts
-    assert result == {'a_field': str, 'd_field': str}
+    assert result == {'d_field': str}
 
 
 def test__parse_dtypes():


### PR DESCRIPTION
resolves #503 

#503 was filed because a categorical column that was made up of float values was being loaded as a string type. When certain constraints were applied to it, it crashed since the column was expected to have numerical values but actually had string. Since we allow for categorical data to be of any type, we no longer want to cast a column as `str` if it is categorical.