### PR TITLE
Fix conditional sampling with custom constraint

### DIFF
--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -29,6 +29,7 @@ import numpy as np
 import pandas as pd
 
 from sdv.constraints.base import Constraint, import_object
+from sdv.constraints.errors import MissingConstraintColumnError
 from sdv.constraints.utils import is_datetime_type
 
 
@@ -51,6 +52,10 @@ class CustomConstraint(Constraint):
     def _run(self, function, table_data, reverse=False):
         table_data = table_data.copy()
         if self._columns:
+            missing_columns = [col for col in self._columns if col not in table_data.columns]
+            if missing_columns:
+                raise MissingConstraintColumnError()
+
             if reverse:
                 columns = reversed(self._columns)
             else:

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -52,10 +52,6 @@ class CustomConstraint(Constraint):
     def _run(self, function, table_data, reverse=False):
         table_data = table_data.copy()
         if self._columns:
-            missing_columns = [col for col in self._columns if col not in table_data.columns]
-            if missing_columns:
-                raise MissingConstraintColumnError()
-
             if reverse:
                 columns = reversed(self._columns)
             else:
@@ -73,6 +69,11 @@ class CustomConstraint(Constraint):
         return table_data
 
     def _run_transform(self, table_data):
+        if self._columns:
+            missing_columns = [col for col in self._columns if col not in table_data.columns]
+            if missing_columns:
+                raise MissingConstraintColumnError()
+
         return self._run(self._transform, table_data)
 
     def _run_reverse_transform(self, table_data):

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -70,8 +70,7 @@ class CustomConstraint(Constraint):
 
     def _run_transform(self, table_data):
         if self._columns:
-            missing_columns = [col for col in self._columns if col not in table_data.columns]
-            if missing_columns:
+            if any(column not in table_data.columns for column in self._columns):
                 raise MissingConstraintColumnError()
 
         return self._run(self._transform, table_data)

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -195,6 +195,27 @@ class TestCustomConstraint():
         pd.testing.assert_frame_equal(called[0][0], table_data)
         pd.testing.assert_frame_equal(transformed, dummy_transform_mock.return_value)
 
+    def test__run_transform_missing_column(self):
+        """Test the ``CustomConstraint._run`` method.
+
+        The ``_run`` method excutes ``transform`` and ``reverse_transform``
+        based on the signature of the functions. In this test, we evaluate
+        the execution of "table" that is missing the constraint column.
+
+        Setup:
+        - Pass dummy transform function with ``table_data`` and ``column`` arguments.
+        Side Effects:
+        - MissingConstraintColumnError is thrown.
+        """
+        # Setup
+        table_data = pd.DataFrame({'b': [1, 2, 3]})
+        dummy_transform_mock = Mock(side_effect=dummy_transform_table_column,
+                                    return_value=table_data)
+        # Run and assert
+        instance = CustomConstraint(columns='a', transform=dummy_transform_mock)
+        with pytest.raises(MissingConstraintColumnError):
+            transformed = instance.transform(table_data)
+
     def test__run_reverse_transform_table_column(self):
         """Test the ``CustomConstraint._run`` method.
 

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -214,7 +214,7 @@ class TestCustomConstraint():
         # Run and assert
         instance = CustomConstraint(columns='a', transform=dummy_transform_mock)
         with pytest.raises(MissingConstraintColumnError):
-            transformed = instance.transform(table_data)
+            instance.transform(table_data)
 
     def test__run_reverse_transform_table_column(self):
         """Test the ``CustomConstraint._run`` method.


### PR DESCRIPTION
If we use conditional sampling and a custom constraint together, we currently get a KeyError from the constraint's transform method. This is expected when we transform the conditions, as it is not the complete table data.

Update the custom constraint to return a `MissingConstraintColumnError` in this case, so that the error can be handled properly.  

Resolves #696 