### PR TITLE
Check for invalid conditions when sampling

### DIFF
--- a/sdv/errors.py
+++ b/sdv/errors.py
@@ -3,3 +3,11 @@
 
 class NotFittedError(Exception):
     """Error to raise when sample is called and the model is not fitted."""
+
+
+class ConstraintsNotMetError(ValueError):
+    """Exception raised when the given data is not valid for the constraints."""
+
+    def __init__(self, message=''):
+        self.message = message
+        super().__init__(self.message)

--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -578,8 +578,7 @@ class Table:
 
         Args:
             data (pandas.DataFrame):
-                Table data. If the table data is not valid for the provided constraints,
-                a `ValueError` is raised.
+                Table data.
             on_missing_column (str):
                 If the value is error, then a `MissingConstraintColumnError` is raised.
                 If the value is drop, then the columns involved in the constraint that
@@ -588,6 +587,10 @@ class Table:
         Returns:
             pandas.DataFrame:
                 Transformed data.
+
+        Raises:
+            ConstraintsNotMetError:
+                If the table data is not valid for the provided constraints.
         """
         if not self.fitted:
             raise MetadataNotFittedError()

--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -562,16 +562,16 @@ class Table:
                 Table data.
 
         Returns:
-            bool:
-                Whether or not the table data is valid for the constraints.
-        """
-        is_valid = True
+            None
 
+        Raises:
+            ConstraintsNotMetError:
+                If the table data is not valid for the provided constraints.
+        """
         for constraint in self._constraints:
             if set(constraint.constraint_columns).issubset(data.columns.values):
-                is_valid = is_valid and constraint.is_valid(data).all()
-
-        return is_valid
+                if not constraint.is_valid(data).all():
+                    raise ConstraintsNotMetError('Data is not valid for the given constraints')
 
     def transform(self, data, on_missing_column='error'):
         """Transform the given data.
@@ -599,8 +599,7 @@ class Table:
         LOGGER.debug('Anonymizing table %s', self.name)
         data = self._anonymize(data[fields])
 
-        if not self._validate_data_on_constraints(data):
-            raise ConstraintsNotMetError('Data is not valid for the given constraints')
+        self._validate_data_on_constraints(data)
 
         LOGGER.debug('Transforming constraints for table %s', self.name)
         data = self._transform_constraints(data, on_missing_column)

--- a/tests/integration/test_constraints.py
+++ b/tests/integration/test_constraints.py
@@ -1,6 +1,4 @@
-import pandas as pd
-
-from sdv.constraints import ColumnFormula, CustomConstraint, GreaterThan, UniqueCombinations
+from sdv.constraints import ColumnFormula, GreaterThan, UniqueCombinations
 from sdv.demo import load_tabular_demo
 from sdv.tabular import GaussianCopula
 
@@ -41,30 +39,4 @@ def test_constraints(tmpdir):
     gc.fit(employees)
     gc.save(tmpdir / 'test.pkl')
     gc = gc.load(tmpdir / 'test.pkl')
-    gc.sample(10)
-
-
-_IS_VALID_CALLED = []
-
-
-def _is_valid(rows):
-    if not _IS_VALID_CALLED:
-        _IS_VALID_CALLED.append(True)
-        return pd.Series([False] * len(rows), index=rows.index)
-
-    return pd.Series([True] * len(rows), index=rows.index)
-
-
-def test_constraints_reject_sampling_zero_valid():
-    """Ensure everything works if no rows are valid on the first try.
-
-    See https://github.com/sdv-dev/SDV/issues/285
-    """
-    employees = load_tabular_demo()
-
-    _IS_VALID_CALLED.clear()
-    constraint = CustomConstraint(is_valid=_is_valid)
-
-    gc = GaussianCopula(constraints=[constraint])
-    gc.fit(employees)
     gc.sample(10)

--- a/tests/unit/metadata/test_table.py
+++ b/tests/unit/metadata/test_table.py
@@ -236,3 +236,86 @@ class TestTable:
             'item 1': [3, 4, 5]
         }, index=[0, 1, 2])
         assert result.equals(expected_result)
+
+    def test__validate_data_on_constraints(self):
+        """Test the ``Table._validate_data_on_constraints`` method.
+
+        Expect that the method returns True when the constraint columns are in the given data,
+        and the constraint.is_valid method returns True.
+
+        Input:
+        - Table data
+        Output:
+        - True
+        """
+        # Setup
+        data = pd.DataFrame({
+            'a': [0, 1, 2],
+            'b': [3, 4, 5]
+        }, index=[0, 1, 2])
+        constraint_mock = Mock()
+        constraint_mock.is_valid.return_value = pd.Series([True, True, True])
+        constraint_mock.constraint_columns = ['a', 'b']
+        table_mock = Mock()
+        table_mock._constraints = [constraint_mock]
+
+        # Run
+        result = Table._validate_data_on_constraints(table_mock, data)
+
+        # Assert
+        assert result
+
+    def test__validate_data_on_constraints_invalid_input(self):
+        """Test the ``Table._validate_data_on_constraints`` method.
+
+        Expect that the method returns False when the constraint columns are in the given data,
+        and the constraint.is_valid method returns False for any row.
+
+        Input:
+        - Table data contains an invalid row
+        Output:
+        - False
+        """
+        # Setup
+        data = pd.DataFrame({
+            'a': [0, 1, 2],
+            'b': [3, 4, 5]
+        }, index=[0, 1, 2])
+        constraint_mock = Mock()
+        constraint_mock.is_valid.return_value = pd.Series([True, False, True])
+        constraint_mock.constraint_columns = ['a', 'b']
+        table_mock = Mock()
+        table_mock._constraints = [constraint_mock]
+
+        # Run
+        result = Table._validate_data_on_constraints(table_mock, data)
+
+        # Assert
+        assert not result
+
+    def test__validate_data_on_constraints_missing_cols(self):
+        """Test the ``Table._validate_data_on_constraints`` method.
+
+        Expect that the method returns True when the constraint columns are not
+        in the given data.
+
+        Input:
+        - Table data that is missing a constraint column
+        Output:
+        - False
+        """
+        # Setup
+        data = pd.DataFrame({
+            'a': [0, 1, 2],
+            'b': [3, 4, 5]
+        }, index=[0, 1, 2])
+        constraint_mock = Mock()
+        constraint_mock.constraint_columns = ['a', 'b', 'c']
+        table_mock = Mock()
+        table_mock._constraints = [constraint_mock]
+
+        # Run
+        result = Table._validate_data_on_constraints(table_mock, data)
+
+        # Assert
+        assert result

--- a/tests/unit/metadata/test_table.py
+++ b/tests/unit/metadata/test_table.py
@@ -5,6 +5,7 @@ import pytest
 from rdt.transformers.numerical import NumericalTransformer
 
 from sdv.constraints.errors import MissingConstraintColumnError
+from sdv.errors import ConstraintsNotMetError
 from sdv.metadata import Table
 
 
@@ -246,7 +247,9 @@ class TestTable:
         Input:
         - Table data
         Output:
-        - True
+        - None
+        Side Effects:
+        - No error
         """
         # Setup
         data = pd.DataFrame({
@@ -263,7 +266,7 @@ class TestTable:
         result = Table._validate_data_on_constraints(table_mock, data)
 
         # Assert
-        assert result
+        assert result is None
 
     def test__validate_data_on_constraints_invalid_input(self):
         """Test the ``Table._validate_data_on_constraints`` method.
@@ -274,7 +277,9 @@ class TestTable:
         Input:
         - Table data contains an invalid row
         Output:
-        - False
+        - None
+        Side Effects:
+        - A ConstraintsNotMetError is thrown
         """
         # Setup
         data = pd.DataFrame({
@@ -287,11 +292,9 @@ class TestTable:
         table_mock = Mock()
         table_mock._constraints = [constraint_mock]
 
-        # Run
-        result = Table._validate_data_on_constraints(table_mock, data)
-
-        # Assert
-        assert not result
+        # Run and assert
+        with pytest.raises(ConstraintsNotMetError):
+            Table._validate_data_on_constraints(table_mock, data)
 
     def test__validate_data_on_constraints_missing_cols(self):
         """Test the ``Table._validate_data_on_constraints`` method.
@@ -302,7 +305,9 @@ class TestTable:
         Input:
         - Table data that is missing a constraint column
         Output:
-        - False
+        - None
+        Side Effects:
+        - No error
         """
         # Setup
         data = pd.DataFrame({
@@ -318,4 +323,4 @@ class TestTable:
         result = Table._validate_data_on_constraints(table_mock, data)
 
         # Assert
-        assert result
+        assert result is None


### PR DESCRIPTION
If we don't have any non-null transformed conditions when sampling, return a more informative error (`InvalidConditionsError`), which tells the user that there are no valid conditions to sample with.

Resolves #511 