### PR TITLE
Fix between constraint is valid for nan columns

### DIFF
--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -824,14 +824,18 @@ class Between(Constraint):
             pandas.Series:
                 Whether each row is valid.
         """
-        satisfy_low_bound = self._lt(
-            self._get_low_value(table_data), table_data[self.constraint_column]
-        )
-        satisfy_high_bound = self._lt(
-            table_data[self.constraint_column], self._get_high_value(table_data)
+        low = self._get_low_value(table_data)
+        high = self._get_high_value(table_data)
+
+        satisfy_low_bound = self._lt(low, table_data[self.constraint_column])
+        satisfy_high_bound = self._lt(table_data[self.constraint_column], high)
+
+        isnull = np.logical_or(
+            np.isnan(table_data[self.constraint_column]),
+            np.logical_or(np.isnan(low), np.isnan(high))
         )
 
-        return satisfy_low_bound & satisfy_high_bound
+        return np.logical_or((satisfy_low_bound & satisfy_high_bound), isnull)
 
     def _transform(self, table_data):
         """Transform the table data.

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -844,7 +844,7 @@ class Between(Constraint):
         )
 
         return np.logical_or(
-            (satisfy_low_bound & satisfy_high_bound),
+            np.logical_and(satisfy_low_bound, satisfy_high_bound),
             np.isnan(table_data[self.constraint_column]),
         )
 

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -728,12 +728,19 @@ class Between(Constraint):
         self.constraint_column = column
         self.constraint_columns = (column,)
         self.rebuild_columns = (column,)
-        self._low = low
-        self._high = high
         self._strict = strict
         self._high_is_scalar = high_is_scalar
         self._low_is_scalar = low_is_scalar
         self._lt = operator.lt if strict else operator.le
+
+        self._low = low
+        if self._low_is_scalar and isinstance(low, pd.Timestamp):
+            self._low = low.to_datetime64()
+
+        self._high = high
+        if self._high_is_scalar and isinstance(high, pd.Timestamp):
+            self._high = high.to_datetime64()
+
         super().__init__(handling_strategy=handling_strategy,
                          fit_columns_model=fit_columns_model)
 
@@ -827,15 +834,19 @@ class Between(Constraint):
         low = self._get_low_value(table_data)
         high = self._get_high_value(table_data)
 
-        satisfy_low_bound = self._lt(low, table_data[self.constraint_column])
-        satisfy_high_bound = self._lt(table_data[self.constraint_column], high)
-
-        isnull = np.logical_or(
-            np.isnan(table_data[self.constraint_column]),
-            np.logical_or(np.isnan(low), np.isnan(high))
+        satisfy_low_bound = np.logical_or(
+            self._lt(low, table_data[self.constraint_column]),
+            np.isnan(low),
+        )
+        satisfy_high_bound = np.logical_or(
+            self._lt(table_data[self.constraint_column], high),
+            np.isnan(high),
         )
 
-        return np.logical_or((satisfy_low_bound & satisfy_high_bound), isnull)
+        return np.logical_or(
+            (satisfy_low_bound & satisfy_high_bound),
+            np.isnan(table_data[self.constraint_column]),
+        )
 
     def _transform(self, table_data):
         """Transform the table data.

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -4061,7 +4061,8 @@ class TestBetween():
         # Assert
         expected_out = pd.DataFrame({
             'b': [4, 5, 6],
-            'a#1900-01-01 00:00:00#2021-01-01 00:00:00': transform(table_data[column], low, high)
+            'a#1900-01-01T00:00:00.000000000#2021-01-01T00:00:00.000000000': transform(
+                table_data[column], low, high)
         })
         pd.testing.assert_frame_equal(expected_out, out)
 
@@ -4105,7 +4106,8 @@ class TestBetween():
                 pd.to_datetime('2020-11-01'),
                 pd.to_datetime('2020-11-03'),
             ],
-            'a#1900-01-01 00:00:00#b': transform(table_data[column], low, table_data[high])
+            'a#1900-01-01T00:00:00.000000000#b': transform(
+                table_data[column], low, table_data[high])
         })
         pd.testing.assert_frame_equal(expected_out, out)
 
@@ -4149,7 +4151,8 @@ class TestBetween():
                 pd.to_datetime('2020-02-01'),
                 pd.to_datetime('2020-02-03'),
             ],
-            'a#b#2021-01-01 00:00:00': transform(table_data[column], table_data[low], high)
+            'a#b#2021-01-01T00:00:00.000000000': transform(
+                table_data[column], table_data[low], high)
         })
         pd.testing.assert_frame_equal(expected_out, out)
 
@@ -4388,7 +4391,8 @@ class TestBetween():
         instance.fit(table_data)
         transformed = pd.DataFrame({
             'b': [4, 5, 6],
-            'a#1900-01-01 00:00:00#2021-01-01 00:00:00': transform(table_data[column], low, high)
+            'a#1900-01-01T00:00:00.000000000#2021-01-01T00:00:00.000000000': transform(
+                table_data[column], low, high)
         })
         out = instance.reverse_transform(transformed)
 
@@ -4437,7 +4441,8 @@ class TestBetween():
                 pd.to_datetime('2020-11-01'),
                 pd.to_datetime('2020-11-03'),
             ],
-            'a#1900-01-01 00:00:00#b': transform(table_data[column], low, table_data[high])
+            'a#1900-01-01T00:00:00.000000000#b': transform(
+                table_data[column], low, table_data[high])
         })
         out = instance.reverse_transform(transformed)
 
@@ -4485,7 +4490,8 @@ class TestBetween():
                 pd.to_datetime('2020-02-01'),
                 pd.to_datetime('2020-02-03'),
             ],
-            'a#b#2021-01-01 00:00:00': transform(table_data[column], table_data[low], high)
+            'a#b#2021-01-01T00:00:00.000000000': transform(
+                table_data[column], table_data[low], high)
         })
         out = instance.reverse_transform(transformed)
 

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -4702,7 +4702,160 @@ class TestBetween():
 
         # Assert
         expected_out = pd.Series([True, True, False])
+        pd.testing.assert_series_equal(expected_out, out)
 
+    def test_is_valid_low_high_nans(self):
+        """Test the ``Between.is_valid`` method with nan values in low and high columns.
+
+        If there is a NaN row, expect that `is_valid` returns True.
+
+        Input:
+        - Table with a NaN row
+        Output:
+        - True should be returned for the NaN row.
+        """
+        # Setup
+        instance = Between(column='a', low='b', high='c')
+
+        # Run
+        table_data = pd.DataFrame({
+            'a': [0.1, 0.5, 0.9],
+            'b': [0, None, 0.5],
+            'c': [0.5, None, 0.6]
+        })
+        instance.fit(table_data)
+        out = instance.is_valid(table_data)
+
+        # Assert
+        expected_out = pd.Series([True, True, False])
+        pd.testing.assert_series_equal(expected_out, out)
+
+    def test_is_valid_low_nans(self):
+        """Test the ``Between.is_valid`` method with nan values in low column.
+
+        If there is a NaN row, expect that `is_valid` returns True.
+
+        Input:
+        - Table with a NaN row
+        Output:
+        - True should be returned for the NaN row.
+        """
+        # Setup
+        instance = Between(column='a', low='b', high='c')
+
+        # Run
+        table_data = pd.DataFrame({
+            'a': [0.1, 0.5, 0.9],
+            'b': [0, None, 0.5],
+            'c': [0.5, 1.5, 0.6]
+        })
+        instance.fit(table_data)
+        out = instance.is_valid(table_data)
+
+        # Assert
+        expected_out = pd.Series([True, True, False])
+        pd.testing.assert_series_equal(expected_out, out)
+
+    def test_is_valid_column_nans(self):
+        """Test the ``Between.is_valid`` method with nan values in constraint column.
+
+        If there is a NaN row, expect that `is_valid` returns True.
+
+        Input:
+        - Table with a NaN row
+        Output:
+        - True should be returned for the NaN row.
+        """
+        # Setup
+        instance = Between(column='a', low='b', high='c')
+
+        # Run
+        table_data = pd.DataFrame({
+            'a': [0.1, 0.5, None],
+            'b': [0, 0.1, 0.5],
+            'c': [0.5, 1.5, 0.6]
+        })
+        instance.fit(table_data)
+        out = instance.is_valid(table_data)
+
+        # Assert
+        expected_out = pd.Series([True, True, True])
+        pd.testing.assert_series_equal(expected_out, out)
+
+    def test_is_valid_low_high_nans_datetime(self):
+        """Test the ``Between.is_valid`` method with nan values in low and high datetime columns.
+
+        If there is a row containing NaNs, expect that `is_valid` returns True.
+
+        Input:
+        - Table with row NaN containing NaNs.
+        Output:
+        - True should be returned for the NaN row.
+        """
+        # Setup
+        instance = Between(column='a', low='b', high='c')
+
+        # Run
+        table_data = pd.DataFrame({
+            'a': [
+                pd.to_datetime('2020-09-13'),
+                pd.to_datetime('2020-08-12'),
+                pd.to_datetime('2020-08-13'),
+            ],
+            'b': [
+                pd.to_datetime('2020-09-03'),
+                pd.to_datetime('2020-08-02'),
+                None,
+            ],
+            'c': [
+                pd.to_datetime('2020-10-03'),
+                pd.to_datetime('2020-11-01'),
+                None,
+            ]
+        })
+        instance.fit(table_data)
+        out = instance.is_valid(table_data)
+
+        # Assert
+        expected_out = pd.Series([True, True, True])
+        pd.testing.assert_series_equal(expected_out, out)
+
+    def test_is_valid_column_nans_datetime(self):
+        """Test the ``Between.is_valid`` method with nan values in the constraint column.
+
+        If there is a row containing NaNs, expect that `is_valid` returns True.
+
+        Input:
+        - Table with row NaN containing NaNs.
+        Output:
+        - True should be returned for the NaN row.
+        """
+        # Setup
+        instance = Between(column='a', low='b', high='c')
+
+        # Run
+        table_data = pd.DataFrame({
+            'a': [
+                None,
+                pd.to_datetime('2020-08-12'),
+                pd.to_datetime('2020-08-13'),
+            ],
+            'b': [
+                pd.to_datetime('2020-09-03'),
+                pd.to_datetime('2020-08-02'),
+                pd.to_datetime('2020-08-03'),
+            ],
+            'c': [
+                pd.to_datetime('2020-10-03'),
+                pd.to_datetime('2020-11-01'),
+                pd.to_datetime('2020-11-01'),
+            ]
+        })
+        instance.fit(table_data)
+        out = instance.is_valid(table_data)
+
+        # Assert
+        expected_out = pd.Series([True, True, True])
         pd.testing.assert_series_equal(expected_out, out)
 
 


### PR DESCRIPTION
Resolves #632 

Handle NaNs in Between constraint's `is_valid` method.
- If the constraint column is `NaN`, return True
- If both `low` and `high` are `NaN`, return True
- If constraint column is not `NaN` and only one of `low` or `high` is `NaN`, ignore the `NaN` value when making comparisons.
