### PR TITLE
only showing progress bar for single table

### DIFF
--- a/sdv/relational/hma.py
+++ b/sdv/relational/hma.py
@@ -362,7 +362,8 @@ class HMA1(BaseRelationalModel):
                 Sampled rows, shape (, num_rows)
         """
         num_rows = num_rows or model._num_rows
-        sampled = model.sample(num_rows, output_file_path='disable')
+        sampled = model._sample_with_progress_bar(
+            num_rows, output_file_path='disable', show_progress_bar=False)
 
         primary_key_name = self.metadata.get_primary_key(table_name)
         if primary_key_name:

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -503,23 +503,13 @@ class BaseTabularModel:
         batch_size = min(batch_size, num_rows) if batch_size else num_rows
 
         try:
-            if show_progress_bar:
-                with tqdm.tqdm(total=num_rows) as progress_bar:
-                    progress_bar.set_description('Sampling rows')
-                    sampled = self._sample_in_batches(
-                        num_rows=num_rows,
-                        batch_size=batch_size,
-                        max_tries_per_batch=max_tries_per_batch,
-                        progress_bar=progress_bar,
-                        output_file_path=output_file_path
-                    )
-
-            else:
+            with tqdm.tqdm(total=num_rows, disable=not show_progress_bar) as progress_bar:
+                progress_bar.set_description('Sampling rows')
                 sampled = self._sample_in_batches(
                     num_rows=num_rows,
                     batch_size=batch_size,
                     max_tries_per_batch=max_tries_per_batch,
-                    progress_bar=None,
+                    progress_bar=progress_bar,
                     output_file_path=output_file_path
                 )
 

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -557,6 +557,8 @@ class BaseTabularModel:
             pandas.DataFrame:
                 Sampled data.
         """
+        show_progress_bar = bool(self.get_metadata()._constraints) or num_rows != batch_size
+
         return self._sample_with_progress_bar(
             num_rows,
             randomize_samples,
@@ -564,7 +566,7 @@ class BaseTabularModel:
             batch_size,
             output_file_path,
             conditions,
-            show_progress_bar=True
+            show_progress_bar=show_progress_bar
         )
 
     def _validate_conditions(self, conditions):

--- a/sdv/timeseries/base.py
+++ b/sdv/timeseries/base.py
@@ -258,7 +258,8 @@ class BaseTimeseriesModel:
 
             context = pd.DataFrame(index=range(num_sequences or 1))
         elif context is None:
-            context = self._context_model.sample(num_sequences, output_file_path='disable')
+            context = self._context_model._sample_with_progress_bar(
+                num_sequences, output_file_path='disable', show_progress_bar=False)
             for column in self._entity_columns or []:
                 if column not in context:
                     context[column] = range(len(context))

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -428,6 +428,31 @@ class TestBaseTabularModel:
         model._sample_with_progress_bar.assert_called_once_with(
             5, True, 100, 5, None, None, show_progress_bar=True)
 
+    def test_sample_batch_show_progress_bar_because_of_multiple_batches(self):
+        """Test the ``sample`` method.
+
+        If ``num_rows`` does not equal the ``batch_size``, the ``show_progress_bar`` should be
+        shown.
+
+        Setup:
+            - Mock the ``get_metadata`` method to not have constraints.
+
+        Input:
+            - ``num_rows`` set to same value as ``batch_size``.
+        """
+        # Setup
+        model = CTGAN()
+        model.get_metadata = Mock()
+        model.get_metadata._constraints.return_value = None
+        model._sample_with_progress_bar = Mock()
+
+        # Run
+        model.sample(5, batch_size=1)
+
+        # Assert
+        model._sample_with_progress_bar.assert_called_once_with(
+            5, True, 100, 1, None, None, show_progress_bar=True)
+
     @patch('sdv.tabular.base.tqdm.tqdm', spec=tqdm.tqdm)
     def test_sample_valid_num_rows(self, tqdm_mock):
         """Test the ``BaseTabularModel.sample`` method with a valid ``num_rows`` argument.

--- a/tutorials/single_table_data/01_GaussianCopula_Model.ipynb
+++ b/tutorials/single_table_data/01_GaussianCopula_Model.ipynb
@@ -2234,6 +2234,7 @@
     "\n",
     "model = GaussianCopula(\n",
     "    primary_key='student_id',\n",
+    "    categorical_transformer='categorical',\n",
     "    field_distributions={\n",
     "        'experience_years': 'gamma'\n",
     "    }\n",


### PR DESCRIPTION
This PR solves the problem of tons of progress bars being printed in the multi-table sample case. It also only shows the progress bar for `sample` if there are multiple batches to sample or constraints.