### PR TITLE
Validate UniqueCombinations columns input

### DIFF
--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -73,7 +73,8 @@ class UniqueCombinations(Constraint):
 
     Args:
         columns (list[str]):
-            Names of the columns that need to produce unique combinations.
+            Names of the columns that need to produce unique combinations. Must
+            contain at least two columns.
         handling_strategy (str):
             How this Constraint should be handled, which can be ``transform``,
             ``reject_sampling`` or ``all``. Defaults to ``transform``.
@@ -85,6 +86,9 @@ class UniqueCombinations(Constraint):
     _uuids_to_combinations = None
 
     def __init__(self, columns, handling_strategy='transform', fit_columns_model=True):
+        if len(columns) < 2:
+            raise ValueError('UniqueCombinations requires at least two constraint columns.')
+
         self._columns = columns
         self.constraint_columns = tuple(columns)
         super().__init__(handling_strategy=handling_strategy,

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -75,6 +75,22 @@ class TestUniqueCombinations():
         # Assert
         assert instance._columns == columns
 
+    def test___init__with_one_column(self):
+        """Test the ``UniqueCombinations.__init__`` method with only one constraint column.
+
+        Expect a ``ValueError`` because UniqueCombinations requires at least two
+        constraint columns.
+
+        Side effects:
+        - A ValueError is raised
+        """
+        # Setup
+        columns = ['c']
+
+        # Run and assert
+        with pytest.raises(ValueError):
+            UniqueCombinations(columns=columns)
+
     def test_fit(self):
         """Test the ``UniqueCombinations.fit`` method.
 


### PR DESCRIPTION
Validate the `UniqueCombinations` `columns` input to make sure `columns` contains at least 2 values, since we expect this constraint to be over multiple columns.

Resolves #509 