### PR TITLE
Allow conditioning on constraint column in `ColumnFormula`

### DIFF
--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -457,7 +457,7 @@ class BaseTabularModel:
 
             condition_indices = dataframe[COND_IDX]
             condition = dict(zip(condition_columns, group))
-            if transformed_conditions.empty:
+            if len(transformed_columns) == 0:
                 sampled_rows = self._conditionally_sample_rows(
                     dataframe,
                     max_retries,

--- a/tests/integration/test_constraints.py
+++ b/tests/integration/test_constraints.py
@@ -68,30 +68,3 @@ def test_constraints_reject_sampling_zero_valid():
     gc = GaussianCopula(constraints=[constraint])
     gc.fit(employees)
     gc.sample(10)
-
-
-def test_constraints_condition_on_constraint_column():
-    """Test the CustomFormula constraint when conditioning on the constraint column.
-
-    Expect conditioning on the constraint column to work with CustomFormula.
-
-    Setup:
-        - Load employee data
-        - Setup CustomFormula on `years_in_the_company` column
-        - Create and fit the model
-        - Sample, conditioning on `years_in_the_company` column
-    Side effects:
-        - Expect no errors
-    """
-    employees = load_tabular_demo()
-
-    years_in_the_company_constraint = ColumnFormula(
-        column='years_in_the_company',
-        formula=years_in_the_company,
-        handling_strategy='transform'
-    )
-
-    constraints = [years_in_the_company_constraint]
-    gc = GaussianCopula(constraints=constraints)
-    gc.fit(employees)
-    gc.sample(10, conditions={'years_in_the_company': 1})

--- a/tests/integration/test_constraints.py
+++ b/tests/integration/test_constraints.py
@@ -68,3 +68,30 @@ def test_constraints_reject_sampling_zero_valid():
     gc = GaussianCopula(constraints=[constraint])
     gc.fit(employees)
     gc.sample(10)
+
+
+def test_constraints_condition_on_constraint_column():
+    """Test the CustomFormula constraint when conditioning on the constraint column.
+
+    Expect conditioning on the constraint column to work with CustomFormula.
+
+    Setup:
+        - Load employee data
+        - Setup CustomFormula on `years_in_the_company` column
+        - Create and fit the model
+        - Sample, conditioning on `years_in_the_company` column
+    Side effects:
+        - Expect no errors
+    """
+    employees = load_tabular_demo()
+
+    years_in_the_company_constraint = ColumnFormula(
+        column='years_in_the_company',
+        formula=years_in_the_company,
+        handling_strategy='transform'
+    )
+
+    constraints = [years_in_the_company_constraint]
+    gc = GaussianCopula(constraints=constraints)
+    gc.fit(employees)
+    gc.sample(10, conditions={'years_in_the_company': 1})

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -16,6 +16,68 @@ MODELS = [
 ]
 
 
+class DataFrameMatcher:
+    def __init__(self, df):
+        self.df = df
+
+    def __eq__(self, other):
+        return self.df.equals(other)
+
+
+class TestBaseTabularModel:
+
+    @patch("sdv.tabular.base.COND_IDX", 'test-cond-idx')
+    def test_sample_no_transformed_columns(self):
+        """Test the ``BaseTabularModel.sample`` method with no transformed columns.
+
+        When the transformed conditions DataFrame has no columns, expect that sample
+        does not pass through any conditions when conditionally sampling.
+
+        Setup:
+            - Mock the ``_make_conditions_df`` method to return a dataframe representing
+              the expected conditions, and the ``get_fields`` method to return metadata
+              fields containing the expected conditioned column.
+            - Mock the ``_metadata.transform`` method to return an empty transformed
+              conditions dataframe.
+            - Mock the ``_conditionally_sample_rows`` method to return the expected
+              sampled rows.
+        Input:
+            - number of rows
+            - one set of conditions
+        Output:
+            - the expected sampled rows
+        Side Effects:
+            - Expect ``_conditionally_sample_rows`` to be called with the given condition
+              and a transformed_condition of None.
+        """
+        # Setup
+        gaussian_copula = Mock(spec_set=GaussianCopula)
+        expected = pd.DataFrame(['a', 'a', 'a'])
+
+        gaussian_copula._make_conditions_df.return_value = pd.DataFrame({'a': ['a', 'a', 'a']})
+        gaussian_copula._metadata.get_fields.return_value = ['a']
+        gaussian_copula._metadata.transform.return_value = pd.DataFrame({}, index=[0, 1, 2])
+        gaussian_copula._conditionally_sample_rows.return_value = pd.DataFrame({
+            'a': ['a', 'a', 'a'],
+            'test-cond-idx': [0, 1, 2]})
+        gaussian_copula._metadata.make_ids_unique.return_value = expected
+
+        # Run
+        out = GaussianCopula.sample(gaussian_copula, num_rows=3, conditions={'a': 'a'})
+
+        # Asserts
+        gaussian_copula._conditionally_sample_rows.assert_called_once_with(
+            DataFrameMatcher(pd.DataFrame({'test-cond-idx': [0, 1, 2], 'a': ['a', 'a', 'a']})),
+            100,
+            10,
+            {'a': 'a'},
+            None,
+            0.01,
+            False,
+        )
+        assert out.equals(expected)
+
+
 @patch('sdv.tabular.base.Table', spec_set=Table)
 def test__init__passes_correct_parameters(metadata_mock):
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,13 @@
+"""Utils for testing."""
+import pandas as pd
+
+
+class DataFrameMatcher:
+    """Match a given Pandas DataFrame in a mock function call."""
+
+    def __init__(self, df):
+        self.df = df
+
+    def __eq__(self, other):
+        pd.testing.assert_frame_equal(self.df, other)
+        return True


### PR DESCRIPTION
If the transformed conditions doesn't have any columns, don't pass through the conditions when sampling.

Resolve #506 