### PR TITLE
Create Unique Constraint

### DIFF
--- a/docs/api_reference/constraints/tabular.rst
+++ b/docs/api_reference/constraints/tabular.rst
@@ -148,3 +148,19 @@ OneHotEncoding
    OneHotEncoding.filter_valid
    OneHotEncoding.from_dict
    OneHotEncoding.to_dict
+
+Unique
+~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: api/
+
+   Unique
+   Unique.fit
+   Unique.transform
+   Unique.fit_transform
+   Unique.reverse_transform
+   Unique.is_valid
+   Unique.filter_valid
+   Unique.from_dict
+   Unique.to_dict

--- a/sdv/constraints/__init__.py
+++ b/sdv/constraints/__init__.py
@@ -3,7 +3,7 @@
 from sdv.constraints.base import Constraint
 from sdv.constraints.tabular import (
     Between, ColumnFormula, CustomConstraint, GreaterThan, Negative, OneHotEncoding, Positive,
-    Rounding, UniqueCombinations)
+    Rounding, Unique, UniqueCombinations)
 
 __all__ = [
     'Constraint',
@@ -15,5 +15,6 @@ __all__ = [
     'Negative',
     'Positive',
     'Rounding',
-    'OneHotEncoding'
+    'OneHotEncoding',
+    'Unique'
 ]

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -956,3 +956,40 @@ class OneHotEncoding(Constraint):
         table_data[self._columns] = transformed_data
 
         return table_data
+
+
+class Unique(Constraint):
+    """Ensure that each value for a specified column/group of columns is unique.
+
+    This constraint is provided a list of columns, and guarantees that every
+    unique combination of those columns appears at most once in the sampled
+    data.
+
+    Args:
+        columns (str or list[str]):
+            Name of the column(s) to keep unique.
+    """
+
+    def __init__(self, columns):
+        self.columns = [columns] if isinstance(columns, str) else columns 
+        self.handling_strategy = 'reject_sampling'
+
+    def is_valid(self, table_data):
+        """Get indices of first instance of unique rows.
+
+        If a row is the first instance of that combination of column
+        values, it is valid. Otherwise it is false.
+
+        Args:
+            table_data (pandas.DataFrame):
+                Table data.
+
+        Returns:
+            pandas.Series:
+                Whether each row is valid.
+        """
+        data = table_data.reset_index()
+        groups = data.groupby(self.columns)
+        valid = pd.Series([False]*data.shape[0])
+        valid.iloc[groups.first()['index'].values] = True
+        return valid

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -972,7 +972,7 @@ class Unique(Constraint):
 
     def __init__(self, columns):
         self.columns = [columns] if isinstance(columns, str) else columns
-        self.handling_strategy = 'reject_sampling'
+        super().__init__(handling_strategy='reject_sampling', fit_columns_model=False)
 
     def is_valid(self, table_data):
         """Get indices of first instance of unique rows.
@@ -988,8 +988,8 @@ class Unique(Constraint):
             pandas.Series:
                 Whether each row is valid.
         """
+        valid = pd.Series([False] * table_data.shape[0])
         data = table_data.reset_index()
         groups = data.groupby(self.columns)
-        valid = pd.Series([False] * data.shape[0])
         valid.iloc[groups.first()['index'].values] = True
         return valid

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -971,7 +971,7 @@ class Unique(Constraint):
     """
 
     def __init__(self, columns):
-        self.columns = [columns] if isinstance(columns, str) else columns 
+        self.columns = [columns] if isinstance(columns, str) else columns
         self.handling_strategy = 'reject_sampling'
 
     def is_valid(self, table_data):
@@ -990,6 +990,6 @@ class Unique(Constraint):
         """
         data = table_data.reset_index()
         groups = data.groupby(self.columns)
-        valid = pd.Series([False]*data.shape[0])
+        valid = pd.Series([False] * data.shape[0])
         valid.iloc[groups.first()['index'].values] = True
         return valid

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -971,7 +971,7 @@ class Unique(Constraint):
     """
 
     def __init__(self, columns):
-        self.columns = [columns] if isinstance(columns, str) else columns
+        self.columns = columns if isinstance(columns, list) else [columns]
         super().__init__(handling_strategy='reject_sampling', fit_columns_model=False)
 
     def is_valid(self, table_data):

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -234,7 +234,7 @@ class BaseTabularModel:
             sampled = self._metadata.reverse_transform(sampled)
 
             if previous_rows is not None:
-                sampled = previous_rows.append(sampled)
+                sampled = previous_rows.append(sampled).reset_index(drop=True)
 
             sampled = self._metadata.filter_valid(sampled)
 

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -234,7 +234,7 @@ class BaseTabularModel:
             sampled = self._metadata.reverse_transform(sampled)
 
             if previous_rows is not None:
-                sampled = previous_rows.append(sampled).reset_index(drop=True)
+                sampled = previous_rows.append(sampled, ignore_index=True)
 
             sampled = self._metadata.filter_valid(sampled)
 

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -3409,6 +3409,7 @@ class TestUnique():
         # Assert
         assert instance.columns == ['a', 'b']
         assert instance.handling_strategy == 'reject_sampling'
+        assert instance.fit_columns_model is False
 
     def test___init__one_column(self):
         """Test the ``Unique.__init__`` method.

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -3400,36 +3400,34 @@ class TestUnique():
         Input:
         - column names to keep unique.
         Output:
-        - Instance with ``columns`` set and ``handling_strategy``
-        set to ``'reject_sampling'``.
+        - Instance with ``columns`` set and ``transform``
+        and ``reverse_transform`` methods set to ``instance._identity``.
         """
         # Run
         instance = Unique(columns=['a', 'b'])
 
         # Assert
         assert instance.columns == ['a', 'b']
-        assert instance.handling_strategy == 'reject_sampling'
         assert instance.fit_columns_model is False
+        assert instance.transform == instance._identity
+        assert instance.reverse_transform == instance._identity
 
     def test___init__one_column(self):
         """Test the ``Unique.__init__`` method.
 
         The ``columns`` should be set to a list even if a string is
-        provided and the ``handling_strategy`` should be set to
-        ``'reject_sampling'``.
+        provided.
 
         Input:
         - string that is the name of a column.
         Output:
-        - Instance with ``columns`` set and ``handling_strategy``
-        set to ``'reject_sampling'``.
+        - Instance with ``columns`` set to list of one element.
         """
         # Run
         instance = Unique(columns='a')
 
         # Assert
         assert instance.columns == ['a']
-        assert instance.handling_strategy == 'reject_sampling'
 
     def test_is_valid(self):
         """Test the ``Unique.is_valid`` method.

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -86,7 +86,7 @@ def test__sample_rows_previous_rows_appended_correctly():
     """Test the ``BaseTabularModel._sample_rows`` method.
 
     If ``_sample_rows`` is passed ``previous_rows``, then it
-    shuld reset the index when appending them to the new
+    should reset the index when appending them to the new
     sampled rows.
 
     Input:


### PR DESCRIPTION
resolve #532

This PR adds a new constraint class called `Unique`. The class takes in one parameter for its `__init__`: `columns` which is either a string defining the one column name that needs to be unique or a list of column names.

The `Unique` constraint only works with the `reject_sampling` `handling_strategy`. For this reason it only implements a `is_valid` method. 

The `is_valid` method returns a `pd.Series` where the index corresponding to the first occurrence of a unique value for the specified `columns` is set to True, and the rest are set to False.