### PR TITLE
Fix field distribution arg in GaussianCopula

### DIFF
--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -292,7 +292,7 @@ class GaussianCopula(BaseTabularModel):
             if column not in self._field_distributions:
                 # Check if the column is a derived column.
                 column_name = column.replace('.value', '').replace('.is_null', '')
-                self._field_distributions[column] = self._field_distribution.get(
+                self._field_distributions[column] = self._field_distributions.get(
                     column_name, self._default_distribution)
 
         self._model = copulas.multivariate.GaussianMultivariate(

--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -289,9 +289,11 @@ class GaussianCopula(BaseTabularModel):
                 Data to be fitted.
         """
         for column in table_data.columns:
-            distribution = self._field_distributions.get(column)
-            if not distribution:
-                self._field_distributions[column] = self._default_distribution
+            if column not in self._field_distributions:
+                # Check if the column is a derived column.
+                column_name = column.replace('.value', '').replace('.is_null', '')
+                self._field_distributions[column] = self._field_distribution.get(
+                    column_name, self._default_distribution)
 
         self._model = copulas.multivariate.GaussianMultivariate(
             distribution=self._field_distributions)

--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -291,7 +291,7 @@ class GaussianCopula(BaseTabularModel):
         for column in table_data.columns:
             if column not in self._field_distributions:
                 # Check if the column is a derived column.
-                column_name = column.replace('.value', '').replace('.is_null', '')
+                column_name = column.replace('.value', '')
                 self._field_distributions[column] = self._field_distributions.get(
                     column_name, self._default_distribution)
 


### PR DESCRIPTION
In GaussianCopula _fit, we received transformed columns which have columns `a.value` and `a.is_null` if the original dataset has a column 'a'. When this happens, the field distribution does not get properly passed through to GaussianCopula since it has been specified under the key 'a'. We can fix this by matching transformed columns to the original column names.