### PR TITLE
Fix missing case for None in _validate_file_path

### DIFF
--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -422,7 +422,7 @@ class BaseTabularModel:
     def _validate_file_path(self, output_file_path):
         """Validate the user-passed output file arg, and create the file."""
         output_path = None
-        if output_file_path == DISABLE_TMP_FILE:
+        if output_file_path == DISABLE_TMP_FILE or output_file_path is None:
             # Temporary way of disabling the output file feature, used by HMA1.
             return output_path
 

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -635,6 +635,13 @@ class TestBaseTabularModel:
         with pytest.raises(AssertionError, match='path/to/file already exists'):
             BaseTabularModel._validate_file_path(model, 'file_path')
 
+    def test_given_none_output_file_path_when_validate_file_path_then_return_none(self):
+        model = Mock(spec_set=CTGAN)
+        expected = None
+
+        actual = BaseTabularModel._validate_file_path(model, output_file_path=None)
+        assert actual is expected
+
     @patch('sdv.tabular.base.os')
     def test_sample_with_default_file_path(self, os_mock):
         """Test the `BaseTabularModel.sample` method with the default file path.


### PR DESCRIPTION
As by the doc of `sample` if `output_file_path` is set to `None`, there should be no temporary file writing.
However, [`_validate_file_path`](https://github.com/sdv-dev/SDV/blob/8d3d847505805801c0bb5662838b11ccefa3f934/sdv/tabular/base.py#L422) does not implement a None case, thus it always falls in the [else](https://github.com/sdv-dev/SDV/blob/8d3d847505805801c0bb5662838b11ccefa3f934/sdv/tabular/base.py#L434) option and uses `TMP_FILE_NAME`.

This PR adds a None case and adds a unit test to test this case.
