### PR TITLE
Fixes #610 using unique constraint on subsets of data when fitting a model

### DIFF
--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -127,7 +127,8 @@ class BaseTabularModel:
                 the path to a CSV file which can be loaded using
                 ``pandas.read_csv``.
         """
-        data = data.reset_index(drop=True)
+        if isinstance(data, pd.DataFrame):
+            data = data.reset_index(drop=True)
 
         LOGGER.debug('Fitting %s to table %s; shape: %s', self.__class__.__name__,
                      self._metadata.name, data.shape)

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -127,6 +127,8 @@ class BaseTabularModel:
                 the path to a CSV file which can be loaded using
                 ``pandas.read_csv``.
         """
+        data = data.reset_index(drop=True)
+
         LOGGER.debug('Fitting %s to table %s; shape: %s', self.__class__.__name__,
                      self._metadata.name, data.shape)
         if not self._metadata_fitted:

--- a/tests/integration/tabular/test_base.py
+++ b/tests/integration/tabular/test_base.py
@@ -144,14 +144,14 @@ def test_fit_with_unique_constraint_on_data_subset():
         }
     }
 
-    test_df = test_df.iloc[[3]]
+    test_df = test_df.iloc[[1, 3, 4]]
     model = GaussianCopula(table_metadata=err_metadata)
 
     # Run
     model.fit(test_df)
 
     # Assert
-    assert model._num_rows == 1
+    assert len(model.sample(2)) == 2
 
 
 @patch('sdv.tabular.copulas.copulas.multivariate.GaussianMultivariate',

--- a/tests/integration/tabular/test_base.py
+++ b/tests/integration/tabular/test_base.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 from copulas.multivariate.gaussian import GaussianMultivariate
 
-from sdv.constraints import UniqueCombinations
+from sdv.constraints import Unique, UniqueCombinations
 from sdv.constraints.tabular import GreaterThan
 from sdv.tabular.copulagan import CopulaGAN
 from sdv.tabular.copulas import GaussianCopula
@@ -92,6 +92,46 @@ def test_conditional_sampling_graceful_reject_sampling_False_dataframe(model):
 
     with pytest.raises(ValueError):
         model.sample(conditions=conditions)
+
+
+def test_regression_unique_on_subset():
+    test_df = pd.DataFrame({
+        "key": [
+            1,
+            2,
+            3,
+            4,
+            5,
+        ],
+        "error_column": [
+            "A",
+            "B",
+            "C",
+            "D",
+            "E",
+        ]
+    })
+    unique = Unique(
+        columns=["error_column"]
+    )
+    err_metadata = {
+        "name": "error",
+        "constraints": [unique],
+        "primary_key": "key",
+        "fields": {
+            "key": {
+                "type": "id", "subtype": "string"
+            },
+            "error_column": {
+                "type": "categorical",
+            }
+        }
+    }
+
+    test_df = test_df.iloc[[3]]
+    model = GaussianCopula(table_metadata=err_metadata)
+    model.fit(test_df)
+    model.sample()
 
 
 @patch('sdv.tabular.copulas.copulas.multivariate.GaussianMultivariate',

--- a/tests/integration/tabular/test_base.py
+++ b/tests/integration/tabular/test_base.py
@@ -120,7 +120,7 @@ def test_regression_unique_on_subset():
         "primary_key": "key",
         "fields": {
             "key": {
-                "type": "id", "subtype": "string"
+                "type": "id", "subtype": "integer"
             },
             "error_column": {
                 "type": "categorical",

--- a/tests/integration/tabular/test_base.py
+++ b/tests/integration/tabular/test_base.py
@@ -108,6 +108,9 @@ def test_fit_with_unique_constraint_on_data_subset():
 
     Input:
     - Subset of data, Metadata with unique constraint
+
+    Github Issue:
+    - Tests that https://github.com/sdv-dev/SDV/issues/610 does not occur
     """
     # Setup
     test_df = pd.DataFrame({
@@ -148,9 +151,11 @@ def test_fit_with_unique_constraint_on_data_subset():
 
     # Run
     model.fit(test_df)
+    samples = model.sample(2)
 
     # Assert
-    assert len(model.sample(2)) == 2
+    assert len(samples) == 2
+    assert samples["error_column"].is_unique
 
 
 @patch('sdv.tabular.copulas.copulas.multivariate.GaussianMultivariate',

--- a/tests/integration/tabular/test_base.py
+++ b/tests/integration/tabular/test_base.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pandas as pd
+
 import pytest
 from copulas.multivariate.gaussian import GaussianMultivariate
 
@@ -95,8 +96,7 @@ def test_conditional_sampling_graceful_reject_sampling_False_dataframe(model):
 
 
 def test_fit_with_unique_constraint_on_data_subset():
-    """
-    Test that the ``fit`` method runs without error when metadata specifies unique constraint,
+    """Test that the ``fit`` method runs without error when metadata specifies unique constraint,
     ``fit`` is called on a subset of the original data.
 
     The ``fit`` method is expected to fit the model to the subset of data,
@@ -110,6 +110,7 @@ def test_fit_with_unique_constraint_on_data_subset():
     Input:
     - Subset of data, Metadata with unique constraint
     """
+    # Setup
     test_df = pd.DataFrame({
         "key": [
             1,
@@ -145,8 +146,12 @@ def test_fit_with_unique_constraint_on_data_subset():
 
     test_df = test_df.iloc[[3]]
     model = GaussianCopula(table_metadata=err_metadata)
+
+    # Run
     model.fit(test_df)
-    model.sample()
+
+    # Assert
+    assert model._num_rows == 1
 
 
 @patch('sdv.tabular.copulas.copulas.multivariate.GaussianMultivariate',

--- a/tests/integration/tabular/test_base.py
+++ b/tests/integration/tabular/test_base.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 import pandas as pd
-
 import pytest
 from copulas.multivariate.gaussian import GaussianMultivariate
 

--- a/tests/integration/tabular/test_base.py
+++ b/tests/integration/tabular/test_base.py
@@ -94,7 +94,22 @@ def test_conditional_sampling_graceful_reject_sampling_False_dataframe(model):
         model.sample(conditions=conditions)
 
 
-def test_regression_unique_on_subset():
+def test_fit_with_unique_constraint_on_data_subset():
+    """
+    Test that the ``fit`` method runs without error when metadata specifies unique constraint,
+    ``fit`` is called on a subset of the original data.
+
+    The ``fit`` method is expected to fit the model to the subset of data,
+    taking into account the metadata and the ``Unique`` constraint.
+
+    Setup:
+    - The model is passed a metadata ``dict`` that contains a ``Unique`` constraint and is
+    matched to a subset of the specified data.
+    Subdividing the data results in missing indexes in the subset contained in the original data.
+
+    Input:
+    - Subset of data, Metadata with unique constraint
+    """
     test_df = pd.DataFrame({
         "key": [
             1,


### PR DESCRIPTION
Fixes issue #610 and allows fitting a model to a subset of data when also specifying the use of a `Unique` constraint.

The indexes are reset before each fitting process by using `.reset_index(drop=True)` for all data passed to the ``fit`` method.