### PR TITLE
Fix #614 conditional sampling crashes when num_rows is not specifed

### DIFF
--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -338,14 +338,15 @@ class BaseTabularModel:
             pandas.DataFrame:
                 `conditions` as a dataframe.
         """
+        n_rows = (num_rows if num_rows else self._num_rows)
         if isinstance(conditions, pd.Series):
-            conditions = pd.DataFrame([conditions] * num_rows)
+            conditions = pd.DataFrame([conditions] * n_rows)
 
         elif isinstance(conditions, dict):
             try:
                 conditions = pd.DataFrame(conditions)
             except ValueError:
-                conditions = pd.DataFrame([conditions] * num_rows)
+                conditions = pd.DataFrame([conditions] * n_rows)
 
         elif not isinstance(conditions, pd.DataFrame):
             raise TypeError('`conditions` must be a dataframe, a dictionary or a pandas series.')

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -338,15 +338,12 @@ class BaseTabularModel:
             pandas.DataFrame:
                 `conditions` as a dataframe.
         """
-        n_rows = (num_rows if num_rows else self._num_rows)
+        n_rows = num_rows if num_rows else self._num_rows
         if isinstance(conditions, pd.Series):
             conditions = pd.DataFrame([conditions] * n_rows)
 
         elif isinstance(conditions, dict):
-            try:
-                conditions = pd.DataFrame(conditions)
-            except ValueError:
-                conditions = pd.DataFrame([conditions] * n_rows)
+            conditions = pd.DataFrame(conditions, index=range(n_rows))
 
         elif not isinstance(conditions, pd.DataFrame):
             raise TypeError('`conditions` must be a dataframe, a dictionary or a pandas series.')

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -1,6 +1,8 @@
+import random
 from unittest.mock import Mock, call, patch
 
 import pandas as pd
+from pandas.core.frame import DataFrame
 import pytest
 
 from sdv.metadata.table import Table
@@ -343,3 +345,38 @@ def test_sample_batches_transform_conditions_correctly():
     model._sample_batch.assert_any_call(
         1, 100, 10, {'column1': 30}, {'transformed_column': 70}, 0.01
     )
+
+
+def test__make_conditions_df_without_num_rows():
+    """Test ``_make_conditions_df`` works correctly when ``num_rows`` is not passed.
+
+    The ``_make_conditions_df`` method is expected to:
+    - Return conditions as a ``DataFrame`` for every row in the data.
+
+    Input:
+    - Conditions
+
+    Output:
+    - Conditions as ``DataFrame``
+    """
+    # Setup
+    N_ROWS = 1000
+    model = GaussianCopula()
+    data = pd.DataFrame({
+        'column1': list(range(N_ROWS)),
+        'column2': [random.choice(['M', 'F']) for _ in range(N_ROWS)],
+    })
+    conditions = {
+        'column2': 'M'
+    }
+    expected_conditions = pd.DataFrame([conditions] * len(data))
+
+    model.fit(data)
+
+    # Run
+    result_conditions = model._make_conditions_df(conditions=conditions, num_rows=None)
+
+    # Assert
+    assert isinstance(result_conditions, pd.DataFrame)
+    assert len(result_conditions) == len(data)
+    assert all(result_conditions == expected_conditions)

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -346,7 +346,36 @@ def test_sample_batches_transform_conditions_correctly():
     )
 
 
-def test__make_conditions_df_without_num_rows():
+@pytest.mark.parametrize('model', MODELS)
+def test_fit_sets_num_rows(model):
+    """Test ``fit`` sets ``_num_rows`` to the length of the data passed.
+
+    The ``fit`` method is expected to:
+    - Save the length of the data passed to the ``fit`` method in the ``_num_rows`` attribute.
+
+    Input:
+    - DataFrame
+
+    Side Effects:
+    - ``_num_rows`` is set to the length of the data passed to ``fit``.
+    """
+    # Setup
+    _N_DATA_ROWS = 100
+    data = pd.DataFrame({
+        'column1': list(range(_N_DATA_ROWS)),
+        'column2': list(range(_N_DATA_ROWS)),
+        'column3': list(range(_N_DATA_ROWS))
+    })
+
+    # Run
+    model.fit(data)
+
+    # Assert
+    assert model._num_rows == _N_DATA_ROWS
+
+
+@pytest.mark.parametrize('model', MODELS)
+def test__make_conditions_df_without_num_rows(model):
     """Test ``_make_conditions_df`` works correctly when ``num_rows`` is not passed.
 
     The ``_make_conditions_df`` method is expected to:
@@ -359,9 +388,7 @@ def test__make_conditions_df_without_num_rows():
     - Conditions as ``DataFrame``
     """
     # Setup
-    _N_DATA_ROWS = 1000
-
-    model = GaussianCopula()
+    _N_DATA_ROWS = 100
     conditions = {'column2': 'M'}
     expected_conditions = pd.DataFrame([conditions] * _N_DATA_ROWS)
 
@@ -376,7 +403,8 @@ def test__make_conditions_df_without_num_rows():
     assert all(result_conditions == expected_conditions)
 
 
-def test__make_conditions_df_specifying_num_rows():
+@pytest.mark.parametrize('model', MODELS)
+def test__make_conditions_df_specifying_num_rows(model):
     """Test ``_make_conditions_df`` works correctly when ``num_rows`` is passed.
 
     The ``_make_conditions_df`` method is expected to:
@@ -390,10 +418,9 @@ def test__make_conditions_df_specifying_num_rows():
     - Conditions as ``DataFrame``
     """
     # Setup
-    _N_DATA_ROWS = 1000
-    _NUM_ROWS = 100
+    _N_DATA_ROWS = 100
+    _NUM_ROWS = 10
 
-    model = GaussianCopula()
     conditions = {'column2': 'M'}
     expected_conditions = pd.DataFrame([conditions] * _NUM_ROWS)
 

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -1,4 +1,3 @@
-import random
 from unittest.mock import Mock, call, patch
 
 import pandas as pd

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -359,23 +359,50 @@ def test__make_conditions_df_without_num_rows():
     - Conditions as ``DataFrame``
     """
     # Setup
-    N_ROWS = 1000
-    model = GaussianCopula()
-    data = pd.DataFrame({
-        'column1': list(range(N_ROWS)),
-        'column2': [random.choice(['M', 'F']) for _ in range(N_ROWS)],
-    })
-    conditions = {
-        'column2': 'M'
-    }
-    expected_conditions = pd.DataFrame([conditions] * len(data))
+    _N_DATA_ROWS = 1000
 
-    model.fit(data)
+    model = GaussianCopula()
+    conditions = {'column2': 'M'}
+    expected_conditions = pd.DataFrame([conditions] * _N_DATA_ROWS)
+
+    model._num_rows = _N_DATA_ROWS
 
     # Run
     result_conditions = model._make_conditions_df(conditions=conditions, num_rows=None)
 
     # Assert
     assert isinstance(result_conditions, pd.DataFrame)
-    assert len(result_conditions) == len(data)
+    assert len(result_conditions) == _N_DATA_ROWS
+    assert all(result_conditions == expected_conditions)
+
+
+def test__make_conditions_df_specifying_num_rows():
+    """Test ``_make_conditions_df`` works correctly when ``num_rows`` is passed.
+
+    The ``_make_conditions_df`` method is expected to:
+    - Return as many condition rows as specified with ``num_rows`` as a ``DataFrame``.
+
+    Input:
+    - Conditions
+    - Num_rows
+
+    Output:
+    - Conditions as ``DataFrame``
+    """
+    # Setup
+    _N_DATA_ROWS = 1000
+    _NUM_ROWS = 100
+
+    model = GaussianCopula()
+    conditions = {'column2': 'M'}
+    expected_conditions = pd.DataFrame([conditions] * _NUM_ROWS)
+
+    model._num_rows = _N_DATA_ROWS
+
+    # Run
+    result_conditions = model._make_conditions_df(conditions=conditions, num_rows=_NUM_ROWS)
+
+    # Assert
+    assert isinstance(result_conditions, pd.DataFrame)
+    assert len(result_conditions) == _NUM_ROWS
     assert all(result_conditions == expected_conditions)

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -2,7 +2,6 @@ import random
 from unittest.mock import Mock, call, patch
 
 import pandas as pd
-from pandas.core.frame import DataFrame
 import pytest
 
 from sdv.metadata.table import Table

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -350,13 +350,13 @@ def test_fit_sets_num_rows(model):
     """Test ``fit`` sets ``_num_rows`` to the length of the data passed.
 
     The ``fit`` method is expected to:
-    - Save the length of the data passed to the ``fit`` method in the ``_num_rows`` attribute.
+        - Save the length of the data passed to the ``fit`` method in the ``_num_rows`` attribute.
 
     Input:
-    - DataFrame
+        - DataFrame
 
     Side Effects:
-    - ``_num_rows`` is set to the length of the data passed to ``fit``.
+        - ``_num_rows`` is set to the length of the data passed to ``fit``.
     """
     # Setup
     _N_DATA_ROWS = 100
@@ -378,13 +378,13 @@ def test__make_conditions_df_without_num_rows(model):
     """Test ``_make_conditions_df`` works correctly when ``num_rows`` is not passed.
 
     The ``_make_conditions_df`` method is expected to:
-    - Return conditions as a ``DataFrame`` for every row in the data.
+        - Return conditions as a ``DataFrame`` for every row in the data.
 
     Input:
-    - Conditions
+        - Conditions
 
     Output:
-    - Conditions as ``DataFrame``
+        - Conditions as ``DataFrame``
     """
     # Setup
     _N_DATA_ROWS = 100
@@ -410,11 +410,11 @@ def test__make_conditions_df_specifying_num_rows(model):
     - Return as many condition rows as specified with ``num_rows`` as a ``DataFrame``.
 
     Input:
-    - Conditions
-    - Num_rows
+        - Conditions
+        - Num_rows
 
     Output:
-    - Conditions as ``DataFrame``
+        - Conditions as ``DataFrame``
     """
     # Setup
     _N_DATA_ROWS = 100


### PR DESCRIPTION
This PR includes:

- test for the previous behavior to verify the problem specified in the issue #614 
- creates a temporary `n_rows` variable to be used when creating the conditions `DataFrame` which is set to the number of rows when fitting the model if `num_rows` is `None`
- refactors a control flow through exception and specifies an index when creating a condition `DataFrame`