### PR TITLE
Raise error if constraint does not exist in SingleTableMetadata

### DIFF
--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pandas as pd
 
 from sdv.constraints import Constraint
+from sdv.metadata.errors import MetadataError
 
 
 class SingleTableMetadata:
@@ -356,7 +357,11 @@ class SingleTableMetadata:
             **kwargs:
                 Any other arguments the constraint requires.
         """
-        constraint_class = Constraint._get_class_from_dict(constraint_name)
+        try:
+            constraint_class = Constraint._get_class_from_dict(constraint_name)
+        except KeyError:
+            raise MetadataError(f"Invalid constraint ('{constraint_name}').")
+
         constraint_class._validate_metadata(self, **kwargs)
         constraint = constraint_class(**kwargs)
         self._constraints.append(constraint)

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from sdv.metadata.errors import MetadataError
 from sdv.metadata.single_table import SingleTableMetadata
 
 
@@ -1381,3 +1382,22 @@ class TestSingleTableMetadata:
             low_column_name='child_age',
             high_column_name='start_date'
         )
+
+    def test_add_constraint_bad_constraint(self):
+        """Test the ``add_constraint`` method with a non-existent constraint.
+
+        If the constraint_name passed doesn't exist, an error should be raised.
+
+        Input:
+            - Fakse constraint name
+
+        Side effect:
+            - MetadataError should be raised
+        """
+        # Setup
+        metadata = SingleTableMetadata()
+
+        # Run
+        error_message = re.escape("Invalid constraint ('fake_constraint').")
+        with pytest.raises(MetadataError, match=error_message):
+            metadata.add_constraint(constraint_name='fake_constraint')


### PR DESCRIPTION
This PR raises an error if the constraint being added in `SingleTableMetadata.add_constraint` doesn't exist 