### PR TITLE
Update column formula is valid to handle nan equality

### DIFF
--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -630,7 +630,9 @@ class ColumnFormula(Constraint):
                 Whether each row is valid.
         """
         computed = self._formula(table_data)
-        return table_data[self._column] == computed
+        isnan = table_data[self._column].isna() & computed.isna()
+
+        return table_data[self._column].eq(computed) | isnan
 
     def _transform(self, table_data):
         """Transform the table data.

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -3205,6 +3205,9 @@ class TestNegative():
 
 def new_column(data):
     """Formula to be used for the ``TestColumnFormula`` class."""
+    if data['a'] is None or data['b'] is None:
+        return None
+
     return data['a'] + data['b']
 
 
@@ -3320,6 +3323,33 @@ class TestColumnFormula():
 
         # Assert
         expected_out = pd.Series([False, False, False])
+        pd.testing.assert_series_equal(expected_out, out)
+
+    def test_is_valid_with_nans(self):
+        """Test the ``ColumnFormula.is_valid`` method for with a formula that produces nans.
+
+        If the data fulfills the formula, result is a series of ``True`` values.
+
+        Input:
+        - Table data fulfilling the formula (pandas.DataFrame)
+        Output:
+        - Series of ``True`` values (pandas.Series)
+        """
+        # Setup
+        column = 'c'
+        instance = ColumnFormula(column=column, formula=new_column)
+
+        # Run
+        table_data = pd.DataFrame({
+            'a': [1, 2, 3],
+            'b': [4, 5, None],
+            'c': [5, 7, None]
+        })
+        instance = ColumnFormula(column=column, formula=new_column)
+        out = instance.is_valid(table_data)
+
+        # Assert
+        expected_out = pd.Series([True, True, True])
         pd.testing.assert_series_equal(expected_out, out)
 
     def test__transform(self):


### PR DESCRIPTION
Currently, if a column formula is expected to produce NaNs, the is_valid method will still flag it as false because nan == nan evaluates to false. We can account for this case by explicitly checking for rows where both the table data and the expected column are NaN.

Resolves #593 