### PR TITLE
resolved FutureWarning with Pandas replaced append by concat

### DIFF
--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -249,7 +249,7 @@ class BaseTabularModel:
             sampled = self._metadata.reverse_transform(sampled)
 
             if previous_rows is not None:
-                sampled = previous_rows.append(sampled, ignore_index=True)
+                sampled = pd.concat([previous_rows, sampled], ignore_index=True)
 
             sampled = self._metadata.filter_valid(sampled)
 


### PR DESCRIPTION
Hello, 

I am just providing a simple fix to replace the `append` function which is now triggering a `FutureWarning` for deprecation from Pandas.

Best regards,
Romain.