### PR TITLE
Raise error when multiple constraints can't be enforced

### DIFF
--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -123,6 +123,7 @@ class Constraint(metaclass=ConstraintMeta):
         if handling_strategy == 'transform':
             self.filter_valid = self._identity
         elif handling_strategy == 'reject_sampling':
+            self.rebuild_columns = ()
             self.transform = self._identity
             self.reverse_transform = self._identity
         elif handling_strategy != 'all':

--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -94,6 +94,12 @@ class Constraint(metaclass=ConstraintMeta):
     ``reverse_transform`` methods will be replaced respectively by a simple
     identity function.
 
+    Attributes:
+        constraint_columns (tuple[str]):
+            The names of the columns used by this constraint.
+        rebuild_columns (typle[str]):
+            The names of the columns that this constraint will rebuild during
+            ``reverse_transform``.
     Args:
         handling_strategy (str):
             How this Constraint should be handled, which can be ``transform``,

--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -114,7 +114,6 @@ class Constraint(metaclass=ConstraintMeta):
 
     def __init__(self, handling_strategy, fit_columns_model=True):
         self.fit_columns_model = fit_columns_model
-        self.handling_strategy = handling_strategy
         if handling_strategy == 'transform':
             self.filter_valid = self._identity
         elif handling_strategy == 'reject_sampling':

--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -105,6 +105,7 @@ class Constraint(metaclass=ConstraintMeta):
     """
 
     constraint_columns = ()
+    rebuild_columns = ()
     _hyper_transformer = None
     _columns_model = None
 

--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -113,6 +113,7 @@ class Constraint(metaclass=ConstraintMeta):
 
     def __init__(self, handling_strategy, fit_columns_model=True):
         self.fit_columns_model = fit_columns_model
+        self.handling_strategy = handling_strategy
         if handling_strategy == 'transform':
             self.filter_valid = self._identity
         elif handling_strategy == 'reject_sampling':

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -93,6 +93,7 @@ class UniqueCombinations(Constraint):
 
         self._columns = columns
         self.constraint_columns = tuple(columns)
+        self.rebuild_columns = tuple(columns)
         super().__init__(handling_strategy=handling_strategy,
                          fit_columns_model=fit_columns_model)
 
@@ -297,6 +298,7 @@ class GreaterThan(Constraint):
         self._low, self._high, self.constraint_columns = self._validate_inputs(
             low=low, high=high, scalar=scalar, drop=drop)
         self._columns_to_reconstruct = self._get_columns_to_reconstruct()
+        self.rebuild_columns = self._columns_to_reconstruct.copy()
 
         if strict:
             self.operator = np.greater
@@ -553,6 +555,8 @@ class ColumnFormula(Constraint):
         self.constraint_columns = (column,)
         self._formula = import_object(formula)
         self._drop_column = drop_column
+        if self._drop_column:
+            self.rebuild_columns = (column,)
         super().__init__(handling_strategy, fit_columns_model=False)
 
     def is_valid(self, table_data):
@@ -649,6 +653,7 @@ class Between(Constraint):
                  fit_columns_model=True, high_is_scalar=None, low_is_scalar=None):
         self.constraint_column = column
         self.constraint_columns = (column,)
+        self.rebuild_columns = (column,)
         self._low = low
         self._high = high
         self._strict = strict

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -93,7 +93,8 @@ class UniqueCombinations(Constraint):
 
         self._columns = columns
         self.constraint_columns = tuple(columns)
-        self.rebuild_columns = tuple(columns)
+        if handling_strategy != 'reject_sampling':
+            self.rebuild_columns = tuple(columns)
         super().__init__(handling_strategy=handling_strategy,
                          fit_columns_model=fit_columns_model)
 
@@ -298,7 +299,8 @@ class GreaterThan(Constraint):
         self._low, self._high, self.constraint_columns = self._validate_inputs(
             low=low, high=high, scalar=scalar, drop=drop)
         self._columns_to_reconstruct = self._get_columns_to_reconstruct()
-        self.rebuild_columns = self._columns_to_reconstruct.copy()
+        if handling_strategy != 'reject_sampling':
+            self.rebuild_columns = self._columns_to_reconstruct.copy()
 
         if strict:
             self.operator = np.greater
@@ -555,7 +557,7 @@ class ColumnFormula(Constraint):
         self.constraint_columns = (column,)
         self._formula = import_object(formula)
         self._drop_column = drop_column
-        if self._drop_column:
+        if handling_strategy != 'reject_sampling':
             self.rebuild_columns = (column,)
         super().__init__(handling_strategy, fit_columns_model=False)
 
@@ -653,7 +655,8 @@ class Between(Constraint):
                  fit_columns_model=True, high_is_scalar=None, low_is_scalar=None):
         self.constraint_column = column
         self.constraint_columns = (column,)
-        self.rebuild_columns = (column,)
+        if handling_strategy != 'reject_sampling':
+            self.rebuild_columns = (column,)
         self._low = low
         self._high = high
         self._strict = strict

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -93,8 +93,7 @@ class UniqueCombinations(Constraint):
 
         self._columns = columns
         self.constraint_columns = tuple(columns)
-        if handling_strategy != 'reject_sampling':
-            self.rebuild_columns = tuple(columns)
+        self.rebuild_columns = tuple(columns)
         super().__init__(handling_strategy=handling_strategy,
                          fit_columns_model=fit_columns_model)
 
@@ -299,8 +298,7 @@ class GreaterThan(Constraint):
         self._low, self._high, self.constraint_columns = self._validate_inputs(
             low=low, high=high, scalar=scalar, drop=drop)
         self._columns_to_reconstruct = self._get_columns_to_reconstruct()
-        if handling_strategy != 'reject_sampling':
-            self.rebuild_columns = self._columns_to_reconstruct.copy()
+        self.rebuild_columns = self._columns_to_reconstruct.copy()
 
         if strict:
             self.operator = np.greater
@@ -557,8 +555,7 @@ class ColumnFormula(Constraint):
         self.constraint_columns = (column,)
         self._formula = import_object(formula)
         self._drop_column = drop_column
-        if handling_strategy != 'reject_sampling':
-            self.rebuild_columns = (column,)
+        self.rebuild_columns = (column,)
         super().__init__(handling_strategy, fit_columns_model=False)
 
     def is_valid(self, table_data):
@@ -655,8 +652,7 @@ class Between(Constraint):
                  fit_columns_model=True, high_is_scalar=None, low_is_scalar=None):
         self.constraint_column = column
         self.constraint_columns = (column,)
-        if handling_strategy != 'reject_sampling':
-            self.rebuild_columns = (column,)
+        self.rebuild_columns = (column,)
         self._low = low
         self._high = high
         self._strict = strict

--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -207,6 +207,7 @@ class Table:
 
     @staticmethod
     def _prepare_constraints(constraints):
+        constraints = constraints or []
         rebuild_columns = set()
         transform_constraints = []
         reject_sampling_constraints = []
@@ -248,7 +249,6 @@ class Table:
         self._sequence_index = sequence_index
         self._entity_columns = entity_columns or []
         self._context_columns = context_columns or []
-        self._constraints = constraints or []
         self._constraints = self._prepare_constraints(self._constraints)
         self._dtype_transformers = self._DTYPE_TRANSFORMERS.copy()
         self._transformer_templates = self._TRANSFORMER_TEMPLATES.copy()

--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -249,7 +249,7 @@ class Table:
         self._sequence_index = sequence_index
         self._entity_columns = entity_columns or []
         self._context_columns = context_columns or []
-        self._constraints = self._prepare_constraints(self._constraints)
+        self._constraints = self._prepare_constraints(constraints)
         self._dtype_transformers = self._DTYPE_TRANSFORMERS.copy()
         self._transformer_templates = self._TRANSFORMER_TEMPLATES.copy()
         self._update_transformer_templates(rounding, min_value, max_value)

--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -205,6 +205,16 @@ class Table:
                 'float': custom_float
             })
 
+    @staticmethod
+    def _get_constraint_sort_key(constraint):
+        try:
+            if constraint.handling_strategy == 'reject_sampling':
+                return 0
+            else:
+                return 1
+        except AttributeError:
+            return 1
+
     def __init__(self, name=None, field_names=None, field_types=None, field_transformers=None,
                  anonymize_fields=None, primary_key=None, constraints=None,
                  dtype_transformers=None, model_kwargs=None, sequence_index=None,
@@ -222,6 +232,7 @@ class Table:
         self._entity_columns = entity_columns or []
         self._context_columns = context_columns or []
         self._constraints = constraints or []
+        self._constraints.sort(key=self._get_constraint_sort_key)
         self._dtype_transformers = self._DTYPE_TRANSFORMERS.copy()
         self._transformer_templates = self._TRANSFORMER_TEMPLATES.copy()
         self._update_transformer_templates(rounding, min_value, max_value)

--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -241,7 +241,8 @@ class Table:
             for j in range(i + 1, len(transform_constraints)):
                 next_constraint = transform_constraints[j]
                 try:
-                    if any(c in next_constraint.columns for c in cur_constraint.rebuild_columns):
+                    if any(c in next_constraint.constraint_columns
+                           for c in cur_constraint.rebuild_columns):
                         raise Exception('Multiple constraints will modify the same column which'
                                         + 'may lead to the constraint being unenforceable. Please'
                                         + 'use reject_sampling as the handling_strategy instead.')

--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -241,11 +241,12 @@ class Table:
             for j in range(i + 1, len(transform_constraints)):
                 next_constraint = transform_constraints[j]
                 try:
-                    if any(c in next_constraint.constraint_columns
-                           for c in cur_constraint.rebuild_columns):
-                        raise Exception('Multiple constraints will modify the same column which'
-                                        + 'may lead to the constraint being unenforceable. Please'
-                                        + 'use reject_sampling as the handling_strategy instead.')
+                    for column in cur_constraint.rebuild_columns:
+                        if column in next_constraint.constraint_columns:
+                            raise Exception('Multiple constraints will modify the same column: '
+                                            f'"{column}", which may lead to the constraint being '
+                                            'unenforceable. Please use "reject_sampling" as the '
+                                            '"handling_strategy" instead.')
                 except AttributeError:
                     pass
 

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -75,6 +75,42 @@ class TestUniqueCombinations():
         # Assert
         assert instance._columns == columns
 
+    def test___init__sets_rebuild_columns_if_not_reject_sampling(self):
+        """Test the ``UniqueCombinations.__init__`` method.
+
+        The rebuild columns should only be set if the ``handling_strategy``
+        is not ``reject_sampling``.
+
+        Side effects:
+        - instance.rebuild_columns are set
+        """
+        # Setup
+        columns = ['b', 'c']
+
+        # Run
+        instance = UniqueCombinations(columns=columns, handling_strategy='transform')
+
+        # Assert
+        assert instance.rebuild_columns == tuple(columns)
+
+    def test___init__does_not_set_rebuild_columns_reject_sampling(self):
+        """Test the ``UniqueCombinations.__init__`` method.
+
+        The rebuild columns should not be set if the ``handling_strategy``
+        is ``reject_sampling``.
+
+        Side effects:
+        - instance.rebuild_columns are empty
+        """
+        # Setup
+        columns = ['b', 'c']
+
+        # Run
+        instance = UniqueCombinations(columns=columns, handling_strategy='reject_sampling')
+
+        # Assert
+        assert instance.rebuild_columns == ()
+
     def test___init__with_one_column(self):
         """Test the ``UniqueCombinations.__init__`` method with only one constraint column.
 
@@ -720,6 +756,36 @@ class TestGreaterThan():
         assert instance._scalar is None
         assert instance._drop is None
         assert instance.constraint_columns == ('a', 'b')
+
+    def test___init__sets_rebuild_columns_if_not_reject_sampling(self):
+        """Test the ``GreaterThan.__init__`` method.
+
+        The rebuild columns should only be set if the ``handling_strategy``
+        is not ``reject_sampling``.
+
+        Side effects:
+        - instance.rebuild_columns are set
+        """
+        # Run
+        instance = GreaterThan(low='a', high='b', handling_strategy='transform')
+
+        # Assert
+        assert instance.rebuild_columns == ['b']
+
+    def test___init__does_not_set_rebuild_columns_reject_sampling(self):
+        """Test the ``GreaterThan.__init__`` method.
+
+        The rebuild columns should not be set if the ``handling_strategy``
+        is ``reject_sampling``.
+
+        Side effects:
+        - instance.rebuild_columns are empty
+        """
+        # Run
+        instance = GreaterThan(low='a', high='b', handling_strategy='reject_sampling')
+
+        # Assert
+        assert instance.rebuild_columns == ()
 
     def test___init___high_is_scalar(self):
         """Test the ``GreaterThan.__init__`` method.
@@ -2865,6 +2931,43 @@ class TestColumnFormula():
         assert instance._formula == new_column
         assert instance.constraint_columns == ('col', )
 
+    def test___init__sets_rebuild_columns_if_not_reject_sampling(self):
+        """Test the ``ColumnFormula.__init__`` method.
+
+        The rebuild columns should only be set if the ``handling_strategy``
+        is not ``reject_sampling``.
+
+        Side effects:
+        - instance.rebuild_columns are set
+        """
+        # Setup
+        column = 'col'
+
+        # Run
+        instance = ColumnFormula(column=column, formula=new_column, handling_strategy='transform')
+
+        # Assert
+        assert instance.rebuild_columns == (column,)
+
+    def test___init__does_not_set_rebuild_columns_reject_sampling(self):
+        """Test the ``ColumnFormula.__init__`` method.
+
+        The rebuild columns should not be set if the ``handling_strategy``
+        is ``reject_sampling``.
+
+        Side effects:
+        - instance.rebuild_columns are empty
+        """
+        # Setup
+        column = 'col'
+
+        # Run
+        instance = ColumnFormula(column=column, formula=new_column,
+                                 handling_strategy='reject_sampling')
+
+        # Assert
+        assert instance.rebuild_columns == ()
+
     def test_is_valid_valid(self):
         """Test the ``ColumnFormula.is_valid`` method for a valid data.
 
@@ -3288,6 +3391,42 @@ def transform(data, low, high):
 
 
 class TestBetween():
+
+    def test___init__sets_rebuild_columns_if_not_reject_sampling(self):
+        """Test the ``Between.__init__`` method.
+
+        The rebuild columns should only be set if the ``handling_strategy``
+        is not ``reject_sampling``.
+
+        Side effects:
+        - instance.rebuild_columns are set
+        """
+        # Setup
+        column = 'col'
+
+        # Run
+        instance = Between(column=column, low=10, high=20, handling_strategy='transform')
+
+        # Assert
+        assert instance.rebuild_columns == (column,)
+
+    def test___init__does_not_set_rebuild_columns_reject_sampling(self):
+        """Test the ``Between.__init__`` method.
+
+        The rebuild columns should not be set if the ``handling_strategy``
+        is ``reject_sampling``.
+
+        Side effects:
+        - instance.rebuild_columns are empty
+        """
+        # Setup
+        column = 'col'
+
+        # Run
+        instance = Between(column=column, low=10, high=20, handling_strategy='reject_sampling')
+
+        # Assert
+        assert instance.rebuild_columns == ()
 
     def test_fit_only_one_datetime_arg(self):
         """Test the ``Between.fit`` method by passing in only one arg as datetime.

--- a/tests/unit/metadata/test_table.py
+++ b/tests/unit/metadata/test_table.py
@@ -86,6 +86,62 @@ class TestTable:
         # Asserts
         instance._constraints == [constraint3, constraint1, constraint2]
 
+    @patch('sdv.metadata.table.Table._sort_constraints')
+    def test__init__validates_constraint_order_raises_exception(self, _):
+        """Test the ``__init__`` method validates the constraint order.
+
+        If one constraint has ``rebuild_columns`` that are in a later
+        constraint's ``constraint_columns``, an exception should be raised.
+
+        Setup:
+        - Instance should have ``instance._constraints`` set to
+        list of constraints with some having ``rebuild_columns``
+        that are in a later constraint's ``constraint_columns``.
+        Side Effect:
+        - Exception should be raised.
+        """
+        # Setup
+        constraint1 = CustomConstraint()
+        constraint2 = Constraint(handling_strategy='transform')
+        constraint3 = Constraint(handling_strategy='reject_sampling')
+        constraint4 = Constraint(handling_strategy='transform')
+        constraint2.rebuild_columns = ['a', 'd']
+        constraint4.constraint_columns = ['a', 'b', 'c']
+        constraints = [constraint1, constraint2, constraint3, constraint4]
+
+        # Run
+        with pytest.raises(Exception):
+            Table(constraints=constraints)
+
+    @patch('sdv.metadata.table.Table._sort_constraints')
+    def test__init__validates_constraint_order(self, _):
+        """Test the ``__init__`` method validates the constraint order.
+
+        If no constraint has ``rebuild_columns`` that are in a later
+        constraint's ``constraint_columns``, no exception should be raised.
+
+        Setup:
+        - Instance should have ``instance._constraints`` set to
+        list of constraints with none having ``rebuild_columns``
+        that are in a later constraint's ``constraint_columns``.
+        Side Effect:
+        - Constraints are set.
+        """
+        # Setup
+        constraint1 = CustomConstraint()
+        constraint2 = Constraint(handling_strategy='transform')
+        constraint3 = Constraint(handling_strategy='reject_sampling')
+        constraint4 = Constraint(handling_strategy='transform')
+        constraint2.rebuild_columns = ['e', 'd']
+        constraint4.constraint_columns = ['a', 'b', 'c']
+        constraints = [constraint1, constraint2, constraint3, constraint4]
+
+        # Run
+        instance = Table(constraints=constraints)
+
+        # Assert
+        instance._constraints == constraints
+
     def test__make_ids(self):
         """Test whether regex is correctly generating expressions."""
         metadata = {'subtype': 'string', 'regex': '[a-d]'}


### PR DESCRIPTION
Resolve #541

This PR:
- adds a `rebuild_columns` attribute to the `Constraint` classes. This list will contain any column names that the constraint needs to rebuild during `reverse_transform`
- Adds functionality to sort the constraints during the `metadata.Table.__init__`. It will put any constraints that have `reject_sampling` as the `handling_strategy` before the rest
- Adds a validation method to the `__init__` that checks to make sure the `rebuild_columns` in a constraint do not show up in the `constraint_columns` of a later constraint.