### PR TITLE
Handle null values in speed preset

### DIFF
--- a/sdv/lite/tabular.py
+++ b/sdv/lite/tabular.py
@@ -47,20 +47,19 @@ class TabularPreset(BaseTabularModel):
         if optimize_for == SPEED_PRESET:
             self._model = GaussianCopula(
                 table_metadata=metadata,
-                categorical_transformer='categorical',
+                categorical_transformer='label_encoding',
                 default_distribution='gaussian',
                 rounding=None,
             )
 
             dtype_transformers = {
-                'numerical': rdt.transformers.NumericalTransformer(null_column=False),
-                'integer': rdt.transformers.NumericalTransformer(
+                'i': rdt.transformers.NumericalTransformer(
                     dtype=np.int64, null_column=False),
-                'float': rdt.transformers.NumericalTransformer(
+                'f': rdt.transformers.NumericalTransformer(
                     dtype=np.float64, null_column=False),
-                'categorical': rdt.transformers.CategoricalTransformer(fuzzy=True),
-                'boolean': rdt.transformers.BooleanTransformer(null_column=False),
-                'datetime': rdt.transformers.DatetimeTransformer(null_column=False),
+                'O': rdt.transformers.CategoricalTransformer(fuzzy=True),
+                'b': rdt.transformers.BooleanTransformer(null_column=False),
+                'M': rdt.transformers.DatetimeTransformer(null_column=False),
             }
             self._model._metadata._dtype_transformers.update(dtype_transformers)
 

--- a/sdv/lite/tabular.py
+++ b/sdv/lite/tabular.py
@@ -6,8 +6,8 @@ import sys
 import warnings
 
 import numpy as np
-
 import rdt
+
 from sdv.tabular import GaussianCopula
 from sdv.tabular.base import BaseTabularModel
 
@@ -62,7 +62,7 @@ class TabularPreset(BaseTabularModel):
                 'boolean': rdt.transformers.BooleanTransformer(null_column=False),
                 'datetime': rdt.transformers.DatetimeTransformer(null_column=False),
             }
-            self._model._metadata._dtype_transformers.update({dtype_transformers})
+            self._model._metadata._dtype_transformers.update(dtype_transformers)
 
             print('This config optimizes the modeling speed above all else.\n\n'
                   'Your exact runtime is dependent on the data. Benchmarks:\n'
@@ -74,7 +74,7 @@ class TabularPreset(BaseTabularModel):
         self._null_percentages = {}
         table_meta = self._model._metadata.to_dict()
 
-        for field, field_meta in table_meta['fields'].items():
+        for field in table_meta['fields']:
             num_nulls = data[field].isna().sum()
             if num_nulls > 0:
                 # Store null percentage for future reference.
@@ -85,10 +85,13 @@ class TabularPreset(BaseTabularModel):
     def sample(self, num_rows):
         """Sample rows from this table."""
         sampled = self._model.sample(num_rows)
+
         if self._null_percentages:
             for field, percentage in self._null_percentages.items():
                 sampled[field] = sampled[field].apply(
                     lambda x: np.nan if random.random() < percentage else x)
+
+        return sampled
 
     @classmethod
     def list_available_presets(cls, out=sys.stdout):

--- a/tests/unit/lite/test_tabular.py
+++ b/tests/unit/lite/test_tabular.py
@@ -56,7 +56,7 @@ class TestTabularPreset:
         # Assert
         gaussian_copula_mock.assert_called_once_with(
             table_metadata=None,
-            categorical_transformer='categorical',
+            categorical_transformer='label_encoding',
             default_distribution='gaussian',
             rounding=None,
         )


### PR DESCRIPTION
In the speed preset, we want to avoid modeling nulls in the GaussianCopula model. Instead, we capture the null value percentage of each column with null values before fitting, and add nulls back with the same likelihood after sampling. 

Resolves #716 