### PR TITLE
Update Gaussian copula conditional sampling API

### DIFF
--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -680,7 +680,7 @@ class BaseTabularModel:
                     * any of the conditions' columns are not valid.
                     * no rows could be generated.
         """
-        self._sample_conditions(
+        return self._sample_conditions(
             conditions, max_tries, batch_size_per_try, randomize_samples, output_file_path)
 
     def _sample_conditions(self, conditions, max_tries, batch_size_per_try, randomize_samples,
@@ -763,7 +763,7 @@ class BaseTabularModel:
                     * any of the conditions' columns are not valid.
                     * no rows could be generated.
         """
-        self._sample_remaining_columns(
+        return self._sample_remaining_columns(
             known_columns, max_tries, batch_size_per_try, randomize_samples, output_file_path)
 
     def _sample_remaining_columns(self, known_columns, max_tries, batch_size_per_try,

--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -331,7 +331,8 @@ class GaussianCopula(BaseTabularModel):
                     * any of the conditions' columns are not valid.
                     * no rows could be generated.
         """
-        self._sample_conditions(conditions, 100, batch_size, randomize_samples, output_file_path)
+        return self._sample_conditions(
+            conditions, 100, batch_size, randomize_samples, output_file_path)
 
     def sample_remaining_columns(self, known_columns, batch_size=None, randomize_samples=True,
                                  output_file_path=None):
@@ -363,7 +364,7 @@ class GaussianCopula(BaseTabularModel):
                     * any of the conditions' columns are not valid.
                     * no rows could be generated.
         """
-        self._sample_remaining_columns(
+        return self._sample_remaining_columns(
             known_columns, 100, batch_size, randomize_samples, output_file_path)
 
     def _sample(self, num_rows, conditions=None):

--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -301,6 +301,71 @@ class GaussianCopula(BaseTabularModel):
         self._model.fit(table_data)
         self._update_metadata()
 
+    def sample_conditions(self, conditions, batch_size=None, randomize_samples=True,
+                          output_file_path=None):
+        """Sample rows from this table with the given conditions.
+
+        Args:
+            conditions (list[sdv.sampling.Condition]):
+                A list of sdv.sampling.Condition objects, which specify the column
+                values in a condition, along with the number of rows for that
+                condition.
+            batch_size (int or None):
+                The batch size to sample. Defaults to `num_rows`, if None.
+            randomize_samples (bool):
+                Whether or not to use a fixed seed when sampling. Defaults
+                to True.
+            output_file_path (str or None):
+                The file to periodically write sampled rows to. Defaults to
+                a temporary file, if None.
+
+        Returns:
+            pandas.DataFrame:
+                Sampled data.
+
+        Raises:
+            ConstraintsNotMetError:
+                If the conditions are not valid for the given constraints.
+            ValueError:
+                If any of the following happens:
+                    * any of the conditions' columns are not valid.
+                    * no rows could be generated.
+        """
+        self._sample_conditions(conditions, 100, batch_size, randomize_samples, output_file_path)
+
+    def sample_remaining_columns(self, known_columns, batch_size=None, randomize_samples=True,
+                                 output_file_path=None):
+        """Sample rows from this table.
+
+        Args:
+            known_columns (pandas.DataFrame):
+                A pandas.DataFrame with the columns that are already known. The output
+                is a DataFrame such that each row in the output is sampled
+                conditionally on the corresponding row in the input.
+            batch_size (int or None):
+                The batch size to sample. Defaults to `num_rows`, if None.
+            randomize_samples (bool):
+                Whether or not to use a fixed seed when sampling. Defaults
+                to True.
+            output_file_path (str or None):
+                The file to periodically write sampled rows to. Defaults to
+                a temporary file, if None.
+
+        Returns:
+            pandas.DataFrame:
+                Sampled data.
+
+        Raises:
+            ConstraintsNotMetError:
+                If the conditions are not valid for the given constraints.
+            ValueError:
+                If any of the following happens:
+                    * any of the conditions' columns are not valid.
+                    * no rows could be generated.
+        """
+        self._sample_remaining_columns(
+            known_columns, 100, batch_size, randomize_samples, output_file_path)
+
     def _sample(self, num_rows, conditions=None):
         """Sample the indicated number of rows from the model.
 

--- a/sdv/tabular/utils.py
+++ b/sdv/tabular/utils.py
@@ -173,7 +173,7 @@ def handle_sampling_error(is_tmp_file, output_file_path, sampling_error):
         print('Error: Sampling terminated. Partial results are stored in a temporary file: '
               f'{output_file_path}. This file will be overridden the next time you sample. '
               'Please rename the file if you wish to save these results.')
-    else:
+    elif output_file_path is not None:
         print('Error: Sampling terminated. '
               f'Partial results are stored in {output_file_path}.')
 

--- a/tests/unit/tabular/test_copulas.py
+++ b/tests/unit/tabular/test_copulas.py
@@ -8,6 +8,7 @@ from copulas.multivariate.gaussian import GaussianMultivariate
 from copulas.univariate import GaussianKDE, GaussianUnivariate
 
 from sdv.constraints import CustomConstraint
+from sdv.sampling.tabular import Condition
 from sdv.tabular.base import NonParametricError
 from sdv.tabular.copulas import GaussianCopula
 
@@ -644,3 +645,68 @@ class TestGaussianCopula:
         out = GaussianCopula._validate_distribution('copulas.univariate.GaussianUnivariate')
 
         assert out == 'copulas.univariate.GaussianUnivariate'
+
+    def test_sample_conditions(self):
+        """Test ``sample_conditions`` method.
+
+        Expect the correct args to be passed to ``_sample_conditions``.
+
+        Input:
+            - valid conditions
+        Side Effects:
+            - The expected ``_sample_conditions`` call.
+        """
+        # Setup
+        model = Mock(spec_set=GaussianCopula)
+        condition = Condition(
+            {'column1': 'b'},
+            num_rows=5,
+        )
+        batch_size = 1
+        randomize_samples = False
+        output_file_path = 'test.csv'
+
+        # Run
+        out = GaussianCopula.sample_conditions(
+            model,
+            [condition],
+            batch_size=batch_size,
+            randomize_samples=False,
+            output_file_path=output_file_path,
+        )
+
+        # Assert
+        model._sample_conditions.assert_called_once_with(
+            [condition], 100, batch_size, randomize_samples, output_file_path)
+        assert out == model._sample_conditions.return_value
+
+    def test_sample_remaining_columns(self):
+        """Test ``sample_remaining_columns`` method.
+
+        Expect the correct args to be passed to ``_sample_remaining_columns``
+
+        Input:
+            - valid DataFrame
+        Side Effects:
+            - The expected ``_sample_remaining_columns`` call.
+        """
+        # Setup
+        model = Mock(spec_set=GaussianCopula)
+        conditions = pd.DataFrame([{'cola': 'a'}] * 5)
+        batch_size = 1
+        randomize_samples = False
+        output_file_path = 'test.csv'
+
+        # Run
+        out = GaussianCopula.sample_remaining_columns(
+            model,
+            conditions,
+            batch_size=batch_size,
+            randomize_samples=randomize_samples,
+            output_file_path=output_file_path,
+        )
+
+        # Assert
+        model._sample_remaining_columns.assert_called_once_with(
+            conditions, 100, batch_size, randomize_samples, output_file_path)
+        assert out == model._sample_remaining_columns.return_value


### PR DESCRIPTION
Resolves #729 

Since GaussianCopula can do conditional sampling without reject sampling, we can update its conditional sampling methods to remove the reject sampling arguments (`max_tries`, and `batch_size_per_try`). Also update the warning message for GaussianCopula