### PR TITLE
Add flake8-varible-names

### DIFF
--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -508,14 +508,14 @@ class ScalarInequality(Constraint):
     def _validate_metadata_specific_to_constraint(metadata, **kwargs):
         column_name = kwargs.get('column_name')
         sdtype = metadata._columns.get(column_name, {}).get('sdtype')
-        val = kwargs.get('value')
+        value = kwargs.get('value')
         if sdtype == 'numerical':
-            if not isinstance(val, (int, float)):
+            if not isinstance(value, (int, float)):
                 raise ConstraintMetadataError("'value' must be an int or float.")
 
         elif sdtype == 'datetime':
             datetime_format = metadata._columns.get(column_name).get('datetime_format')
-            matches_format = matches_datetime_format(val, datetime_format)
+            matches_format = matches_datetime_format(value, datetime_format)
             if not matches_format:
                 raise ConstraintMetadataError(
                     "'value' must be a datetime string of the right format."

--- a/sdv/constraints/utils.py
+++ b/sdv/constraints/utils.py
@@ -55,20 +55,20 @@ def get_datetime_format(value):
     return _guess_datetime_format_for_array(value)
 
 
-def matches_datetime_format(value, format):
+def matches_datetime_format(value, datetime_format):
     """Check if datetime value matches the provided format.
 
     Args:
         value (str):
             The datetime value.
-        format (str):
+        datetime_format (str):
             The datetime format to check for.
 
     Return:
         True if the value matches the format. Otherwise False.
     """
     try:
-        datetime.strptime(value, format)
+        datetime.strptime(value, datetime_format)
     except Exception:
         return False
 

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -380,42 +380,42 @@ class MultiTableMetadata:
         table.detect_from_dataframe(data)
         self._tables[table_name] = table
 
-    def set_primary_key(self, table_name, id):  # noqa
+    def set_primary_key(self, table_name, column_name):
         """Set the primary key of a table.
 
         Args:
             table_name (str):
                 Name of the table to set the primary key.
-            id (str, tulple[str]):
+            column_name (str, tulple[str]):
                 Name (or tuple of names) of the primary key column(s).
         """
         self._validate_table_exists(table_name)
-        self._tables[table_name].set_primary_key(id)
+        self._tables[table_name].set_primary_key(column_name)
 
-    def set_sequence_key(self, table_name, id):  # noqa
+    def set_sequence_key(self, table_name, column_name):
         """Set the sequence key of a table.
 
         Args:
             table_name (str):
                 Name of the table to set the sequence key.
-            id (str, tulple[str]):
+            column_name (str, tulple[str]):
                 Name (or tuple of names) of the sequence key column(s).
         """
         self._validate_table_exists(table_name)
         warnings.warn('Sequential modeling is not yet supported on SDV Multi Table models.')
-        self._tables[table_name].set_sequence_key(id)
+        self._tables[table_name].set_sequence_key(column_name)
 
-    def set_alternate_keys(self, table_name, ids):
+    def set_alternate_keys(self, table_name, column_names):
         """Set the alternate keys of a table.
 
         Args:
             table_name (str):
                 Name of the table to set the sequence key.
-            ids (list[str], list[tuple]):
+            column_names (list[str], list[tuple]):
                 List of names (or tuple of names) of the alternate key columns.
         """
         self._validate_table_exists(table_name)
-        self._tables[table_name].set_alternate_keys(ids)
+        self._tables[table_name].set_alternate_keys(column_names)
 
     def set_sequence_index(self, table_name, column_name):
         """Set the sequence index of a table.

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -380,7 +380,7 @@ class MultiTableMetadata:
         table.detect_from_dataframe(data)
         self._tables[table_name] = table
 
-    def set_primary_key(self, table_name, id):
+    def set_primary_key(self, table_name, id):  # noqa
         """Set the primary key of a table.
 
         Args:
@@ -392,7 +392,7 @@ class MultiTableMetadata:
         self._validate_table_exists(table_name)
         self._tables[table_name].set_primary_key(id)
 
-    def set_sequence_key(self, table_name, id):
+    def set_sequence_key(self, table_name, id):  # noqa
         """Set the sequence key of a table.
 
         Args:

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -244,17 +244,18 @@ class SingleTableMetadata:
         self.detect_from_dataframe(data)
 
     @staticmethod
-    def _validate_datatype(id):  # noqa
-        """Check whether id is a string or a tuple of strings."""
-        return isinstance(id, str) or isinstance(id, tuple) and all(isinstance(i, str) for i in id)
+    def _validate_datatype(column_name):
+        """Check whether column_name is a string or a tuple of strings."""
+        return isinstance(column_name, str) or \
+            isinstance(column_name, tuple) and all(isinstance(i, str) for i in column_name)
 
-    def _validate_key(self, id, key_type):  # noqa
+    def _validate_key(self, column_name, key_type):
         """Validate the primary and sequence keys."""
-        if id is not None:
-            if not self._validate_datatype(id):
+        if column_name is not None:
+            if not self._validate_datatype(column_name):
                 raise ValueError(f"'{key_type}_key' must be a string or tuple of strings.")
 
-            keys = {id} if isinstance(id, str) else set(id)
+            keys = {column_name} if isinstance(column_name, str) else set(column_name)
             invalid_ids = keys - set(self._columns)
             if invalid_ids:
                 raise ValueError(
@@ -262,47 +263,48 @@ class SingleTableMetadata:
                     ' Keys should be columns that exist in the table.'
                 )
 
-    def set_primary_key(self, id):  # noqa
+    def set_primary_key(self, column_name):
         """Set the metadata primary key.
 
         Args:
-            id (str, tuple):
+            column_name (str, tuple):
                 Name (or tuple of names) of the primary key column(s).
         """
-        self._validate_key(id, 'primary')
+        self._validate_key(column_name, 'primary')
         if self._primary_key is not None:
             warnings.warn(
                 f"There is an existing primary key {self._primary_key}."
                 ' This key will be removed.'
             )
 
-        self._primary_key = id
+        self._primary_key = column_name
 
-    def set_sequence_key(self, id):  # noqa
+    def set_sequence_key(self, column_name):
         """Set the metadata sequence key.
 
         Args:
-            id (str, tuple):
+            column_name (str, tuple):
                 Name (or tuple of names) of the sequence key column(s).
         """
-        self._validate_key(id, 'sequence')
+        self._validate_key(column_name, 'sequence')
         if self._sequence_key is not None:
             warnings.warn(
                 f"There is an existing sequence key {self._sequence_key}."
                 ' This key will be removed.'
             )
 
-        self._sequence_key = id
+        self._sequence_key = column_name
 
-    def _validate_alternate_keys(self, ids):
-        if not isinstance(ids, list) or not all(self._validate_datatype(id) for id in ids):  # noqa
+    def _validate_alternate_keys(self, column_names):
+        if not isinstance(column_names, list) or \
+           not all(self._validate_datatype(column_name) for column_name in column_names):
             raise ValueError(
                 "'alternate_keys' must be a list of strings or a list of tuples of strings."
             )
 
         keys = set()
-        for id in ids:  # noqa
-            keys.update({id} if isinstance(id, str) else set(id))  # noqa
+        for column_name in column_names:
+            keys.update({column_name} if isinstance(column_name, str) else set(column_name))
 
         invalid_ids = keys - set(self._columns)
         if invalid_ids:
@@ -311,15 +313,15 @@ class SingleTableMetadata:
                 ' Keys should be columns that exist in the table.'
             )
 
-    def set_alternate_keys(self, ids):
+    def set_alternate_keys(self, column_names):
         """Set the metadata alternate keys.
 
         Args:
-            ids (list[str], list[tuple]):
+            column_names (list[str], list[tuple]):
                 List of names (or tuple of names) of the alternate key columns.
         """
-        self._validate_alternate_keys(ids)
-        self._alternate_keys = ids
+        self._validate_alternate_keys(column_names)
+        self._alternate_keys = column_names
 
     def _validate_sequence_index(self, column_name):
         if not isinstance(column_name, str):

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -244,11 +244,11 @@ class SingleTableMetadata:
         self.detect_from_dataframe(data)
 
     @staticmethod
-    def _validate_datatype(id):
+    def _validate_datatype(id):  # noqa
         """Check whether id is a string or a tuple of strings."""
         return isinstance(id, str) or isinstance(id, tuple) and all(isinstance(i, str) for i in id)
 
-    def _validate_key(self, id, key_type):
+    def _validate_key(self, id, key_type):  # noqa
         """Validate the primary and sequence keys."""
         if id is not None:
             if not self._validate_datatype(id):
@@ -262,7 +262,7 @@ class SingleTableMetadata:
                     ' Keys should be columns that exist in the table.'
                 )
 
-    def set_primary_key(self, id):
+    def set_primary_key(self, id):  # noqa
         """Set the metadata primary key.
 
         Args:
@@ -278,7 +278,7 @@ class SingleTableMetadata:
 
         self._primary_key = id
 
-    def set_sequence_key(self, id):
+    def set_sequence_key(self, id):  # noqa
         """Set the metadata sequence key.
 
         Args:
@@ -295,14 +295,14 @@ class SingleTableMetadata:
         self._sequence_key = id
 
     def _validate_alternate_keys(self, ids):
-        if not isinstance(ids, list) or not all(self._validate_datatype(id) for id in ids):
+        if not isinstance(ids, list) or not all(self._validate_datatype(id) for id in ids):  # noqa
             raise ValueError(
                 "'alternate_keys' must be a list of strings or a list of tuples of strings."
             )
 
         keys = set()
-        for id in ids:
-            keys.update({id} if isinstance(id, str) else set(id))
+        for id in ids:  # noqa
+            keys.update({id} if isinstance(id, str) else set(id))  # noqa
 
         invalid_ids = keys - set(self._columns)
         if invalid_ids:

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ development_requires = [
     'flake8-absolute-import>=1.0,<2',
     'flake8-comprehensions>=3.6.1,<3.7',
     'flake8-docstrings>=1.5.0,<2',
+    'flake8-variables-names>=0.0.4,<0.1',
     'flake8-sfs>=0.0.3,<0.1',
     'dlint>=0.11.0,<0.12',
     'isort>=4.3.4,<5',

--- a/tests/unit/metadata/test_dataset.py
+++ b/tests/unit/metadata/test_dataset.py
@@ -434,8 +434,8 @@ class TestMetadata(TestCase):
         }
         assert result.keys() == expected.keys()
 
-        for k, v in result.items():
-            pd.testing.assert_frame_equal(v, expected[k])
+        for key, value in result.items():
+            pd.testing.assert_frame_equal(value, expected[key])
 
     def test_get_fields(self):
         """Test get fields"""


### PR DESCRIPTION
Add flake8-variable-names as part of https://github.com/sdv-dev/SDV/issues/620.

Note: the `id` variables are being "noqad" because they are builtin errors, which will be fixed in the flake8-builtins PR.