### PR TITLE
Fix tabular preset with metadata

### DIFF
--- a/sdv/lite/tabular.py
+++ b/sdv/lite/tabular.py
@@ -50,10 +50,10 @@ class TabularPreset():
                           'detected from your data. This process may not be accurate. '
                           'We recommend writing metadata to ensure correct data handling.')
 
-        if metadata is not None and constraints is not None:
-            if isinstance(metadata, Table):
-                metadata = metadata.to_dict()
+        if metadata is not None and isinstance(metadata, Table):
+            metadata = metadata.to_dict()
 
+        if metadata is not None and constraints is not None:
             metadata['constraints'] = []
             for constraint in constraints:
                 metadata['constraints'].append(constraint.to_dict())

--- a/tests/unit/lite/test_tabular.py
+++ b/tests/unit/lite/test_tabular.py
@@ -1,11 +1,12 @@
 import io
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
 import pandas as pd
 import pytest
 
 from sdv.lite import TabularPreset
+from sdv.metadata import Table
 from sdv.tabular import GaussianCopula
 from tests.utils import DataFrameMatcher
 
@@ -63,6 +64,32 @@ class TestTabularPreset:
         )
         metadata = gaussian_copula_mock.return_value._metadata
         assert metadata._dtype_transformers.update.call_count == 1
+
+    @patch('sdv.lite.tabular.GaussianCopula', spec_set=GaussianCopula)
+    def test__init__with_metadata(self, gaussian_copula_mock):
+        """Tests the ``TabularPreset.__init__`` method with the speed preset.
+
+        The method should pass the parameters to the ``GaussianCopula`` class.
+
+        Input:
+        - name of the speed preset
+        Side Effects:
+        - GaussianCopula should receive the correct parameters
+        """
+        # Setup
+        metadata = MagicMock(spec_set=Table)
+
+        # Run
+        TabularPreset(name='FAST_ML', metadata=metadata)
+
+        # Assert
+        gaussian_copula_mock.assert_called_once_with(
+            table_metadata=metadata.to_dict(),
+            constraints=None,
+            categorical_transformer='categorical_fuzzy',
+            default_distribution='gaussian',
+            rounding=None,
+        )
 
     @patch('sdv.lite.tabular.GaussianCopula', spec_set=GaussianCopula)
     def test__init__with_constraints(self, gaussian_copula_mock):


### PR DESCRIPTION
Fix tabular preset initialization with only the metadata specified and no constraints. It should transform the metadata to a dictionary in both the case where constraints are not provided and the case where constraints are provided.