### PR TITLE
[Bug-fix doc] Fix missing default values in code and doc, plus remove duplicate batch_size in a tutorial

### DIFF
--- a/docs/user_guides/single_table/ctgan.rst
+++ b/docs/user_guides/single_table/ctgan.rst
@@ -440,7 +440,7 @@ generated data and computational time.
 -   ``verbose``: Whether to print fit progress on stdout. Defaults to ``False``.
 
 -   ``cuda`` (bool or str): If ``True``, use CUDA. If a ``str``, use the
-    indicated device. If ``False``, do not use cuda at all.
+    indicated device. If ``False``, do not use cuda at all. Defaults to ``True``.
 
 .. warning::
 

--- a/docs/user_guides/single_table/tvae.rst
+++ b/docs/user_guides/single_table/tvae.rst
@@ -419,7 +419,7 @@ generated data and computational time.
 -   ``decompress_dims`` (tuple or list of ints): Size of each hidden layer
     in the decoder. Defaults to (128, 128).
 
--   ``l2scale`` (int): Regularization term. Defaults to 1e-5.
+-   ``l2scale`` (float): Regularization term. Defaults to 1e-5.
 
 -   ``loss_factor`` (int): Multiplier for the reconstruction error. Defaults to 2.
 

--- a/docs/user_guides/single_table/tvae.rst
+++ b/docs/user_guides/single_table/tvae.rst
@@ -421,12 +421,10 @@ generated data and computational time.
 
 -   ``l2scale`` (int): Regularization term. Defaults to 1e-5.
 
--   ``batch_size`` (int): Number of data samples to process in each step.
-
 -   ``loss_factor`` (int): Multiplier for the reconstruction error. Defaults to 2.
 
 -   ``cuda`` (bool or str): If ``True``, use CUDA. If a ``str``, use the
-    indicated device. If ``False``, do not use cuda at all.
+    indicated device. If ``False``, do not use cuda at all. Defaults to ``True``.
 
 .. warning::
 

--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -36,11 +36,11 @@ class Table:
             included in the generated output.
             If ``None``, all the fields found in the data are used.
         field_types (dict[str, dict]):
-            Dictinary specifying the data types and subtypes
+            Dictionary specifying the data types and subtypes
             of the fields that will be modeled. Field types and subtypes
             combinations must be compatible with the SDV Metadata Schema.
         field_transformers (dict[str, str]):
-            Dictinary specifying which transformers to use for each field.
+            Dictionary specifying which transformers to use for each field.
             Available transformers are:
 
                 * ``integer``: Uses a ``NumericalTransformer`` of dtype ``int``.

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -43,11 +43,11 @@ class BaseTabularModel:
             included in the generated output.
             If ``None``, all the fields found in the data are used.
         field_types (dict[str, dict]):
-            Dictinary specifying the data types and subtypes
+            Dictionary specifying the data types and subtypes
             of the fields that will be modeled. Field types and subtypes
             combinations must be compatible with the SDV Metadata Schema.
         field_transformers (dict[str, str]):
-            Dictinary specifying which transformers to use for each field.
+            Dictionary specifying which transformers to use for each field.
             Available transformers are:
 
                 * ``integer``: Uses a ``NumericalTransformer`` of dtype ``int``.

--- a/sdv/tabular/copulagan.py
+++ b/sdv/tabular/copulagan.py
@@ -72,11 +72,11 @@ class CopulaGAN(CTGAN):
             included in the generated output.
             If ``None``, all the fields found in the data are used.
         field_types (dict[str, dict]):
-            Dictinary specifying the data types and subtypes
+            Dictionary specifying the data types and subtypes
             of the fields that will be modeled. Field types and subtypes
             combinations must be compatible with the SDV Metadata Schema.
         field_transformers (dict[str, str]):
-            Dictinary specifying which transformers to use for each field.
+            Dictionary specifying which transformers to use for each field.
             Available transformers are:
 
                 * ``integer``: Uses a ``NumericalTransformer`` of dtype ``int``.

--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -26,11 +26,11 @@ class GaussianCopula(BaseTabularModel):
             included in the generated output.
             If ``None``, all the fields found in the data are used.
         field_types (dict[str, dict]):
-            Dictinary specifying the data types and subtypes
+            Dictionary specifying the data types and subtypes
             of the fields that will be modeled. Field types and subtypes
             combinations must be compatible with the SDV Metadata Schema.
         field_transformers (dict[str, str]):
-            Dictinary specifying which transformers to use for each field.
+            Dictionary specifying which transformers to use for each field.
             Available transformers are:
 
                 * ``integer``: Uses a ``NumericalTransformer`` of dtype ``int``.

--- a/sdv/tabular/ctgan.py
+++ b/sdv/tabular/ctgan.py
@@ -146,7 +146,7 @@ class CTGAN(CTGANModel):
         discriminator_decay (float):
             Discriminator weight decay for the Adam Optimizer. Defaults to 1e-6.
         batch_size (int):
-            Number of data samples to process in each step.
+            Number of data samples to process in each step. Defaults to 500.
         discriminator_steps (int):
             Number of discriminator updates to do for each generator update.
             From the WGAN paper: https://arxiv.org/abs/1701.07875. WGAN paper
@@ -163,7 +163,7 @@ class CTGAN(CTGANModel):
             Defaults to 10.
         cuda (bool or str):
             If ``True``, use CUDA. If a ``str``, use the indicated device.
-            If ``False``, do not use cuda at all.
+            If ``False``, do not use cuda at all. Defaults to ``True``.
         rounding (int, str or None):
             Define rounding scheme for ``NumericalTransformer``. If set to an int, values
             will be rounded to that number of decimal places. If ``None``, values will not
@@ -270,14 +270,14 @@ class TVAE(CTGANModel):
         l2scale (int):
             Regularization term. Defaults to 1e-5.
         batch_size (int):
-            Number of data samples to process in each step.
+            Number of data samples to process in each step. Defaults to 500.
         epochs (int):
             Number of training epochs. Defaults to 300.
         loss_factor (int):
             Multiplier for the reconstruction error. Defaults to 2.
         cuda (bool or str):
             If ``True``, use CUDA. If a ``str``, use the indicated device.
-            If ``False``, do not use cuda at all.
+            If ``False``, do not use cuda at all. Defaults to ``True``.
         rounding (int, str or None):
             Define rounding scheme for ``NumericalTransformer``. If set to an int, values
             will be rounded to that number of decimal places. If ``None``, values will not

--- a/sdv/tabular/ctgan.py
+++ b/sdv/tabular/ctgan.py
@@ -267,7 +267,7 @@ class TVAE(CTGANModel):
             Size of each hidden layer in the encoder. Defaults to (128, 128).
         decompress_dims (tuple or list of ints):
            Size of each hidden layer in the decoder. Defaults to (128, 128).
-        l2scale (int):
+        l2scale (float):
             Regularization term. Defaults to 1e-5.
         batch_size (int):
             Number of data samples to process in each step. Defaults to 500.

--- a/sdv/tabular/ctgan.py
+++ b/sdv/tabular/ctgan.py
@@ -100,11 +100,11 @@ class CTGAN(CTGANModel):
             included in the generated output.
             If ``None``, all the fields found in the data are used.
         field_types (dict[str, dict]):
-            Dictinary specifying the data types and subtypes
+            Dictionary specifying the data types and subtypes
             of the fields that will be modeled. Field types and subtypes
             combinations must be compatible with the SDV Metadata Schema.
         field_transformers (dict[str, str]):
-            Dictinary specifying which transformers to use for each field.
+            Dictionary specifying which transformers to use for each field.
             Available transformers are:
 
                 * ``integer``: Uses a ``NumericalTransformer`` of dtype ``int``.
@@ -232,11 +232,11 @@ class TVAE(CTGANModel):
             included in the generated output.
             If ``None``, all the fields found in the data are used.
         field_types (dict[str, dict]):
-            Dictinary specifying the data types and subtypes
+            Dictionary specifying the data types and subtypes
             of the fields that will be modeled. Field types and subtypes
             combinations must be compatible with the SDV Metadata Schema.
         field_transformers (dict[str, str]):
-            Dictinary specifying which transformers to use for each field.
+            Dictionary specifying which transformers to use for each field.
             Available transformers are:
 
                 * ``integer``: Uses a ``NumericalTransformer`` of dtype ``int``.

--- a/sdv/timeseries/base.py
+++ b/sdv/timeseries/base.py
@@ -26,7 +26,7 @@ class BaseTimeseriesModel:
             included in the generated output.
             If ``None``, all the fields found in the data are used.
         field_types (dict[str, dict]):
-            Dictinary specifying the data types and subtypes
+            Dictionary specifying the data types and subtypes
             of the fields that will be modeled. Field types and subtypes
             combinations must be compatible with the SDV Metadata Schema.
         anonymize_fields (dict[str, str]):

--- a/sdv/timeseries/deepecho.py
+++ b/sdv/timeseries/deepecho.py
@@ -156,7 +156,7 @@ class PAR(DeepEchoModel):
             included in the generated output.
             If ``None``, all the fields found in the data are used.
         field_types (dict[str, dict]):
-            Dictinary specifying the data types and subtypes
+            Dictionary specifying the data types and subtypes
             of the fields that will be modeled. Field types and subtypes
             combinations must be compatible with the SDV Metadata Schema.
         anonymize_fields (dict[str, str]):


### PR DESCRIPTION
This PR fixes: 
- some missing default values in a tabular `CTGAN` module. 
- some missing default values in the tutorial of those same models and cleans duplicate information for `batch_size` in `TVAE`.
- an error in the doc for the `l2scale` param type (what int when it is in fact a float).
- the `Dictionary` typo in the doc.
