### PR TITLE
Fix #634 Metadata visualization erroring due to wrong graphviz usage

### DIFF
--- a/sdv/metadata/visualization.py
+++ b/sdv/metadata/visualization.py
@@ -13,7 +13,7 @@ def _get_graphviz_extension(path):
 
         graphviz_extension = path_splitted[-1]
 
-        if graphviz_extension not in graphviz.backend.FORMATS:
+        if graphviz_extension not in graphviz.FORMATS:
             raise ValueError(
                 '"{}" not a valid graphviz extension format.'.format(graphviz_extension)
             )


### PR DESCRIPTION
remove calling `.backend` from `graphviz``
Issue https://github.com/xflr6/graphviz/issues/149 states:
- this is not the public API
- the underlying submodules should be called directly

Resolves #634 