### PR TITLE
Fix ColumnFormula conditioning bug

### DIFF
--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -522,6 +522,7 @@ class ColumnFormula(Constraint):
                 Transformed data.
         """
         table_data = table_data.copy()
+
         if self._drop_column:
             del table_data[self._column]
 

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -483,12 +483,13 @@ class ColumnFormula(Constraint):
         handling_strategy (str):
             How this Constraint should be handled, which can be ``transform``
             or ``reject_sampling``. Defaults to ``transform``.
-        drop_column(str):
+        drop_column (bool):
             Whether or not to drop the constraint column.
     """
 
     def __init__(self, column, formula, handling_strategy='transform', drop_column=True):
         self._column = column
+        self.constraint_columns = (column,)
         self._formula = import_object(formula)
         self._drop_column = drop_column
         super().__init__(handling_strategy, fit_columns_model=False)
@@ -507,7 +508,7 @@ class ColumnFormula(Constraint):
         computed = self._formula(table_data)
         return table_data[self._column] == computed
 
-    def transform(self, table_data):
+    def _transform(self, table_data):
         """Transform the table data.
 
         The transformation consist on simply dropping the indicated column from the
@@ -523,7 +524,7 @@ class ColumnFormula(Constraint):
         """
         table_data = table_data.copy()
 
-        if self._drop_column:
+        if self._drop_column and self._column in table_data:
             del table_data[self._column]
 
         return table_data

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -1773,8 +1773,8 @@ class TestColumnFormula():
         expected_out = pd.Series([False, False, False])
         pd.testing.assert_series_equal(expected_out, out)
 
-    def test_transform(self):
-        """Test the ``ColumnFormula.transform`` method.
+    def test__transform(self):
+        """Test the ``ColumnFormula._transform`` method.
 
         It is expected to drop the indicated column from the table.
 
@@ -1793,7 +1793,7 @@ class TestColumnFormula():
             'b': [4, 5, 6],
             'c': [5, 7, 9]
         })
-        out = instance.transform(table_data)
+        out = instance._transform(table_data)
 
         # Assert
         expected_out = pd.DataFrame({
@@ -1802,8 +1802,8 @@ class TestColumnFormula():
         })
         pd.testing.assert_frame_equal(expected_out, out)
 
-    def test_transform_without_dropping_column(self):
-        """Test the ``ColumnFormula.transform`` method without dropping the column.
+    def test__transform_without_dropping_column(self):
+        """Test the ``ColumnFormula._transform`` method without dropping the column.
 
         If `drop_column` is false, expect to not drop the constraint column.
 
@@ -1822,7 +1822,7 @@ class TestColumnFormula():
             'b': [4, 5, 6],
             'c': [5, 7, 9]
         })
-        out = instance.transform(table_data)
+        out = instance._transform(table_data)
 
         # Assert
         expected_out = pd.DataFrame({
@@ -1832,13 +1832,16 @@ class TestColumnFormula():
         })
         pd.testing.assert_frame_equal(expected_out, out)
 
-    def test_transform_missing_column(self):
-        """Test the ``ColumnFormula.transform`` method when the constraint column is missing.
+    def test__transform_missing_column(self):
+        """Test the ``ColumnFormula._transform`` method when the constraint column is missing.
 
-        When ``transform`` is called with data that does not contain the constraint column,
+        When ``_transform`` is called with data that does not contain the constraint column,
         expect to return the data as-is.
-        })
+
+        Input:
         - Table data (pandas.DataFrame)
+        Output:
+        - Table data, unchanged (pandas.DataFrame)
         """
         # Setup
         column = 'c'
@@ -1850,7 +1853,7 @@ class TestColumnFormula():
             'b': [4, 5, 6],
             'd': [5, 7, 9]
         })
-        out = instance.transform(table_data)
+        out = instance._transform(table_data)
 
         # Assert
         expected_out = pd.DataFrame({

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -1832,6 +1832,34 @@ class TestColumnFormula():
         })
         pd.testing.assert_frame_equal(expected_out, out)
 
+    def test_transform_missing_column(self):
+        """Test the ``ColumnFormula.transform`` method when the constraint column is missing.
+
+        When ``transform`` is called with data that does not contain the constraint column,
+        expect to return the data as-is.
+        })
+        - Table data (pandas.DataFrame)
+        """
+        # Setup
+        column = 'c'
+        instance = ColumnFormula(column=column, formula=new_column)
+
+        # Run
+        table_data = pd.DataFrame({
+            'a': [1, 2, 3],
+            'b': [4, 5, 6],
+            'd': [5, 7, 9]
+        })
+        out = instance.transform(table_data)
+
+        # Assert
+        expected_out = pd.DataFrame({
+            'a': [1, 2, 3],
+            'b': [4, 5, 6],
+            'd': [5, 7, 9]
+        })
+        pd.testing.assert_frame_equal(expected_out, out)
+
     def test_reverse_transform(self):
         """Test the ``ColumnFormula.reverse_transform`` method.
 

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -1703,15 +1703,16 @@ class TestColumnFormula():
     def test___init__(self):
         """Test the ``ColumnFormula.__init__`` method.
 
-        It is expected to create a new Constraint instance
-        and import the formula to use for the computation.
+        It is expected to create a new Constraint instance,
+        import the formula to use for the computation, and
+        set the specified constraint column.
 
         Input:
-        - column = 'c'
+        - column = 'col'
         - formula = new_column
         """
         # Setup
-        column = 'c'
+        column = 'col'
 
         # Run
         instance = ColumnFormula(column=column, formula=new_column)
@@ -1719,7 +1720,7 @@ class TestColumnFormula():
         # Assert
         assert instance._column == column
         assert instance._formula == new_column
-        assert instance.constraint_columns == ('c', )
+        assert instance.constraint_columns == ('col', )
 
     def test_is_valid_valid(self):
         """Test the ``ColumnFormula.is_valid`` method for a valid data.

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -1719,6 +1719,7 @@ class TestColumnFormula():
         # Assert
         assert instance._column == column
         assert instance._formula == new_column
+        assert instance.constraint_columns == ('c', )
 
     def test_is_valid_valid(self):
         """Test the ``ColumnFormula.is_valid`` method for a valid data.


### PR DESCRIPTION
Resolves #507 

If the column we're conditioning on is not the `ColumnFormula` constraint column, then the code errors out [here](https://github.com/sdv-dev/SDV/blob/master/sdv/tabular/base.py#L442) when trying to apply `ColumnFormula.transform` to the `conditions` dataframe, which only contains the conditioned-on column(s). In this scenario, `ColumnFormula.transform` should just return the original data.