### PR TITLE
Reorder methods in single_table.py and multi_table.py files

### DIFF
--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -193,7 +193,7 @@ class Constraint(metaclass=ConstraintMeta):
             ConstraintsNotMetError:
                 If the table data is not valid for the provided constraints.
         """
-        if set(self.constraint_columns).issubset(table_data.columns.values):
+        if set(self.constraint_columns).issubset(table_data.columns.to_numpy()):
             is_valid_data = self.is_valid(table_data)
             if not is_valid_data.all():
                 constraint_data = table_data[list(self.constraint_columns)]
@@ -323,7 +323,7 @@ class Constraint(metaclass=ConstraintMeta):
                          self.__class__.__name__, sum(~valid), len(valid))
 
         if isinstance(valid, pd.Series):
-            return table_data[valid.values]
+            return table_data[valid.to_numpy()]
 
         return table_data[valid]
 
@@ -466,13 +466,13 @@ class ColumnsModel:
         condition_columns = [c for c in self.constraint_columns if c in table_data.columns]
         grouped_conditions = table_data[condition_columns].groupby(condition_columns)
         all_sampled_rows = []
-        for group, df in grouped_conditions:
+        for group, dataframe in grouped_conditions:
             if not isinstance(group, tuple):
                 group = [group]
 
-            transformed_condition = self._hyper_transformer.transform(df).iloc[0].to_dict()
+            transformed_condition = self._hyper_transformer.transform(dataframe).iloc[0].to_dict()
             sampled_rows = self._reject_sample(
-                num_rows=df.shape[0],
+                num_rows=dataframe.shape[0],
                 conditions=transformed_condition
             )
             all_sampled_rows.append(sampled_rows)

--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -166,8 +166,8 @@ class Constraint(metaclass=ConstraintMeta):
         errors = []
         try:
             cls._validate_inputs(**kwargs)
-        except AggregateConstraintsError as mce:
-            errors.extend(mce.errors)
+        except AggregateConstraintsError as agg_error:
+            errors.extend(agg_error.errors)
 
         try:
             cls._validate_metadata_columns(metadata, **kwargs)

--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -12,7 +12,7 @@ from rdt import HyperTransformer
 from rdt.transformers import OneHotEncoder
 
 from sdv.constraints.errors import (
-    ConstraintMetadataError, MissingConstraintColumnError, MultipleConstraintsErrors)
+    AggregateConstraintsError, ConstraintMetadataError, MissingConstraintColumnError)
 from sdv.errors import ConstraintsNotMetError
 
 LOGGER = logging.getLogger(__name__)
@@ -67,14 +67,14 @@ class ConstraintMeta(type):
     This allows us to later on dump the class definition as a dict.
     """
 
-    def __init__(self, name, bases, attr):
+    def __init__(self, name, bases, attr):  # noqa: N804
         super().__init__(name, bases, attr)
 
         old__init__ = self.__init__
         signature = inspect.signature(old__init__)
         arg_names = list(signature.parameters.keys())[1:]
 
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args, **kwargs):  # noqa: N807
             class_name = self.__class__.__name__
             if name == class_name:
                 self.__kwargs__ = copy.deepcopy(kwargs)
@@ -128,7 +128,7 @@ class Constraint(metaclass=ConstraintMeta):
             ))
 
         if errors:
-            raise MultipleConstraintsErrors(errors)
+            raise AggregateConstraintsError(errors)
 
     @classmethod
     def _validate_metadata_columns(cls, metadata, **kwargs):
@@ -160,13 +160,13 @@ class Constraint(metaclass=ConstraintMeta):
                 Any required kwargs for the constraint.
 
         Raises:
-            MultipleConstraintsErrors:
+            AggregateConstraintsError:
                 All the errors from validating the metadata.
         """
         errors = []
         try:
             cls._validate_inputs(**kwargs)
-        except MultipleConstraintsErrors as mce:
+        except AggregateConstraintsError as mce:
             errors.extend(mce.errors)
 
         try:
@@ -180,7 +180,7 @@ class Constraint(metaclass=ConstraintMeta):
             errors.append(e)
 
         if errors:
-            raise MultipleConstraintsErrors(errors)
+            raise AggregateConstraintsError(errors)
 
     def _validate_data_meets_constraint(self, table_data):
         """Make sure the given data is valid for the constraint.

--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -40,7 +40,7 @@ def _module_contains_callable_name(obj):
 
 def get_subclasses(cls):
     """Recursively find subclasses for the current class object."""
-    subclasses = dict()
+    subclasses = {}
     for subclass in cls.__subclasses__():
         subclasses[subclass.__name__] = subclass
         subclasses.update(get_subclasses(subclass))
@@ -465,7 +465,7 @@ class ColumnsModel:
         """
         condition_columns = [c for c in self.constraint_columns if c in table_data.columns]
         grouped_conditions = table_data[condition_columns].groupby(condition_columns)
-        all_sampled_rows = list()
+        all_sampled_rows = []
         for group, df in grouped_conditions:
             if not isinstance(group, tuple):
                 group = [group]

--- a/sdv/constraints/errors.py
+++ b/sdv/constraints/errors.py
@@ -8,7 +8,7 @@ class MissingConstraintColumnError(Exception):
         self.missing_columns = missing_columns
 
 
-class MultipleConstraintsErrors(Exception):
+class AggregateConstraintsError(Exception):
     """Error used to represent a list of constraint errors."""
 
     def __init__(self, errors):

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -74,16 +74,16 @@ def create_custom_constraint(is_valid_fn, transform_fn=None, reverse_transform_f
     ``is_valid`` methods given in the arguments.
 
     Args:
+        is_valid (callable):
+            Function to replace the ``is_valid`` method.
         transform (callable):
             Function to replace the ``transform`` method.
         reverse_transform (callable):
             Function to replace the ``reverse_transform`` method.
-        is_valid (callable):
-            Function to replace the ``is_valid`` method.
 
     Returns:
         CustomConstraint class:
-            A constraint with custom ``transform``/``reverse_transform``/``is_valid`` methods.
+            A constraint with custom ``is_valid``/``transform``/``reverse_transform`` methods.
     """
     _validate_inputs_custom_constraint(is_valid_fn, transform_fn, reverse_transform_fn)
 

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -1146,7 +1146,7 @@ class FixedIncrements(Constraint):
             pandas.Series:
                 Whether each row is valid.
         """
-        isnan = pd.isnull(table_data[self.column_name])
+        isnan = pd.isna(table_data[self.column_name])
         is_divisible = table_data[self.column_name] % self.increment_value == 0
         return is_divisible | isnan
 
@@ -1242,8 +1242,9 @@ class OneHotEncoding(Constraint):
                 Transformed data.
         """
         one_hot_data = table_data[self._column_names]
-        transformed_data = np.zeros_like(one_hot_data.values)
-        transformed_data[np.arange(len(one_hot_data)), np.argmax(one_hot_data.values, axis=1)] = 1
+        transformed_data = np.zeros_like(one_hot_data.to_numpy())
+        max_category_indices = np.argmax(one_hot_data.to_numpy(), axis=1)
+        transformed_data[np.arange(len(one_hot_data)), max_category_indices] = 1
         table_data[self._column_names] = transformed_data
 
         return table_data

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -365,7 +365,7 @@ class Inequality(Constraint):
         self._high_column_name = high_column_name
         self._diff_column_name = f'{self._low_column_name}#{self._high_column_name}'
         self._operator = np.greater if strict_boundaries else np.greater_equal
-        self.constraint_columns = tuple([low_column_name, high_column_name])
+        self.constraint_columns = (low_column_name, high_column_name)
         self._dtype = None
         self._is_datetime = None
 
@@ -386,7 +386,7 @@ class Inequality(Constraint):
         return is_datetime
 
     def _validate_columns_exist(self, table_data):
-        missing = set([self._low_column_name, self._high_column_name]) - set(table_data.columns)
+        missing = {self._low_column_name, self._high_column_name} - set(table_data.columns)
         if missing:
             raise KeyError(f'The columns {missing} were not found in table_data.')
 
@@ -549,7 +549,7 @@ class ScalarInequality(Constraint):
         self._value = cast_to_datetime64(value) if is_datetime_type(value) else value
         self._column_name = column_name
         self._diff_column_name = f'{self._column_name}#diff'
-        self.constraint_columns = tuple([column_name])
+        self.constraint_columns = (column_name)
         self._is_datetime = None
         self._datetime_format = None
         self._dtype = None
@@ -1133,7 +1133,7 @@ class FixedIncrements(Constraint):
 
         self.increment_value = increment_value
         self.column_name = column_name
-        self.constraint_columns = tuple([column_name])
+        self.constraint_columns = (column_name,)
 
     def is_valid(self, table_data):
         """Determine if the data is evenly divisible by the increment.

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -100,9 +100,12 @@ def create_custom_constraint(is_valid_fn, transform_fn=None, reverse_transform_f
         @classmethod
         def _validate_inputs(cls, **kwargs):
             if 'column_names' not in set(kwargs):
-                errors = [ConstraintMetadataError(
-                    "Missing required values {'column_names'} in a CustomConstraint constraint."
-                )]
+                errors = [
+                    ConstraintMetadataError(
+                        "Missing required values {'column_names'} in a"
+                        ' CustomConstraint constraint.'
+                    )
+                ]
                 raise MultipleConstraintsErrors(errors)
 
         def __init__(self, column_names, **kwargs):

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -1112,8 +1112,8 @@ class FixedIncrements(Constraint):
         errors = []
         try:
             super()._validate_inputs(**kwargs)
-        except AggregateConstraintsError as mce:
-            errors.extend(mce.errors)
+        except AggregateConstraintsError as agg_error:
+            errors.extend(agg_error.errors)
         except Exception as e:
             errors.append(e)
 

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -38,7 +38,7 @@ import pandas as pd
 
 from sdv.constraints.base import Constraint
 from sdv.constraints.errors import (
-    ConstraintMetadataError, FunctionError, InvalidFunctionError, MultipleConstraintsErrors)
+    AggregateConstraintsError, ConstraintMetadataError, FunctionError, InvalidFunctionError)
 from sdv.constraints.utils import (
     cast_to_datetime64, get_datetime_format, is_datetime_type, logit, matches_datetime_format,
     sigmoid)
@@ -106,7 +106,7 @@ def create_custom_constraint(is_valid_fn, transform_fn=None, reverse_transform_f
                         ' CustomConstraint constraint.'
                     )
                 ]
-                raise MultipleConstraintsErrors(errors)
+                raise AggregateConstraintsError(errors)
 
         def __init__(self, column_names, **kwargs):
             self.column_names = column_names
@@ -505,7 +505,7 @@ class ScalarInequality(Constraint):
             ))
 
         if errors:
-            raise MultipleConstraintsErrors(errors)
+            raise AggregateConstraintsError(errors)
 
     @staticmethod
     def _validate_metadata_specific_to_constraint(metadata, **kwargs):
@@ -1112,7 +1112,7 @@ class FixedIncrements(Constraint):
         errors = []
         try:
             super()._validate_inputs(**kwargs)
-        except MultipleConstraintsErrors as mce:
+        except AggregateConstraintsError as mce:
             errors.extend(mce.errors)
         except Exception as e:
             errors.append(e)
@@ -1125,7 +1125,7 @@ class FixedIncrements(Constraint):
             ))
 
         if errors:
-            raise MultipleConstraintsErrors(errors)
+            raise AggregateConstraintsError(errors)
 
     def __init__(self, column_name, increment_value):
         if increment_value <= 0:

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -508,14 +508,14 @@ class ScalarInequality(Constraint):
     def _validate_metadata_specific_to_constraint(metadata, **kwargs):
         column_name = kwargs.get('column_name')
         sdtype = metadata._columns.get(column_name, {}).get('sdtype')
-        val = kwargs.get('value')
+        value = kwargs.get('value')
         if sdtype == 'numerical':
-            if not isinstance(val, (int, float)):
+            if not isinstance(value, (int, float)):
                 raise ConstraintMetadataError("'value' must be an int or float.")
 
         elif sdtype == 'datetime':
             datetime_format = metadata._columns.get(column_name).get('datetime_format')
-            matches_format = matches_datetime_format(val, datetime_format)
+            matches_format = matches_datetime_format(value, datetime_format)
             if not matches_format:
                 raise ConstraintMetadataError(
                     "'value' must be a datetime string of the right format."

--- a/sdv/constraints/utils.py
+++ b/sdv/constraints/utils.py
@@ -55,20 +55,20 @@ def get_datetime_format(value):
     return _guess_datetime_format_for_array(value)
 
 
-def matches_datetime_format(value, format):
+def matches_datetime_format(value, datetime_format):
     """Check if datetime value matches the provided format.
 
     Args:
         value (str):
             The datetime value.
-        format (str):
+        datetime_format (str):
             The datetime format to check for.
 
     Return:
         True if the value matches the format. Otherwise False.
     """
     try:
-        datetime.strptime(value, format)
+        datetime.strptime(value, datetime_format)
     except Exception:
         return False
 

--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -9,7 +9,7 @@ import rdt
 
 from sdv.constraints import Constraint
 from sdv.constraints.errors import (
-    FunctionError, MissingConstraintColumnError, AggregateConstraintsError)
+    AggregateConstraintsError, FunctionError, MissingConstraintColumnError)
 from sdv.data_processing.errors import NotFittedError
 from sdv.metadata.single_table import SingleTableMetadata
 

--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -9,7 +9,7 @@ import rdt
 
 from sdv.constraints import Constraint
 from sdv.constraints.errors import (
-    FunctionError, MissingConstraintColumnError, MultipleConstraintsErrors)
+    FunctionError, MissingConstraintColumnError, AggregateConstraintsError)
 from sdv.data_processing.errors import NotFittedError
 from sdv.metadata.single_table import SingleTableMetadata
 
@@ -128,7 +128,7 @@ class DataProcessor:
                 errors.append(e)
 
         if errors:
-            raise MultipleConstraintsErrors(errors)
+            raise AggregateConstraintsError(errors)
 
     def _transform_constraints(self, data, is_condition=False):
         errors = []
@@ -162,7 +162,7 @@ class DataProcessor:
                 errors.append(error)
 
         if errors:
-            raise MultipleConstraintsErrors(errors)
+            raise AggregateConstraintsError(errors)
 
         return data
 
@@ -300,7 +300,7 @@ class DataProcessor:
                 column_data = column_data.round()
 
             dtype = self._dtypes[column_name]
-            reversed_data[column_name] = column_data[column_data.notnull()].astype(dtype)
+            reversed_data[column_name] = column_data[column_data.notna()].astype(dtype)
 
         return reversed_data[original_columns]
 

--- a/sdv/demo.py
+++ b/sdv/demo.py
@@ -144,19 +144,25 @@ def _load_relational_dummy():
     sessions = pd.DataFrame({
         'session_id': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
         'user_id': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-        'device': ['mobile', 'tablet', 'tablet', 'mobile', 'mobile',
-                   'mobile', 'mobile', 'tablet', 'mobile', 'tablet'],
-        'os': ['android', 'ios', 'android', 'android', 'ios',
-               'android', 'ios', 'ios', 'ios', 'ios'],
+        'device': [
+            'mobile', 'tablet', 'tablet', 'mobile', 'mobile',
+            'mobile', 'mobile', 'tablet', 'mobile', 'tablet'
+        ],
+        'os': [
+            'android', 'ios', 'android', 'android', 'ios',
+            'android', 'ios', 'ios', 'ios', 'ios'
+        ],
         'minutes': [23, 12, 8, 13, 9, 32, 7, 21, 29, 34],
     })
     transactions = pd.DataFrame({
         'transaction_id': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
         'session_id': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-        'timestamp': ['2019-01-01T12:34:32', '2019-01-01T12:42:21', '2019-01-07T17:23:11',
-                      '2019-01-10T11:08:57', '2019-01-10T21:54:08', '2019-01-11T11:21:20',
-                      '2019-01-22T14:44:10', '2019-01-23T10:14:09', '2019-01-27T16:09:17',
-                      '2019-01-29T12:10:48'],
+        'timestamp': [
+            '2019-01-01T12:34:32', '2019-01-01T12:42:21', '2019-01-07T17:23:11',
+            '2019-01-10T11:08:57', '2019-01-10T21:54:08', '2019-01-11T11:21:20',
+            '2019-01-22T14:44:10', '2019-01-23T10:14:09', '2019-01-27T16:09:17',
+            '2019-01-29T12:10:48'
+        ],
         'amount': [100.0, 55.3, 79.5, 112.1, 110.0, 76.3, 89.5, 132.1, 68.0, 99.9],
         'cancelled': [False, False, False, True, True, False, False, True, False, False],
     })

--- a/sdv/demo.py
+++ b/sdv/demo.py
@@ -184,15 +184,11 @@ def sample_relational_demo(size=30):
     countries = [faker.country_code() for _ in range(5)]
     country = np.random.choice(countries, size=size)
     gender = np.random.choice(['F', 'M', None], p=[0.5, 0.4, 0.1], size=size)
-    age = (
-        sp.stats.truncnorm.rvs(-1.2, 1.5, loc=30, scale=10, size=size).astype(int)
-        + 3 * (gender == 'M')
-        + 3 * (country == countries[0]).astype(int)
-    )
-    num_sessions = (
-        sp.stats.gamma.rvs(1, loc=0, scale=2, size=size)
-        * (0.8 + 0.2 * (gender == 'F'))
-    ).round().astype(int)
+    trunc_noise = sp.stats.truncnorm.rvs(-1.2, 1.5, loc=30, scale=10, size=size).astype(int)
+    age = trunc_noise + 3 * (gender == 'M') + 3 * (country == countries[0]).astype(int)
+    gamma_noise = sp.stats.gamma.rvs(1, loc=0, scale=2, size=size)
+    num_sessions = gamma_noise * (0.8 + 0.2 * (gender == 'F'))
+    num_sessions = num_sessions.round().astype(int)
 
     users = pd.DataFrame({
         'country': country,
@@ -219,12 +215,11 @@ def sample_relational_demo(size=30):
         for device in devices:
             os.append(pc_os if device == 'pc' else phone_os)
 
-        minutes = (
-            sp.stats.truncnorm.rvs(-3, 3, loc=30, scale=10, size=user.num_sessions)
-            * (1 + 0.1 * (user.gender == 'M'))
-            * (1 + user.age / 100)
-            * (1 + 0.1 * (devices == 'pc'))
+        noise = sp.stats.truncnorm.rvs(-3, 3, loc=30, scale=10, size=user.num_sessions)
+        prob = (
+            (1 + .1 * (user.gender == 'M')) * (1 + user.age / 100) * (1 + .1 * (devices == 'pc'))
         )
+        minutes = noise * prob
         num_transactions = (minutes / 10) * (0.5 + (user.gender == 'F'))
 
         sessions = sessions.append(pd.DataFrame({

--- a/sdv/lite/tabular.py
+++ b/sdv/lite/tabular.py
@@ -257,7 +257,7 @@ class TabularPreset():
                 The loaded tabular model.
         """
         with open(path, 'rb') as f:
-            model = pickle.load(f)
+            model = pickle.load(f)  # noqa: DUO103
             throw_version_mismatch_warning(getattr(model, '_package_versions', None))
 
             return model

--- a/sdv/metadata/dataset.py
+++ b/sdv/metadata/dataset.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__)
 
 def _read_csv_dtypes(table_meta):
     """Get the dtypes specification that needs to be passed to read_csv."""
-    dtypes = dict()
+    dtypes = {}
     for name, field in table_meta['fields'].items():
         field_type = field['type']
         if field_type == 'id' and field.get('subtype', 'integer') == 'string':
@@ -152,13 +152,13 @@ class Metadata:
             }
             return new_metadata
 
-        new_tables = dict()
+        new_tables = {}
         for table in tables:
             if table.pop('use', True):
                 new_tables[table.pop('name')] = table
 
                 fields = table['fields']
-                new_fields = dict()
+                new_fields = {}
                 for field in fields:
                     new_fields[field.pop('name')] = field
 
@@ -181,7 +181,7 @@ class Metadata:
         else:
             self._metadata = {'tables': {}}
 
-        self._hyper_transformers = dict()
+        self._hyper_transformers = {}
         self._analyze_relationships()
 
     def get_children(self, table_name):
@@ -378,7 +378,7 @@ class Metadata:
                 exist in this metadata.
         """
         errors = [] if errors is None else errors
-        dtypes = dict()
+        dtypes = {}
         table_meta = self.get_table_meta(table_name)
         for name, field in table_meta['fields'].items():
             field_type = field['type']
@@ -781,7 +781,7 @@ class Metadata:
             ValueError:
                 If a column from the data analyzed is an unsupported data type or
         """
-        fields_metadata = dict()
+        fields_metadata = {}
         for field in fields:
             dtype = data[field].dtype
             field_template = self._FIELD_TEMPLATES.get(dtype.kind)
@@ -851,12 +851,12 @@ class Metadata:
             if fields_metadata:
                 fields = [field for field in fields if field not in fields_metadata]
             else:
-                fields_metadata = dict()
+                fields_metadata = {}
 
             fields_metadata.update(self._get_field_details(data, fields))
 
         elif fields_metadata is None:
-            fields_metadata = dict()
+            fields_metadata = {}
 
         table_metadata = {'fields': fields_metadata}
         if path:

--- a/sdv/metadata/dataset.py
+++ b/sdv/metadata/dataset.py
@@ -922,11 +922,11 @@ class Metadata:
         ]
 
         return (
-            "Metadata\n"
-            "  root_path: {}\n"
-            "  tables: {}\n"
-            "  relationships:\n"
-            "{}"
+            'Metadata\n'
+            '  root_path: {}\n'
+            '  tables: {}\n'
+            '  relationships:\n'
+            '{}'
         ).format(
             self.root_path,
             tables,

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -380,42 +380,42 @@ class MultiTableMetadata:
         table.detect_from_dataframe(data)
         self._tables[table_name] = table
 
-    def set_primary_key(self, table_name, id):
+    def set_primary_key(self, table_name, column_name):
         """Set the primary key of a table.
 
         Args:
             table_name (str):
                 Name of the table to set the primary key.
-            id (str, tulple[str]):
+            column_name (str, tulple[str]):
                 Name (or tuple of names) of the primary key column(s).
         """
         self._validate_table_exists(table_name)
-        self._tables[table_name].set_primary_key(id)
+        self._tables[table_name].set_primary_key(column_name)
 
-    def set_sequence_key(self, table_name, id):
+    def set_sequence_key(self, table_name, column_name):
         """Set the sequence key of a table.
 
         Args:
             table_name (str):
                 Name of the table to set the sequence key.
-            id (str, tulple[str]):
+            column_name (str, tulple[str]):
                 Name (or tuple of names) of the sequence key column(s).
         """
         self._validate_table_exists(table_name)
         warnings.warn('Sequential modeling is not yet supported on SDV Multi Table models.')
-        self._tables[table_name].set_sequence_key(id)
+        self._tables[table_name].set_sequence_key(column_name)
 
-    def set_alternate_keys(self, table_name, ids):
+    def set_alternate_keys(self, table_name, column_names):
         """Set the alternate keys of a table.
 
         Args:
             table_name (str):
                 Name of the table to set the sequence key.
-            ids (list[str], list[tuple]):
+            column_names (list[str], list[tuple]):
                 List of names (or tuple of names) of the alternate key columns.
         """
         self._validate_table_exists(table_name)
-        self._tables[table_name].set_alternate_keys(ids)
+        self._tables[table_name].set_alternate_keys(column_names)
 
     def set_sequence_index(self, table_name, column_name):
         """Set the sequence index of a table.

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -53,7 +53,7 @@ class MultiTableMetadata:
 
     @staticmethod
     def _validate_no_missing_tables_in_relationship(parent_table_name, child_table_name, tables):
-        missing_table_names = set([parent_table_name, child_table_name]) - set(tables)
+        missing_table_names = {parent_table_name, child_table_name} - set(tables)
         if missing_table_names:
             if len(missing_table_names) == 1:
                 raise ValueError(f'Relationship contains an unknown table {missing_table_names}.')

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -116,7 +116,7 @@ class MultiTableMetadata:
         if errors:
             raise ValueError(
                 'The relationships in the dataset describe a circular dependency between '
-                f'tables {set(errors)}.'
+                f'tables {errors}.'
             )
 
     def _validate_relationship(self, parent_table_name, child_table_name,
@@ -469,7 +469,7 @@ class MultiTableMetadata:
                     queue.append(child)
 
         if not all(connected.values()):
-            disconnected_tables = {table for table, value in connected.items() if not value}
+            disconnected_tables = [table for table, value in connected.items() if not value]
             if len(disconnected_tables) > 1:
                 table_msg = (
                     f'Tables {disconnected_tables} are not connected to any of the other tables.'

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -244,17 +244,18 @@ class SingleTableMetadata:
         self.detect_from_dataframe(data)
 
     @staticmethod
-    def _validate_datatype(id):
-        """Check whether id is a string or a tuple of strings."""
-        return isinstance(id, str) or isinstance(id, tuple) and all(isinstance(i, str) for i in id)
+    def _validate_datatype(column_name):
+        """Check whether column_name is a string or a tuple of strings."""
+        return isinstance(column_name, str) or \
+            isinstance(column_name, tuple) and all(isinstance(i, str) for i in column_name)
 
-    def _validate_key(self, id, key_type):
+    def _validate_key(self, column_name, key_type):
         """Validate the primary and sequence keys."""
-        if id is not None:
-            if not self._validate_datatype(id):
+        if column_name is not None:
+            if not self._validate_datatype(column_name):
                 raise ValueError(f"'{key_type}_key' must be a string or tuple of strings.")
 
-            keys = {id} if isinstance(id, str) else set(id)
+            keys = {column_name} if isinstance(column_name, str) else set(column_name)
             invalid_ids = keys - set(self._columns)
             if invalid_ids:
                 raise ValueError(
@@ -262,47 +263,48 @@ class SingleTableMetadata:
                     ' Keys should be columns that exist in the table.'
                 )
 
-    def set_primary_key(self, id):
+    def set_primary_key(self, column_name):
         """Set the metadata primary key.
 
         Args:
-            id (str, tuple):
+            column_name (str, tuple):
                 Name (or tuple of names) of the primary key column(s).
         """
-        self._validate_key(id, 'primary')
+        self._validate_key(column_name, 'primary')
         if self._primary_key is not None:
             warnings.warn(
                 f"There is an existing primary key {self._primary_key}."
                 ' This key will be removed.'
             )
 
-        self._primary_key = id
+        self._primary_key = column_name
 
-    def set_sequence_key(self, id):
+    def set_sequence_key(self, column_name):
         """Set the metadata sequence key.
 
         Args:
-            id (str, tuple):
+            column_name (str, tuple):
                 Name (or tuple of names) of the sequence key column(s).
         """
-        self._validate_key(id, 'sequence')
+        self._validate_key(column_name, 'sequence')
         if self._sequence_key is not None:
             warnings.warn(
                 f"There is an existing sequence key {self._sequence_key}."
                 ' This key will be removed.'
             )
 
-        self._sequence_key = id
+        self._sequence_key = column_name
 
-    def _validate_alternate_keys(self, ids):
-        if not isinstance(ids, list) or not all(self._validate_datatype(id) for id in ids):
+    def _validate_alternate_keys(self, column_names):
+        if not isinstance(column_names, list) or \
+           not all(self._validate_datatype(column_name) for column_name in column_names):
             raise ValueError(
                 "'alternate_keys' must be a list of strings or a list of tuples of strings."
             )
 
         keys = set()
-        for id in ids:
-            keys.update({id} if isinstance(id, str) else set(id))
+        for column_name in column_names:
+            keys.update({column_name} if isinstance(column_name, str) else set(column_name))
 
         invalid_ids = keys - set(self._columns)
         if invalid_ids:
@@ -311,15 +313,15 @@ class SingleTableMetadata:
                 ' Keys should be columns that exist in the table.'
             )
 
-    def set_alternate_keys(self, ids):
+    def set_alternate_keys(self, column_names):
         """Set the metadata alternate keys.
 
         Args:
-            ids (list[str], list[tuple]):
+            column_names (list[str], list[tuple]):
                 List of names (or tuple of names) of the alternate key columns.
         """
-        self._validate_alternate_keys(ids)
-        self._alternate_keys = ids
+        self._validate_alternate_keys(column_names)
+        self._alternate_keys = column_names
 
     def _validate_sequence_index(self, column_name):
         if not isinstance(column_name, str):

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -217,8 +217,8 @@ class SingleTableMetadata:
             kind = clean_data.infer_objects().dtype.kind
             self._columns[field] = {'sdtype': self._DTYPES_TO_SDTYPES.get(kind, 'categorical')}
 
-        print('Detected metadata:')
-        print(json.dumps(self.to_dict(), indent=4))
+        print('Detected metadata:')  # noqa: T001
+        print(json.dumps(self.to_dict(), indent=4))  # noqa: T001
 
     def detect_from_csv(self, filepath, pandas_kwargs=None):
         """Detect the metadata from a ``csv`` file.

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pandas as pd
 
 from sdv.constraints import Constraint
-from sdv.constraints.errors import MultipleConstraintsErrors
+from sdv.constraints.errors import AggregateConstraintsError
 from sdv.metadata.errors import InvalidMetadataError
 from sdv.metadata.utils import cast_to_iterable, read_json, validate_file_does_not_exist
 
@@ -390,7 +390,7 @@ class SingleTableMetadata:
             constraint_name = constraint_dict.pop('constraint_name')
             try:
                 self._validate_constraint(constraint_name, **constraint_dict)
-            except MultipleConstraintsErrors as e:
+            except AggregateConstraintsError as e:
                 reformated_errors = '\n'.join(map(str, e.errors))
                 errors.append(reformated_errors)
 

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -119,7 +119,7 @@ class SingleTableMetadata:
 
     def _validate_unexpected_kwargs(self, column_name, sdtype, **kwargs):
         expected_kwargs = self._EXPECTED_KWARGS.get(sdtype, ['pii'])
-        unexpected_kwargs = set(list(kwargs)) - set(expected_kwargs)
+        unexpected_kwargs = set(kwargs) - set(expected_kwargs)
         if unexpected_kwargs:
             unexpected_kwargs = sorted(unexpected_kwargs)
             unexpected_kwargs = ', '.join(unexpected_kwargs)

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -273,7 +273,7 @@ class SingleTableMetadata:
         self._validate_key(column_name, 'primary')
         if self._primary_key is not None:
             warnings.warn(
-                f"There is an existing primary key {self._primary_key}."
+                f'There is an existing primary key {self._primary_key}.'
                 ' This key will be removed.'
             )
 
@@ -289,7 +289,7 @@ class SingleTableMetadata:
         self._validate_key(column_name, 'sequence')
         if self._sequence_key is not None:
             warnings.warn(
-                f"There is an existing sequence key {self._sequence_key}."
+                f'There is an existing sequence key {self._sequence_key}.'
                 ' This key will be removed.'
             )
 

--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -98,7 +98,7 @@ class Table:
     _fields_metadata = None
     fitted = False
 
-    _ANONYMIZATION_MAPPINGS = dict()
+    _ANONYMIZATION_MAPPINGS = {}
     _TRANSFORMER_TEMPLATES = {
         'FloatFormatter': rdt.transformers.FloatFormatter(
             learn_rounding_scheme=True,
@@ -195,7 +195,7 @@ class Table:
         if isinstance(category, (tuple, list)):
             category, *args = category
         else:
-            args = tuple()
+            args = ()
 
         try:
             if args:
@@ -333,7 +333,7 @@ class Table:
             dict:
                 Dictionary that contains the field names and data types.
         """
-        dtypes = dict()
+        dtypes = {}
         for name, field_meta in self._fields_metadata.items():
             field_type = field_meta['type']
 
@@ -357,7 +357,7 @@ class Table:
             ValueError:
                 If a column from the data analyzed is an unsupported data type
         """
-        fields_metadata = dict()
+        fields_metadata = {}
         for field_name in self._field_names:
             if field_name not in data:
                 raise ValueError('Field {} not found in given data'.format(field_name))
@@ -400,7 +400,7 @@ class Table:
             dict:
                 mapping of field names and transformer instances.
         """
-        transformers = dict()
+        transformers = {}
         for name, dtype in dtypes.items():
             field_metadata = self._fields_metadata.get(name, {})
             transformer_template = field_metadata.get(

--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -718,7 +718,7 @@ class Table:
             if field_metadata['type'] == 'numerical' and field_metadata['subtype'] == 'integer':
                 field_data = field_data.round()
 
-            reversed_data[name] = field_data[field_data.notnull()].astype(self._dtypes[name])
+            reversed_data[name] = field_data[field_data.notna()].astype(self._dtypes[name])
 
         return reversed_data[self._field_names]
 

--- a/sdv/metadata/table.py
+++ b/sdv/metadata/table.py
@@ -12,7 +12,7 @@ from faker import Faker
 
 from sdv.constraints import Constraint
 from sdv.constraints.errors import (
-    FunctionError, MissingConstraintColumnError, MultipleConstraintsErrors)
+    AggregateConstraintsError, FunctionError, MissingConstraintColumnError)
 from sdv.metadata.errors import InvalidMetadataError, MetadataNotFittedError
 from sdv.metadata.utils import strings_from_regex
 
@@ -434,7 +434,7 @@ class Table:
                 errors.append(e)
 
         if errors:
-            raise MultipleConstraintsErrors(errors)
+            raise AggregateConstraintsError(errors)
 
     def _transform_constraints(self, data, is_condition=False):
         errors = []
@@ -468,7 +468,7 @@ class Table:
                 errors.append(e)
 
         if errors:
-            raise MultipleConstraintsErrors(errors)
+            raise AggregateConstraintsError(errors)
 
         return data
 

--- a/sdv/metadata/visualization.py
+++ b/sdv/metadata/visualization.py
@@ -124,9 +124,9 @@ def visualize(metadata, path=None, names=True, details=True):
         'Metadata',
         format=graphviz_extension,
         node_attr={
-            "shape": "Mrecord",
-            "fillcolor": "lightgoldenrod1",
-            "style": "filled"
+            'shape': 'Mrecord',
+            'fillcolor': 'lightgoldenrod1',
+            'style': 'filled'
         },
     )
 
@@ -177,9 +177,9 @@ def visualize_graph(nodes, edges, path=None):
         'Metadata',
         format=graphviz_extension,
         node_attr={
-            "shape": "Mrecord",
-            "fillcolor": "lightgoldenrod1",
-            "style": "filled"
+            'shape': 'Mrecord',
+            'fillcolor': 'lightgoldenrod1',
+            'style': 'filled'
         },
     )
 

--- a/sdv/relational/base.py
+++ b/sdv/relational/base.py
@@ -205,7 +205,7 @@ class BaseRelationalModel:
                 Path from which to load the instance.
         """
         with open(path, 'rb') as f:
-            model = pickle.load(f)
+            model = pickle.load(f)  # noqa: DUO103
             throw_version_mismatch_warning(getattr(model, '_package_versions', None))
 
             return model

--- a/sdv/relational/base.py
+++ b/sdv/relational/base.py
@@ -37,8 +37,8 @@ class BaseRelationalModel:
         else:
             self.metadata = Metadata(metadata, root_path)
 
-        self._primary_key_generators = dict()
-        self._remaining_primary_keys = dict()
+        self._primary_key_generators = {}
+        self._remaining_primary_keys = {}
 
     def _fit(self, tables=None):
         """Fit this relational model instance to the dataset data.
@@ -65,8 +65,8 @@ class BaseRelationalModel:
 
     def _reset_primary_keys_generators(self):
         """Reset the primary key generators."""
-        self._primary_key_generators = dict()
-        self._remaining_primary_keys = dict()
+        self._primary_key_generators = {}
+        self._remaining_primary_keys = {}
 
     def _get_primary_keys(self, table_name, num_rows):
         """Return the primary key and amount of values for the requested table.

--- a/sdv/relational/hma.py
+++ b/sdv/relational/hma.py
@@ -74,7 +74,7 @@ class HMA1(BaseRelationalModel):
         """
         table_meta = self._models[child_name].get_metadata()
 
-        extension_rows = list()
+        extension_rows = []
         foreign_key_values = child_table[foreign_key].unique()
         child_table = child_table.set_index(foreign_key)
         child_primary = self.metadata.get_primary_key(child_name)
@@ -301,7 +301,7 @@ class HMA1(BaseRelationalModel):
             pandas.DataFrame:
                 Formatted synthesized data.
         """
-        final_data = dict()
+        final_data = {}
         for table_name, table_rows in sampled_data.items():
             parents = self.metadata.get_parents(table_name)
             if parents:
@@ -486,7 +486,7 @@ class HMA1(BaseRelationalModel):
             pandas.DataFrame:
                 A DataFrame of the likelihood of each parent id.
         """
-        likelihoods = dict()
+        likelihoods = {}
         for parent_id, row in parent_rows.iterrows():
             parameters = self._extract_parameters(row, table_name, foreign_key)
             table_meta = self._models[table_name].get_metadata()
@@ -589,7 +589,7 @@ class HMA1(BaseRelationalModel):
 
             return sampled_data[table_name]
 
-        sampled_data = dict()
+        sampled_data = {}
         for table in self.metadata.get_tables():
             if not self.metadata.get_parents(table):
                 self._sample_table(table, num_rows, sampled_data=sampled_data)

--- a/sdv/sdv.py
+++ b/sdv/sdv.py
@@ -162,7 +162,7 @@ class SDV:
                 Path from which to load the SDV instance.
         """
         with open(path, 'rb') as f:
-            model = pickle.load(f)
+            model = pickle.load(f)  # noqa: DUO103
             throw_version_mismatch_warning(getattr(model, '_package_versions', None))
 
             return model

--- a/sdv/sdv.py
+++ b/sdv/sdv.py
@@ -42,7 +42,7 @@ class SDV:
                 model_kwargs = self.DEFAULT_MODEL_KWARGS
 
         self._model = model
-        self._model_kwargs = (model_kwargs or dict()).copy()
+        self._model_kwargs = (model_kwargs or {}).copy()
 
     def fit(self, metadata, tables=None, root_path=None):
         """Fit this SDV instance to the dataset data.

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -594,7 +594,7 @@ class BaseTabularModel:
         grouped_conditions = conditions.groupby(condition_columns)
 
         # sample
-        all_sampled_rows = list()
+        all_sampled_rows = []
 
         for group, dataframe in grouped_conditions:
             if not isinstance(group, tuple):

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -411,8 +411,10 @@ class BaseTabularModel:
         else:
             # Didn't get any rows.
             if not graceful_reject_sampling:
-                user_msg = ('Unable to sample any rows for the given conditions '
-                            f'`{transformed_condition}`. ')
+                user_msg = (
+                    'Unable to sample any rows for the given conditions '
+                    f'`{transformed_condition}`. '
+                )
                 if hasattr(self, '_model') and isinstance(
                         self._model, copulas.multivariate.GaussianMultivariate):
                     user_msg = user_msg + (

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -886,7 +886,7 @@ class BaseTabularModel:
                 The loaded tabular model.
         """
         with open(path, 'rb') as f:
-            model = pickle.load(f)
+            model = pickle.load(f)  # noqa: DUO103
             throw_version_mismatch_warning(getattr(model, '_package_versions', None))
 
             return model

--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -406,7 +406,7 @@ class BaseTabularModel:
         )
 
         if len(sampled_rows) > 0:
-            sampled_rows[COND_IDX] = dataframe[COND_IDX].values[:len(sampled_rows)]
+            sampled_rows[COND_IDX] = dataframe[COND_IDX].to_numpy()[:len(sampled_rows)]
 
         else:
             # Didn't get any rows.
@@ -590,7 +590,7 @@ class BaseTabularModel:
         """
         condition_columns = list(conditions.columns)
         conditions.index.name = COND_IDX
-        conditions.reset_index(inplace=True)
+        conditions = conditions.reset_index()
         grouped_conditions = conditions.groupby(condition_columns)
 
         # sample
@@ -856,7 +856,7 @@ class BaseTabularModel:
                 using a simple dictionary.
         """
         num_rows = parameters.pop('num_rows')
-        self._num_rows = 0 if pd.isnull(num_rows) else max(0, int(round(num_rows)))
+        self._num_rows = 0 if pd.isna(num_rows) else max(0, int(round(num_rows)))
 
         if self._metadata.get_dtypes(ids=False):
             self._set_parameters(parameters)

--- a/sdv/tabular/copulagan.py
+++ b/sdv/tabular/copulagan.py
@@ -158,7 +158,7 @@ class CopulaGAN(CTGAN):
             learn_rounding_scheme=learn_rounding_scheme,
             enforce_min_max_values=enforce_min_max_values,
         )
-        self._field_distributions = field_distributions or dict()
+        self._field_distributions = field_distributions or {}
         self._default_distribution = default_distribution or self.DEFAULT_DISTRIBUTION
 
     def get_distributions(self):
@@ -191,7 +191,7 @@ class CopulaGAN(CTGAN):
 
             if field_name in fields and fields.get(
                 field_name,
-                dict(),
+                {},
             ).get('type') != 'categorical':
                 transformers[field] = GaussianNormalizer(
                     model_missing_values=True,

--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -300,7 +300,7 @@ class GaussianCopula(BaseTabularModel):
 
         params = self._model.to_dict()
 
-        covariance = list()
+        covariance = []
         for index, row in enumerate(params['covariance'][1:]):
             covariance.append(row[:index + 1])
 
@@ -403,8 +403,8 @@ class GaussianCopula(BaseTabularModel):
             dict:
                 Model parameters ready to recreate the model.
         """
-        columns = list()
-        univariates = list()
+        columns = []
+        univariates = []
         for column, univariate in model_parameters['univariates'].items():
             columns.append(column)
             univariate['type'] = self._field_distributions[column]

--- a/sdv/tabular/copulas.py
+++ b/sdv/tabular/copulas.py
@@ -296,7 +296,7 @@ class GaussianCopula(BaseTabularModel):
                 univariate = univariate._instance
 
             if univariate.PARAMETRIC == copulas.univariate.ParametricType.NON_PARAMETRIC:
-                raise NonParametricError("This GaussianCopula uses non parametric distributions")
+                raise NonParametricError('This GaussianCopula uses non parametric distributions')
 
         params = self._model.to_dict()
 

--- a/sdv/tabular/utils.py
+++ b/sdv/tabular/utils.py
@@ -168,6 +168,7 @@ def handle_sampling_error(is_tmp_file, output_file_path, sampling_error):
 
     if error_msg:
         raise type(sampling_error)(error_msg + '\n' + str(sampling_error))
+
     raise sampling_error
 
 

--- a/sdv/tabular/utils.py
+++ b/sdv/tabular/utils.py
@@ -154,14 +154,20 @@ def handle_sampling_error(is_tmp_file, output_file_path, sampling_error):
     if 'Unable to sample any rows for the given conditions' in str(sampling_error):
         raise sampling_error
 
+    error_msg = None
     if is_tmp_file:
-        print('Error: Sampling terminated. Partial results are stored in a temporary file: '
-              f'{output_file_path}. This file will be overridden the next time you sample. '
-              'Please rename the file if you wish to save these results.')
+        error_msg = (
+            'Error: Sampling terminated. Partial results are stored in a temporary file: '
+            f'{output_file_path}. This file will be overridden the next time you sample. '
+            'Please rename the file if you wish to save these results.'
+        )
     elif output_file_path is not None:
-        print('Error: Sampling terminated. '
-              f'Partial results are stored in {output_file_path}.')
+        error_msg = (
+            f'Error: Sampling terminated. Partial results are stored in {output_file_path}.'
+        )
 
+    if error_msg:
+        raise type(sampling_error)(error_msg + '\n' + str(sampling_error))
     raise sampling_error
 
 

--- a/sdv/tabular/utils.py
+++ b/sdv/tabular/utils.py
@@ -20,7 +20,7 @@ def flatten_array(nested, prefix=''):
         dict:
             Flattened array.
     """
-    result = dict()
+    result = {}
     for index in range(len(nested)):
         prefix_key = '__'.join([prefix, str(index)]) if len(prefix) else str(index)
 
@@ -53,7 +53,7 @@ def flatten_dict(nested, prefix=''):
         dict:
             Flattened dictionary.
     """
-    result = dict()
+    result = {}
 
     for key, value in nested.items():
         prefix_key = '__'.join([prefix, str(key)]) if len(prefix) else key
@@ -74,7 +74,7 @@ def flatten_dict(nested, prefix=''):
 
 
 def _key_order(key_value):
-    parts = list()
+    parts = []
     for part in key_value[0].split('__'):
         if part.isdigit():
             part = int(part)
@@ -95,7 +95,7 @@ def unflatten_dict(flat):
         dict:
             Nested dict (if corresponds)
     """
-    unflattened = dict()
+    unflattened = {}
 
     for key, value in sorted(flat.items(), key=_key_order):
         if '__' in key:
@@ -106,10 +106,10 @@ def unflatten_dict(flat):
                 column_index = int(name)
                 row_index = int(subkey)
 
-                array = unflattened.setdefault(key, list())
+                array = unflattened.setdefault(key, [])
 
                 if len(array) == row_index:
-                    row = list()
+                    row = []
                     array.append(row)
                 elif len(array) == row_index + 1:
                     row = array[row_index]
@@ -124,11 +124,11 @@ def unflatten_dict(flat):
                     raise ValueError('There was an error unflattening the extension.')
 
             else:
-                subdict = unflattened.setdefault(key, dict())
+                subdict = unflattened.setdefault(key, {})
                 if subkey.isdigit():
                     subkey = int(subkey)
 
-                inner = subdict.setdefault(subkey, dict())
+                inner = subdict.setdefault(subkey, {})
                 inner[name] = value
 
         else:

--- a/sdv/timeseries/base.py
+++ b/sdv/timeseries/base.py
@@ -292,7 +292,7 @@ class BaseTimeseriesModel:
                 The loaded tabular model.
         """
         with open(path, 'rb') as f:
-            model = pickle.load(f)
+            model = pickle.load(f)  # noqa: DUO103
             throw_version_mismatch_warning(getattr(model, '_package_versions', None))
 
             return model

--- a/sdv/timeseries/deepecho.py
+++ b/sdv/timeseries/deepecho.py
@@ -62,8 +62,8 @@ class DeepEchoModel(BaseTimeseriesModel):
             drop_sequence_index=False
         )
 
-        data_types = list()
-        context_types = list()
+        data_types = []
+        context_types = []
         for field in self._output_columns:
             dtype = timeseries_data[field].dtype
             kind = dtype.kind
@@ -110,7 +110,7 @@ class DeepEchoModel(BaseTimeseriesModel):
 
         iterator = tqdm.tqdm(context.iterrows(), disable=not self._verbose, total=len(context))
 
-        output = list()
+        output = []
         for entity_values, context_values in iterator:
             context_values = context_values.tolist()
             sequence = self._model.sample_sequence(context_values, sequence_length)

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -91,8 +91,10 @@ def throw_version_mismatch_warning(package_versions):
     Side Effects:
         A warning is thrown if there is a mismatch.
     """
-    warning_str = ('The libraries used to create the model have older versions '
-                   'than your current setup. This may cause errors when sampling.')
+    warning_str = (
+        'The libraries used to create the model have older versions '
+        'than your current setup. This may cause errors when sampling.'
+    )
 
     if package_versions is None:
         warnings.warn(warning_str)
@@ -106,8 +108,10 @@ def throw_version_mismatch_warning(package_versions):
             current_version = ''
 
         if current_version != version:
-            mismatched_details += (f'\n{lib} used version `{version}`; '
-                                   f'current version is `{current_version}`')
+            mismatched_details += (
+                f'\n{lib} used version `{version}`; '
+                f'current version is `{current_version}`'
+            )
 
     if len(mismatched_details) > 0:
         warnings.warn(f'{warning_str}{mismatched_details}')

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,8 @@ universal = 1
 
 [flake8]
 max-line-length = 99
+inline-quotes = single
+extend-ignore = D107, SFS3, PD005
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
 ignore = D105, D107, W503, SFS2, SFS3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,8 @@ test = pytest
 collect_ignore = ['setup.py']
 
 [pydocstyle]
-ignore = D105, D107, D407, D203, D213, D413, D406, D417
+convention = google
+add-ignore = D105, D107, D407, D203, D213, D413, D406, D417
 
 [pylint]
 persistent = no

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ development_requires = [
     'flake8-docstrings>=1.5.0,<2',
     'flake8-variables-names>=0.0.4,<0.1',
     'flake8-multiline-containers>=0.0.18,<0.1',
+    'flake8-expression-complexity>=0.0.9,<0.1',
     'flake8-sfs>=0.0.3,<0.1',
     'flake8-quotes>=3.3.0,<4',
     'dlint>=0.11.0,<0.12',

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ development_requires = [
     'pandas-vet>=0.2.3,<0.3',
     'isort>=4.3.4,<5',
     'pydocstyle>=6.1.1,<6.2',
+    'flake8-pytest-style>=1.5.0,<2',
 
     # fix style issues
     'autoflake>=1.1,<2',

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ development_requires = [
     'flake8-absolute-import>=1.0,<2',
     'flake8-comprehensions>=3.6.1,<3.7',
     'flake8-docstrings>=1.5.0,<2',
+    'flake8-variables-names>=0.0.4,<0.1',
     'flake8-sfs>=0.0.3,<0.1',
     'dlint>=0.11.0,<0.12',
     'pandas-vet>=0.2.3,<0.3',

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ development_requires = [
     'dlint>=0.11.0,<0.12',
     'pandas-vet>=0.2.3,<0.3',
     'isort>=4.3.4,<5',
+    'pydocstyle>=6.1.1,<6.2',
 
     # fix style issues
     'autoflake>=1.1,<2',

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ development_requires = [
     'flake8-comprehensions>=3.6.1,<3.7',
     'flake8-docstrings>=1.5.0,<2',
     'flake8-sfs>=0.0.3,<0.1',
+    'dlint>=0.11.0,<0.12',
     'isort>=4.3.4,<5',
 
     # fix style issues

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ development_requires = [
     'flake8-docstrings>=1.5.0,<2',
     'flake8-sfs>=0.0.3,<0.1',
     'dlint>=0.11.0,<0.12',
+    'pandas-vet>=0.2.3,<0.3',
     'isort>=4.3.4,<5',
 
     # fix style issues

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ development_requires = [
     'isort>=4.3.4,<5',
     'pydocstyle>=6.1.1,<6.2',
     'flake8-pytest-style>=1.5.0,<2',
+    'pep8-naming>=0.12.1,<0.13',
     'flake8-debugger>=4.0.0,<4.1',
     'flake8-eradicate>=1.1.0,<1.2',
     'flake8-mock>=0.3,<0.4',

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ development_requires = [
     'flake8-comprehensions>=3.6.1,<3.7',
     'flake8-docstrings>=1.5.0,<2',
     'flake8-variables-names>=0.0.4,<0.1',
+    'flake8-multiline-containers>=0.0.18,<0.1',
     'flake8-sfs>=0.0.3,<0.1',
     'dlint>=0.11.0,<0.12',
     'pandas-vet>=0.2.3,<0.3',

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ development_requires = [
     # style check
     'flake8>=3.7.7,<4',
     'flake8-absolute-import>=1.0,<2',
+    'flake8-builtins>=1.5.3,<1.6',
     'flake8-comprehensions>=3.6.1,<3.7',
     'flake8-docstrings>=1.5.0,<2',
     'flake8-variables-names>=0.0.4,<0.1',

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ development_requires = [
     'flake8-variables-names>=0.0.4,<0.1',
     'flake8-multiline-containers>=0.0.18,<0.1',
     'flake8-sfs>=0.0.3,<0.1',
+    'flake8-quotes>=3.3.0,<4',
     'dlint>=0.11.0,<0.12',
     'pandas-vet>=0.2.3,<0.3',
     'isort>=4.3.4,<5',

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,15 @@ development_requires = [
     'isort>=4.3.4,<5',
     'pydocstyle>=6.1.1,<6.2',
     'flake8-pytest-style>=1.5.0,<2',
+    'flake8-debugger>=4.0.0,<4.1',
+    'flake8-eradicate>=1.1.0,<1.2',
+    'flake8-mock>=0.3,<0.4',
+    'flake8-fixme>=1.1.1,<1.2',
+    'flake8-mutable>=1.2.0,<1.3',
+    'flake8-print>=4.0.0,<4.1',
+    'flake8-docstrings>=1.5.0,<2',
+    'isort>=4.3.4,<5',
+    'pylint>=2.5.3,<3',
 
     # fix style issues
     'autoflake>=1.1,<2',

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ development_requires = [
     # style check
     'flake8>=3.7.7,<4',
     'flake8-absolute-import>=1.0,<2',
+    'flake8-comprehensions>=3.6.1,<3.7',
     'flake8-docstrings>=1.5.0,<2',
     'flake8-sfs>=0.0.3,<0.1',
     'isort>=4.3.4,<5',

--- a/tests/integration/constraints/test_tabular.py
+++ b/tests/integration/constraints/test_tabular.py
@@ -8,15 +8,23 @@ from sdv.sampling.tabular import Condition
 from sdv.tabular import GaussianCopula
 
 
+def _is_valid(_, data):
+    return pd.Series([True if data_i > 0 else False for data_i in data['col']])
+
+
+def _reverse_transform(_, data):
+    return pd.DataFrame({'col': data['col'] ** .5})
+
+
 def test_create_custom_constraint():
     """Test the ``create_custom_constraint`` method end to end."""
     # Setup
+    def _transform(_, data):
+        return pd.DataFrame({'col': data['col'] ** 2})
+
     custom_constraint = create_custom_constraint(
-        lambda _, x: pd.Series([True if x_i > 0 else False for x_i in x['col']]),
-        lambda _, x: pd.DataFrame({'col': x['col'] ** 2}),
-        lambda _, x: pd.DataFrame({'col': x['col'] ** .5})
-    )
-    custom_constraint = custom_constraint('col')
+        _is_valid, _transform, _reverse_transform
+    )('col')
     data = pd.DataFrame({'col': np.random.randint(1, 10, size=100)})
     gc = GaussianCopula(constraints=[custom_constraint])
     gc.fit(data)
@@ -33,13 +41,12 @@ def test_invalid_create_custom_constraint():
 
     It should correctly sample the synthetic data through reject sample.
     """
-    # Setup
+    def _bad_transform(_, data):
+        return pd.DataFrame({'col': [10 / 0] * 100})
+
     custom_constraint = create_custom_constraint(
-        lambda _, x: pd.Series([True if x_i > 0 else False for x_i in x['col']]),
-        lambda _: pd.DataFrame({'col': [10 / 0] * 100}),
-        lambda _, x: pd.DataFrame({'col': x['col'] ** .5})
-    )
-    custom_constraint = custom_constraint('col')
+        _is_valid, _bad_transform, _reverse_transform
+    )('col')
     data = pd.DataFrame({'col': np.random.randint(1, 10, size=100)})
     gc = GaussianCopula(constraints=[custom_constraint])
     gc.fit(data)

--- a/tests/integration/constraints/test_tabular.py
+++ b/tests/integration/constraints/test_tabular.py
@@ -58,7 +58,7 @@ def test_invalid_create_custom_constraint():
     assert all(sampled > 0)
 
 
-def test_FixedIncrements():
+def test_fixed_increments():
     """Test the ``FixedIncrements`` constraint end to end."""
     # Setup
     values = np.random.randint(1, 10, size=20) * 5
@@ -74,7 +74,7 @@ def test_FixedIncrements():
     assert all(sampled % 5 == 0)
 
 
-def test_Inequality():
+def test_inequality():
     """Test the ``Inequality`` constraint end to end."""
     # Setup
     data = pd.DataFrame({
@@ -92,7 +92,7 @@ def test_Inequality():
     assert all(sampled['low'] <= sampled['high'])
 
 
-def test_ScalarInequality():
+def test_scalar_inequality():
     """Test the ``ScalarInequality`` constraint end to end."""
     # Setup
     data = pd.DataFrame({
@@ -109,7 +109,7 @@ def test_ScalarInequality():
     assert all(sampled['low'] < 11)
 
 
-def test_Range():
+def test_range():
     """Test the ``Range`` constraint end to end."""
     # Setup
     data = pd.DataFrame({
@@ -135,7 +135,7 @@ def test_Range():
     assert sampled.middle_column.max() <= sampled.high_column.max()
 
 
-def test_ScalarRange():
+def test_scalar_range():
     """Test the ``ScalarRange`` constraint end to end."""
     # Setup
     data = pd.DataFrame({
@@ -159,7 +159,7 @@ def test_ScalarRange():
     assert sampled.column.max() <= 11
 
 
-def test_ScalarRange_conditions():
+def test_scalar_range_conditions():
     """Test ``ScalarRange`` with conditions.
 
     This test ensures that the conditions are not altered by the constraint transformation.

--- a/tests/integration/constraints/test_tabular.py
+++ b/tests/integration/constraints/test_tabular.py
@@ -160,7 +160,7 @@ def test_ScalarRange_conditions():
     # Setup
     constraint = ScalarRange(column_name='input', low_value=49, high_value=100)
     data = pd.DataFrame({
-        'input': [_ for _ in range(50, 80)],
+        'input': list(range(50, 80)),
         'output': [np.random.rand() for _ in range(30)]
     })
     condition = Condition({'input': 88}, num_rows=10)

--- a/tests/integration/constraints/test_tabular.py
+++ b/tests/integration/constraints/test_tabular.py
@@ -15,8 +15,8 @@ def test_create_custom_constraint():
         lambda _, x: pd.Series([True if x_i > 0 else False for x_i in x['col']]),
         lambda _, x: pd.DataFrame({'col': x['col'] ** 2}),
         lambda _, x: pd.DataFrame({'col': x['col'] ** .5})
-    )('col')
-
+    )
+    custom_constraint = custom_constraint('col')
     data = pd.DataFrame({'col': np.random.randint(1, 10, size=100)})
     gc = GaussianCopula(constraints=[custom_constraint])
     gc.fit(data)
@@ -38,8 +38,8 @@ def test_invalid_create_custom_constraint():
         lambda _, x: pd.Series([True if x_i > 0 else False for x_i in x['col']]),
         lambda _: pd.DataFrame({'col': [10 / 0] * 100}),
         lambda _, x: pd.DataFrame({'col': x['col'] ** .5})
-    )('col')
-
+    )
+    custom_constraint = custom_constraint('col')
     data = pd.DataFrame({'col': np.random.randint(1, 10, size=100)})
     gc = GaussianCopula(constraints=[custom_constraint])
     gc.fit(data)

--- a/tests/integration/metadata/test_table.py
+++ b/tests/integration/metadata/test_table.py
@@ -59,14 +59,14 @@ def test_table():
     assert sampled_ssn.dtype == 'object'
     assert sampled_ssn.str.match(ssn_regex).all()
 
-    sampled_company_US = reverse_transformed['company_US']
-    assert sampled_company_US.dtype == 'object'
+    sampled_company_us = reverse_transformed['company_US']
+    assert sampled_company_us.dtype == 'object'
     # Check that all companies are sampled from the `en_US` locale
-    assert ((sampled_company_US > u'\u0000') & (sampled_company_US < u'\u007F')).all()
+    assert ((sampled_company_us > u'\u0000') & (sampled_company_us < u'\u007F')).all()
 
-    sampled_company_US_CN = reverse_transformed['company_US_CN']
-    assert sampled_company_US_CN.dtype == 'object'
+    sampled_company_us_cn = reverse_transformed['company_US_CN']
+    assert sampled_company_us_cn.dtype == 'object'
     # Check that we have sampled companies from the `en_US` locale
-    assert ((sampled_company_US_CN > u'\u0000') & (sampled_company_US_CN < u'\u007F')).any()
+    assert ((sampled_company_us_cn > u'\u0000') & (sampled_company_us_cn < u'\u007F')).any()
     # Check that we have sampled companies from the `zh_CH` locale
-    assert ((sampled_company_US_CN > u'\u4e00') & (sampled_company_US_CN < u'\u9fff')).any()
+    assert ((sampled_company_us_cn > u'\u4e00') & (sampled_company_us_cn < u'\u9fff')).any()

--- a/tests/integration/tabular/test_base.py
+++ b/tests/integration/tabular/test_base.py
@@ -78,7 +78,7 @@ def test_conditional_sampling_graceful_reject_sampling_True_dict(model):
         })
     ]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         model.sample_conditions(conditions=conditions)
 
 

--- a/tests/integration/tabular/test_base.py
+++ b/tests/integration/tabular/test_base.py
@@ -62,7 +62,7 @@ def test___init___copies_metadata():
 
 
 @pytest.mark.parametrize('model', MODELS)
-def test_conditional_sampling_graceful_reject_sampling_True_dict(model):
+def test_conditional_sampling_graceful_reject_sampling_true_dict(model):
     data = pd.DataFrame({
         'column1': list(range(100)),
         'column2': list(range(100)),
@@ -83,7 +83,7 @@ def test_conditional_sampling_graceful_reject_sampling_True_dict(model):
 
 
 @pytest.mark.parametrize('model', MODELS)
-def test_conditional_sampling_graceful_reject_sampling_True_dataframe(model):
+def test_conditional_sampling_graceful_reject_sampling_true_dataframe(model):
     data = pd.DataFrame({
         'column1': list(range(100)),
         'column2': list(range(100)),
@@ -349,7 +349,7 @@ def test_sample_conditions_with_batch_size():
 
 
 @pytest.mark.parametrize('model', MODELS)
-def test_sampling_with_randomize_samples_True(model):
+def test_sampling_with_randomize_samples_true(model):
     data = pd.DataFrame({
         'column1': list(range(100)),
         'column2': list(range(100)),
@@ -365,7 +365,7 @@ def test_sampling_with_randomize_samples_True(model):
 
 
 @pytest.mark.parametrize('model', MODELS)
-def test_sampling_with_randomize_samples_False(model):
+def test_sampling_with_randomize_samples_false(model):
     data = pd.DataFrame({
         'column1': list(range(100)),
         'column2': list(range(100)),

--- a/tests/integration/tabular/test_base.py
+++ b/tests/integration/tabular/test_base.py
@@ -120,23 +120,23 @@ def test_fit_with_unique_constraint_on_data_with_only_index_column():
     """
     # Setup
     test_df = pd.DataFrame({
-        "key": [
+        'key': [
             1,
             2,
             3,
             4,
             5,
         ],
-        "index": [
-            "A",
-            "B",
-            "C",
-            "D",
-            "E",
+        'index': [
+            'A',
+            'B',
+            'C',
+            'D',
+            'E',
         ]
     })
-    unique = Unique(column_names=["index"])
-    model = GaussianCopula(primary_key="key", constraints=[unique])
+    unique = Unique(column_names=['index'])
+    model = GaussianCopula(primary_key='key', constraints=[unique])
 
     # Run
     model.fit(test_df)
@@ -144,7 +144,7 @@ def test_fit_with_unique_constraint_on_data_with_only_index_column():
 
     # Assert
     assert len(samples) == 2
-    assert samples["index"].is_unique
+    assert samples['index'].is_unique
 
 
 def test_fit_with_unique_constraint_on_data_which_has_index_column():
@@ -167,30 +167,30 @@ def test_fit_with_unique_constraint_on_data_which_has_index_column():
     """
     # Setup
     test_df = pd.DataFrame({
-        "key": [
+        'key': [
             1,
             2,
             3,
             4,
             5,
         ],
-        "index": [
-            "A",
-            "B",
-            "C",
-            "D",
-            "E",
+        'index': [
+            'A',
+            'B',
+            'C',
+            'D',
+            'E',
         ],
-        "test_column": [
-            "A1",
-            "B2",
-            "C3",
-            "D4",
-            "E5",
+        'test_column': [
+            'A1',
+            'B2',
+            'C3',
+            'D4',
+            'E5',
         ]
     })
-    unique = Unique(column_names=["test_column"])
-    model = GaussianCopula(primary_key="key", constraints=[unique])
+    unique = Unique(column_names=['test_column'])
+    model = GaussianCopula(primary_key='key', constraints=[unique])
 
     # Run
     model.fit(test_df)
@@ -198,7 +198,7 @@ def test_fit_with_unique_constraint_on_data_which_has_index_column():
 
     # Assert
     assert len(samples) == 2
-    assert samples["test_column"].is_unique
+    assert samples['test_column'].is_unique
 
 
 def test_fit_with_unique_constraint_on_data_subset():
@@ -221,27 +221,27 @@ def test_fit_with_unique_constraint_on_data_subset():
     """
     # Setup
     test_df = pd.DataFrame({
-        "key": [
+        'key': [
             1,
             2,
             3,
             4,
             5,
         ],
-        "test_column": [
-            "A",
-            "B",
-            "C",
-            "D",
-            "E",
+        'test_column': [
+            'A',
+            'B',
+            'C',
+            'D',
+            'E',
         ]
     })
     unique = Unique(
-        column_names=["test_column"]
+        column_names=['test_column']
     )
 
     test_df = test_df.iloc[[1, 3, 4]]
-    model = GaussianCopula(primary_key="key", constraints=[unique])
+    model = GaussianCopula(primary_key='key', constraints=[unique])
 
     # Run
     model.fit(test_df)
@@ -249,7 +249,7 @@ def test_fit_with_unique_constraint_on_data_subset():
 
     # Assert
     assert len(samples) == 2
-    assert samples["test_column"].is_unique
+    assert samples['test_column'].is_unique
 
 
 @patch('sdv.tabular.base.isinstance')

--- a/tests/integration/tabular/test_base.py
+++ b/tests/integration/tabular/test_base.py
@@ -70,11 +70,13 @@ def test_conditional_sampling_graceful_reject_sampling_True_dict(model):
     })
 
     model.fit(data)
-    conditions = [Condition({
-        'column1': 28,
-        'column2': 37,
-        'column3': 93
-    })]
+    conditions = [
+        Condition({
+            'column1': 28,
+            'column2': 37,
+            'column3': 93
+        })
+    ]
 
     with pytest.raises(ValueError):
         model.sample_conditions(conditions=conditions)
@@ -281,13 +283,16 @@ def test_conditional_sampling_constraint_uses_reject_sampling(gm_mock, isinstanc
         'age': [27, 28, 26, 21, 30]
     })
     model = GaussianCopula(constraints=[constraint], categorical_transformer='LabelEncoder')
-    sampled_numeric_data = [pd.DataFrame({
-        'city#state.value': [0, 1, 2, 0, 0],
-        'age.value': [30, 30, 30, 30, 30]
-    }), pd.DataFrame({
-        'city#state.value': [1],
-        'age.value': [30]
-    })]
+    sampled_numeric_data = [
+        pd.DataFrame({
+            'city#state.value': [0, 1, 2, 0, 0],
+            'age.value': [30, 30, 30, 30, 30]
+        }),
+        pd.DataFrame({
+            'city#state.value': [1],
+            'age.value': [30]
+        })
+    ]
     gm_mock.return_value.sample.side_effect = sampled_numeric_data
     model.fit(data)
 

--- a/tests/integration/tabular/test_copulagan.py
+++ b/tests/integration/tabular/test_copulagan.py
@@ -104,7 +104,7 @@ def test_conditional_sampling_dict():
     sampled = model.sample_conditions(conditions=conditions)
 
     assert sampled.shape == data.shape
-    assert set(sampled['column2'].unique()) == set(['b'])
+    assert set(sampled['column2'].unique()) == {'b'}
 
 
 def test_conditional_sampling_dataframe():

--- a/tests/integration/tabular/test_copulagan.py
+++ b/tests/integration/tabular/test_copulagan.py
@@ -69,7 +69,7 @@ def test_recreate():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
     # Metadata
     model_meta = CopulaGAN(epochs=1, table_metadata=model.get_metadata())
@@ -78,7 +78,7 @@ def test_recreate():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
     # Metadata dict
     model_meta_dict = CopulaGAN(epochs=1, table_metadata=model.get_metadata().to_dict())
@@ -87,7 +87,7 @@ def test_recreate():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
 
 def test_conditional_sampling_dict():

--- a/tests/integration/tabular/test_copulagan.py
+++ b/tests/integration/tabular/test_copulagan.py
@@ -98,9 +98,7 @@ def test_conditional_sampling_dict():
 
     model = CopulaGAN(epochs=1)
     model.fit(data)
-    conditions = [Condition({
-        'column2': 'b'
-    }, num_rows=30)]
+    conditions = [Condition({'column2': 'b'}, num_rows=30)]
     sampled = model.sample_conditions(conditions=conditions)
 
     assert sampled.shape == data.shape
@@ -133,10 +131,7 @@ def test_conditional_sampling_two_conditions():
 
     model = CopulaGAN(epochs=1)
     model.fit(data)
-    conditions = [Condition({
-        'column2': 'b',
-        'column3': 'f'
-    }, num_rows=5)]
+    conditions = [Condition({'column2': 'b', 'column3': 'f'}, num_rows=5)]
     samples = model.sample_conditions(conditions=conditions)
     assert list(samples.column2) == ['b'] * 5
     assert list(samples.column3) == ['f'] * 5
@@ -151,9 +146,7 @@ def test_conditional_sampling_numerical():
 
     model = CopulaGAN(epochs=1)
     model.fit(data)
-    conditions = [Condition({
-        'column1': 1.0,
-    }, num_rows=5)]
+    conditions = [Condition({'column1': 1.0}, num_rows=5)]
     sampled = model.sample_conditions(conditions=conditions)
 
     assert list(sampled.column1) == [1.0] * 5

--- a/tests/integration/tabular/test_copulas.py
+++ b/tests/integration/tabular/test_copulas.py
@@ -140,7 +140,7 @@ def test_recreate():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
     # Metadata
     model_meta = GaussianCopula(table_metadata=model.get_metadata())
@@ -149,7 +149,7 @@ def test_recreate():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
     # Metadata dict
     model_meta_dict = GaussianCopula(table_metadata=model.get_metadata().to_dict())
@@ -158,7 +158,7 @@ def test_recreate():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
 
 def test_ids_only():

--- a/tests/integration/tabular/test_copulas.py
+++ b/tests/integration/tabular/test_copulas.py
@@ -191,9 +191,7 @@ def test_conditional_sampling_dict():
 
     model = GaussianCopula()
     model.fit(data)
-    conditions = [Condition({
-        'column2': 'b'
-    }, num_rows=30)]
+    conditions = [Condition({'column2': 'b'}, num_rows=30)]
     sampled = model.sample_conditions(conditions=conditions)
 
     assert sampled.shape == data.shape
@@ -226,10 +224,7 @@ def test_conditional_sampling_two_conditions():
 
     model = GaussianCopula()
     model.fit(data)
-    conditions = [Condition({
-        'column2': 'b',
-        'column3': 'f'
-    }, num_rows=5)]
+    conditions = [Condition({'column2': 'b', 'column3': 'f'}, num_rows=5)]
     samples = model.sample_conditions(conditions=conditions)
     assert list(samples.column2) == ['b'] * 5
     assert list(samples.column3) == ['f'] * 5
@@ -244,9 +239,7 @@ def test_conditional_sampling_numerical():
 
     model = GaussianCopula()
     model.fit(data)
-    conditions = [Condition({
-        'column1': 1.0,
-    }, num_rows=5)]
+    conditions = [Condition({'column1': 1.0}, num_rows=5)]
     sampled = model.sample_conditions(conditions=conditions)
 
     assert list(sampled.column1) == [1.0] * 5

--- a/tests/integration/tabular/test_copulas.py
+++ b/tests/integration/tabular/test_copulas.py
@@ -197,7 +197,7 @@ def test_conditional_sampling_dict():
     sampled = model.sample_conditions(conditions=conditions)
 
     assert sampled.shape == data.shape
-    assert set(sampled['column2'].unique()) == set(['b'])
+    assert set(sampled['column2'].unique()) == {'b'}
 
 
 def test_conditional_sampling_dataframe():

--- a/tests/integration/tabular/test_ctgan.py
+++ b/tests/integration/tabular/test_ctgan.py
@@ -66,7 +66,7 @@ def test_recreate():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
     # Metadata
     model_meta = CTGAN(epochs=1, table_metadata=model.get_metadata())
@@ -75,7 +75,7 @@ def test_recreate():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
     # Metadata dict
     model_meta_dict = CTGAN(epochs=1, table_metadata=model.get_metadata().to_dict())
@@ -84,7 +84,7 @@ def test_recreate():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
 
 def test_conditional_sampling_dict():

--- a/tests/integration/tabular/test_ctgan.py
+++ b/tests/integration/tabular/test_ctgan.py
@@ -101,7 +101,7 @@ def test_conditional_sampling_dict():
     sampled = model.sample_conditions(conditions=conditions)
 
     assert sampled.shape == data.shape
-    assert set(sampled['column2'].unique()) == set(['b'])
+    assert set(sampled['column2'].unique()) == {'b'}
 
 
 def test_conditional_sampling_dataframe():

--- a/tests/integration/tabular/test_ctgan.py
+++ b/tests/integration/tabular/test_ctgan.py
@@ -95,9 +95,7 @@ def test_conditional_sampling_dict():
 
     model = CTGAN(epochs=1)
     model.fit(data)
-    conditions = [Condition({
-        'column2': 'b'
-    }, num_rows=30)]
+    conditions = [Condition({'column2': 'b'}, num_rows=30)]
     sampled = model.sample_conditions(conditions=conditions)
 
     assert sampled.shape == data.shape
@@ -130,10 +128,7 @@ def test_conditional_sampling_two_conditions():
 
     model = CTGAN(epochs=1)
     model.fit(data)
-    conditions = [Condition({
-        'column2': 'b',
-        'column3': 'f'
-    }, num_rows=5)]
+    conditions = [Condition({'column2': 'b', 'column3': 'f'}, num_rows=5)]
     samples = model.sample_conditions(conditions=conditions)
     assert list(samples.column2) == ['b'] * 5
     assert list(samples.column3) == ['f'] * 5
@@ -148,9 +143,7 @@ def test_conditional_sampling_numerical():
 
     model = CTGAN(epochs=1)
     model.fit(data)
-    conditions = [Condition({
-        'column1': 1.0,
-    }, num_rows=5)]
+    conditions = [Condition({'column1': 1.0}, num_rows=5)]
     sampled = model.sample_conditions(conditions=conditions)
 
     assert list(sampled.column1) == [1.0] * 5

--- a/tests/integration/tabular/test_tvae.py
+++ b/tests/integration/tabular/test_tvae.py
@@ -100,7 +100,7 @@ def test_conditional_sampling_dict():
     sampled = model.sample_conditions(conditions=conditions)
 
     assert sampled.shape == data.shape
-    assert set(sampled['column2'].unique()) == set(['b'])
+    assert set(sampled['column2'].unique()) == {'b'}
 
 
 def test_conditional_sampling_dataframe():

--- a/tests/integration/tabular/test_tvae.py
+++ b/tests/integration/tabular/test_tvae.py
@@ -94,9 +94,7 @@ def test_conditional_sampling_dict():
 
     model = TVAE(epochs=1)
     model.fit(data)
-    conditions = [Condition({
-        'column2': 'b'
-    }, num_rows=30)]
+    conditions = [Condition({'column2': 'b'}, num_rows=30)]
     sampled = model.sample_conditions(conditions=conditions)
 
     assert sampled.shape == data.shape
@@ -129,10 +127,12 @@ def test_conditional_sampling_two_conditions():
 
     model = TVAE(epochs=1)
     model.fit(data)
-    conditions = [Condition({
-        'column2': 'b',
-        'column3': 'f'
-    }, num_rows=5)]
+    conditions = [
+        Condition({
+            'column2': 'b',
+            'column3': 'f'
+        }, num_rows=5)
+    ]
     samples = model.sample_conditions(conditions=conditions, max_tries_per_batch=200)
     assert list(samples.column2) == ['b'] * 5
     assert list(samples.column3) == ['f'] * 5
@@ -147,9 +147,7 @@ def test_conditional_sampling_numerical():
 
     model = TVAE(epochs=1)
     model.fit(data)
-    conditions = [Condition({
-        'column1': 1.0,
-    }, num_rows=5)]
+    conditions = [Condition({'column1': 1.0}, num_rows=5)]
     sampled = model.sample_conditions(conditions=conditions)
 
     assert list(sampled.column1) == [1.0] * 5

--- a/tests/integration/tabular/test_tvae.py
+++ b/tests/integration/tabular/test_tvae.py
@@ -65,7 +65,7 @@ def test_recreate():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
     # Metadata
     model_meta = TVAE(epochs=1, table_metadata=model.get_metadata())
@@ -74,7 +74,7 @@ def test_recreate():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
     # Metadata dict
     model_meta_dict = TVAE(epochs=1, table_metadata=model.get_metadata().to_dict())
@@ -83,7 +83,7 @@ def test_recreate():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
 
 def test_conditional_sampling_dict():

--- a/tests/integration/test_constraints.py
+++ b/tests/integration/test_constraints.py
@@ -45,7 +45,7 @@ def test_constraints(tmpdir):
 def test_constraints_with_conditions():
     # Setup
     data = pd.DataFrame(data={
-        'low_col': [i for i in range(50)],
+        'low_col': list(range(50)),
         'mid_col': [i + 1 for i in range(50)],
         'high_col': [i + 2 for i in range(50)]
     })

--- a/tests/integration/test_constraints.py
+++ b/tests/integration/test_constraints.py
@@ -7,7 +7,7 @@ import pytest
 from sdv.constraints import (
     FixedCombinations, FixedIncrements, Inequality, Negative, OneHotEncoding, Positive, Range,
     ScalarInequality, ScalarRange, Unique)
-from sdv.constraints.errors import MultipleConstraintsErrors
+from sdv.constraints.errors import AggregateConstraintsError
 from sdv.constraints.tabular import create_custom_constraint
 from sdv.demo import load_tabular_demo
 from sdv.sampling import Condition
@@ -181,5 +181,5 @@ def test_failing_constraints():
         '\n2  70.0'
     )
 
-    with pytest.raises(MultipleConstraintsErrors, match=err_msg):
+    with pytest.raises(AggregateConstraintsError, match=err_msg):
         gc.fit(data)

--- a/tests/integration/test_evaluation.py
+++ b/tests/integration/test_evaluation.py
@@ -24,7 +24,7 @@ def test_evaluate_tables_from_demo():
 
     sampled = sdv.sample_all()
 
-    table_scores = dict()
+    table_scores = {}
     for table in new_meta.get_tables():
         table_scores[table] = evaluate(
             sampled[table], tables[table], metadata=new_meta, table_name=table)

--- a/tests/integration/timeseries/test_par.py
+++ b/tests/integration/timeseries/test_par.py
@@ -22,7 +22,7 @@ def test_par():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
     # Metadata
     model_meta = PAR(
@@ -35,7 +35,7 @@ def test_par():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
     # Metadata dict
     model_meta_dict = PAR(
@@ -48,7 +48,7 @@ def test_par():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
 
 def test_column_after_date_simple():
@@ -66,7 +66,7 @@ def test_column_after_date_simple():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()
 
 
 def test_column_after_date_complex():
@@ -87,4 +87,4 @@ def test_column_after_date_complex():
 
     assert sampled.shape == data.shape
     assert (sampled.dtypes == data.dtypes).all()
-    assert (sampled.notnull().sum(axis=1) != 0).all()
+    assert (sampled.notna().sum(axis=1) != 0).all()

--- a/tests/unit/constraints/test_base.py
+++ b/tests/unit/constraints/test_base.py
@@ -772,16 +772,14 @@ class TestColumnsModel:
         instance._model = Mock()
         transformed_conditions = [pd.DataFrame([[1], [1], [1], [1], [1]], columns=['b'])]
         instance._model.sample.side_effect = [
-            pd.DataFrame([
-                [1, 2],
-                [1, 3]
-            ], columns=['a', 'b']),
-            pd.DataFrame([
-                [1, 4],
-                [1, 5],
-                [1, 6],
-                [1, 7]
-            ], columns=['a', 'b']),
+            pd.DataFrame({
+                'a': [1, 1],
+                'b': [2, 3]
+            }),
+            pd.DataFrame({
+                'a': [1, 1, 1, 1],
+                'b': [4, 5, 6, 7]
+            })
         ]
         instance._hyper_transformer.transform.side_effect = transformed_conditions
         instance._hyper_transformer.reverse_transform = lambda x: x
@@ -790,13 +788,10 @@ class TestColumnsModel:
         transformed_data = instance._reject_sample(num_rows=5, conditions={'b': 1})
 
         # Assert
-        expected_result = pd.DataFrame([
-            [1, 2],
-            [1, 3],
-            [1, 4],
-            [1, 5],
-            [1, 6]
-        ], columns=['a', 'b'])
+        expected_result = pd.DataFrame({
+            'a': [1, 1, 1, 1, 1],
+            'b': [2, 3, 4, 5, 6]
+        })
         model_calls = instance._model.sample.mock_calls
         assert len(model_calls) == 2
         instance._model.sample.assert_any_call(num_rows=5, conditions={'b': 1})
@@ -804,13 +799,10 @@ class TestColumnsModel:
         pd.testing.assert_frame_equal(transformed_data, expected_result)
 
         expected_call_1 = pd.DataFrame({'a': [1, 1], 'b': [2, 3]})
-        expected_call_2 = pd.DataFrame([
-            [1, 4],
-            [1, 5],
-            [1, 6],
-            [1, 7]
-        ], columns=['a', 'b'])
-
+        expected_call_2 = pd.DataFrame({
+            'a': [1, 1, 1, 1],
+            'b': [4, 5, 6, 7]
+        })
         pd.testing.assert_frame_equal(expected_call_1, constraint.is_valid.call_args_list[0][0][0])
         pd.testing.assert_frame_equal(expected_call_2, constraint.is_valid.call_args_list[1][0][0])
 
@@ -843,12 +835,12 @@ class TestColumnsModel:
         instance._hyper_transformer = Mock()
         instance._model = Mock()
         transformed_conditions = [pd.DataFrame([[1], [1], [1], [1], [1]], columns=['b'])]
-        instance._model.sample.side_effect = [
-            pd.DataFrame([
-                [1, 2],
-                [1, 3]
-            ], columns=['a', 'b'])
-        ] + [pd.DataFrame()] * 100
+        instance._model.sample.side_effect = [pd.DataFrame()] * 100 + [
+            pd.DataFrame({
+                'a': [1, 1],
+                'b': [2, 3]
+            })
+        ]
         instance._hyper_transformer.transform.side_effect = transformed_conditions
         instance._hyper_transformer.reverse_transform = lambda x: x
 
@@ -856,13 +848,10 @@ class TestColumnsModel:
         transformed_data = instance._reject_sample(num_rows=5, conditions={'b': 1})
 
         # Assert
-        expected_result = pd.DataFrame([
-            [1, 2],
-            [1, 3],
-            [1, 2],
-            [1, 3],
-            [1, 2]
-        ], columns=['a', 'b'])
+        expected_result = pd.DataFrame({
+            'a': [1, 1, 1, 1, 1],
+            'b': [2, 3, 2, 3, 2]
+        })
         model_calls = instance._model.sample.mock_calls
         assert len(model_calls) == 101
         instance._model.sample.assert_any_call(num_rows=5, conditions={'b': 1})
@@ -897,12 +886,12 @@ class TestColumnsModel:
         instance._hyper_transformer = Mock()
         instance._model = Mock()
         transformed_conditions = [pd.DataFrame([[1], [1], [1], [1], [1]], columns=['b'])]
-        instance._model.sample.side_effect = [
-            pd.DataFrame([
-                [1, 2],
-                [1, 3]
-            ], columns=['a', 'b'])
-        ] + [pd.DataFrame()] * 100
+        instance._model.sample.side_effect = [pd.DataFrame()] * 100 + [
+            pd.DataFrame({
+                'a': [1, 1],
+                'b': [2, 3]
+            })
+        ]
         instance._hyper_transformer.transform.side_effect = transformed_conditions
         instance._hyper_transformer.reverse_transform = lambda x: x
 
@@ -939,13 +928,10 @@ class TestColumnsModel:
         instance._hyper_transformer.reverse_transform = lambda x: x
         instance._reject_sample = Mock()
         instance._reject_sample.side_effect = [
-            pd.DataFrame([
-                [1, 2],
-                [1, 3],
-                [1, 4],
-                [1, 5],
-                [1, 6],
-            ], columns=['a', 'b']),
+            pd.DataFrame({
+                'a': [1, 1, 1, 1, 1],
+                'b': [2, 3, 4, 5, 6]
+            })
         ]
 
         # Run
@@ -953,12 +939,9 @@ class TestColumnsModel:
         transformed_data = instance.sample(data)
 
         # Assert
-        expected_result = pd.DataFrame([
-            [1, 2],
-            [1, 3],
-            [1, 4],
-            [1, 5],
-            [1, 6]
-        ], columns=['a', 'b'])
+        expected_result = pd.DataFrame({
+            'a': [1, 1, 1, 1, 1],
+            'b': [2, 3, 4, 5, 6]
+        })
         instance._reject_sample.assert_any_call(num_rows=5, conditions={'b': 1})
         pd.testing.assert_frame_equal(transformed_data, expected_result)

--- a/tests/unit/constraints/test_base.py
+++ b/tests/unit/constraints/test_base.py
@@ -11,7 +11,7 @@ from sdv.constraints.base import (
     ColumnsModel, Constraint, _get_qualified_name, _module_contains_callable_name, get_subclasses,
     import_object)
 from sdv.constraints.errors import (
-    ConstraintMetadataError, MissingConstraintColumnError, MultipleConstraintsErrors)
+    AggregateConstraintsError, ConstraintMetadataError, MissingConstraintColumnError)
 from sdv.constraints.tabular import FixedCombinations
 from sdv.errors import ConstraintsNotMetError
 
@@ -166,14 +166,14 @@ class TestConstraint():
         The method should only raise errors if the input paramaters are invalid.
 
         Raise:
-            - ``MultipleConstraintsErrors`` if errors were found.
+            - ``AggregateConstraintsError`` if errors were found.
         """
         # Run
         Constraint._validate_inputs(args='value', kwargs='value')
 
         # Run / Assert
         err_msg = "Invalid values {'wrong_args'} are present in a Constraint constraint."
-        with pytest.raises(MultipleConstraintsErrors, match=err_msg):
+        with pytest.raises(AggregateConstraintsError, match=err_msg):
             Constraint._validate_inputs(args='value', kwargs='value', wrong_args='value')
 
     @patch('sdv.constraints.base.Constraint._validate_inputs')
@@ -196,11 +196,11 @@ class TestConstraint():
             - Mock for metadata
 
         Side effect:
-            - A MultipleConstraintsErrors error should be raised.
+            - A AggregateConstraintsError error should be raised.
         """
         # Setup
         validate_inputs_mock.side_effect = [
-            MultipleConstraintsErrors(errors=[ConstraintMetadataError('input errors')])
+            AggregateConstraintsError(errors=[ConstraintMetadataError('input errors')])
         ]
         validate_metadata_columns_mock.side_effect = [ConstraintMetadataError('column errors')]
         validate_metadata_specific_to_constraint_mock.side_effect = [
@@ -209,7 +209,7 @@ class TestConstraint():
 
         # Run
         error_message = re.escape('\ninput errors\n\nconstraint specific errors\n\ncolumn errors')
-        with pytest.raises(MultipleConstraintsErrors, match=error_message):
+        with pytest.raises(AggregateConstraintsError, match=error_message):
             Constraint._validate_metadata(Mock())
 
     def test_fit(self):

--- a/tests/unit/constraints/test_base.py
+++ b/tests/unit/constraints/test_base.py
@@ -391,11 +391,12 @@ class TestConstraint():
         # Setup
         instance = Constraint()
         instance._transform = Mock()
-        instance._transform.side_effect = Exception()
+        instance._transform.side_effect = Exception('Error.')
         data = pd.DataFrame({'a': [1, 2, 3]})
 
         # Run / Assert
-        with pytest.raises(Exception):
+        err_msg = 'Error.'
+        with pytest.raises(Exception, match=err_msg):
             instance.transform(data)
 
     def test_transform_columns_missing(self):

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -4366,7 +4366,7 @@ class TestFixedIncrements():
             - ``ValueError`` should be raised.
         """
         # Run / Assert
-        error_message = "The increment_value must be greater than 0."
+        error_message = 'The increment_value must be greater than 0.'
         with pytest.raises(ValueError, match=error_message):
             FixedIncrements(column_name='column', increment_value=-1)
 
@@ -4383,7 +4383,7 @@ class TestFixedIncrements():
             - ``ValueError`` should be raised.
         """
         # Run / Assert
-        error_message = "The increment_value must be a whole number."
+        error_message = 'The increment_value must be a whole number.'
         with pytest.raises(ValueError, match=error_message):
             FixedIncrements(column_name='column', increment_value=1.5)
 

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -69,8 +69,8 @@ class TestCreateCustomConstraint():
             "Missing required values {'column_names'} in a CustomConstraint constraint."
         )
         # Run / Assert
+        constraint = create_custom_constraint(sorted, sorted, sorted)
         with pytest.raises(MultipleConstraintsErrors, match=err_msg):
-            constraint = create_custom_constraint(sorted, sorted, sorted)
             constraint._validate_inputs(not_column_name=None, something_else=None)
 
     def test__validate_inputs_custom_constraint_is_valid_incorrect(self):
@@ -558,7 +558,8 @@ class TestFixedCombinations():
         columns = ['c']
 
         # Run and assert
-        with pytest.raises(ValueError):
+        err_msg = 'FixedCombinations requires at least two constraint columns.'
+        with pytest.raises(ValueError, match=err_msg):
             FixedCombinations(column_names=columns)
 
     def test__fit(self):
@@ -758,7 +759,7 @@ class TestFixedCombinations():
         try:
             [uuid.UUID(u) for c, u in out['b#c'].items()]
         except ValueError:
-            assert False
+            pytest.fail('ValueError')
 
     def test_transform_non_string(self):
         """Test the ``FixedCombinations.transform`` method with non strings.
@@ -795,7 +796,7 @@ class TestFixedCombinations():
         try:
             [uuid.UUID(u) for c, u in out['b#c#d'].items()]
         except ValueError:
-            assert False
+            pytest.fail('ValueError')
 
     def test_transform_not_all_columns_provided(self):
         """Test the ``FixedCombinations.transform`` method.
@@ -1067,7 +1068,8 @@ class TestInequality():
         - Raise ``ValueError`` because column names must be strings
         """
         # Run / Assert
-        with pytest.raises(ValueError):
+        err_msg = '`low_column_name` and `high_column_name` must be strings.'
+        with pytest.raises(ValueError, match=err_msg):
             Inequality._validate_init_inputs(
                 low_column_name='a', high_column_name=['b', 'c'], strict_boundaries=True
             )
@@ -1085,7 +1087,8 @@ class TestInequality():
         - Raise ``ValueError`` because ``strict_boundaries`` must be a boolean
         """
         # Run / Assert
-        with pytest.raises(ValueError):
+        err_msg = '`strict_boundaries` must be a boolean.'
+        with pytest.raises(ValueError, match=err_msg):
             Inequality._validate_init_inputs(
                 low_column_name='a', high_column_name='b', strict_boundaries=None
             )

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -276,7 +276,7 @@ class TestCreateCustomConstraint():
         """
         # Setup
         custom_constraint = create_custom_constraint(
-            lambda _, x: list([True if x_i >= 0 else False for x_i in x['col']])
+            lambda _, x: [True if x_i >= 0 else False for x_i in x['col']]
         )('col')
         data = pd.DataFrame({'col': [-10, 1, 0, 3, -.5]})
 

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -11,8 +11,8 @@ import pandas as pd
 import pytest
 
 from sdv.constraints.errors import (
-    ConstraintMetadataError, FunctionError, InvalidFunctionError, MissingConstraintColumnError,
-    MultipleConstraintsErrors)
+    AggregateConstraintsError, ConstraintMetadataError, FunctionError, InvalidFunctionError,
+    MissingConstraintColumnError)
 from sdv.constraints.tabular import (
     FixedCombinations, FixedIncrements, Inequality, Negative, OneHotEncoding, Positive, Range,
     ScalarInequality, ScalarRange, Unique, _validate_inputs_custom_constraint,
@@ -70,7 +70,7 @@ class TestCreateCustomConstraint():
         )
         # Run / Assert
         constraint = create_custom_constraint(sorted, sorted, sorted)
-        with pytest.raises(MultipleConstraintsErrors, match=err_msg):
+        with pytest.raises(AggregateConstraintsError, match=err_msg):
             constraint._validate_inputs(not_column_name=None, something_else=None)
 
     def test__validate_inputs_custom_constraint_is_valid_incorrect(self):
@@ -479,7 +479,7 @@ class TestFixedCombinations():
         - List of ValueErrors
         """
         # Run / Assert
-        with pytest.raises(MultipleConstraintsErrors) as error:
+        with pytest.raises(AggregateConstraintsError) as error:
             FixedCombinations._validate_inputs(not_column_name=None, something_else=None)
 
         err_msg = (
@@ -917,7 +917,7 @@ class TestInequality():
         - List of ValueErrors
         """
         # Run / Assert
-        with pytest.raises(MultipleConstraintsErrors) as error:
+        with pytest.raises(AggregateConstraintsError) as error:
             Inequality._validate_inputs(not_high_column=None, not_low_column=None)
 
         err_msg = (
@@ -1287,7 +1287,7 @@ class TestInequality():
         expected_out = [True, True, False, True, True, False, True, True]
         np.testing.assert_array_equal(expected_out, out)
 
-    def test_is_valid_strict_boundaries_True(self):
+    def test_is_valid_strict_boundaries_true(self):
         """Test the ``Inequality.is_valid`` method with ``strict_boundaries = True``.
 
         The method should return True when ``high_column_name`` column is greater than
@@ -1536,7 +1536,7 @@ class TestScalarInequality():
         - List of ValueErrors
         """
         # Run / Assert
-        with pytest.raises(MultipleConstraintsErrors) as error:
+        with pytest.raises(AggregateConstraintsError) as error:
             ScalarInequality._validate_inputs(
                 not_high_column=None, not_low_column=None, relation='+')
 
@@ -2206,7 +2206,7 @@ class TestPositive():
         - List of ValueErrors
         """
         # Run / Assert
-        with pytest.raises(MultipleConstraintsErrors) as error:
+        with pytest.raises(AggregateConstraintsError) as error:
             Positive._validate_inputs(not_column_name=None, something_else=None)
 
         err_msg = (
@@ -2322,7 +2322,7 @@ class TestPositive():
         assert instance._column_name == 'abc'
         assert instance._operator == np.greater_equal
 
-    def test__init__strict_True(self):
+    def test__init__strict_true(self):
         """Test the ``Positive.__init__`` method.
 
         Ensure the attributes are correctly set when ``strict`` is True.
@@ -2347,7 +2347,7 @@ class TestNegative():
         - List of ValueErrors
         """
         # Run / Assert
-        with pytest.raises(MultipleConstraintsErrors) as error:
+        with pytest.raises(AggregateConstraintsError) as error:
             Negative._validate_inputs(not_column_name=None, something_else=None)
 
         err_msg = (
@@ -2463,7 +2463,7 @@ class TestNegative():
         assert instance._column_name == 'abc'
         assert instance._operator == np.less_equal
 
-    def test__init__strict_True(self):
+    def test__init__strict_true(self):
         """Test the ``Negative.__init__`` method.
 
         Ensure the attributes are correctly set when ``strict`` is True.
@@ -2488,7 +2488,7 @@ class TestRange():
         - List of ValueErrors
         """
         # Run / Assert
-        with pytest.raises(MultipleConstraintsErrors) as error:
+        with pytest.raises(AggregateConstraintsError) as error:
             Range._validate_inputs(not_high_column=None, not_low_column=None)
 
         err_msg = (
@@ -3094,7 +3094,7 @@ class TestScalarRange():
         - List of ValueErrors
         """
         # Run / Assert
-        with pytest.raises(MultipleConstraintsErrors) as error:
+        with pytest.raises(AggregateConstraintsError) as error:
             ScalarRange._validate_inputs(not_high_column=None, not_low_column=None)
 
         err_msg = (
@@ -3803,7 +3803,7 @@ class TestOneHotEncoding():
         - List of ValueErrors
         """
         # Run / Assert
-        with pytest.raises(MultipleConstraintsErrors) as error:
+        with pytest.raises(AggregateConstraintsError) as error:
             OneHotEncoding._validate_inputs(not_column_names=None, something_else=None)
 
         err_msg = (
@@ -3926,7 +3926,7 @@ class TestUnique():
         - List of ValueErrors
         """
         # Run / Assert
-        with pytest.raises(MultipleConstraintsErrors) as error:
+        with pytest.raises(AggregateConstraintsError) as error:
             Unique._validate_inputs(not_column_names=None, something_else=None)
 
         err_msg = (
@@ -4291,7 +4291,7 @@ class TestFixedIncrements():
             ' Increments must be positive integers.'
         )
         # Run / Assert
-        with pytest.raises(MultipleConstraintsErrors) as error:
+        with pytest.raises(AggregateConstraintsError) as error:
             FixedIncrements._validate_inputs(
                 not_column_name=None, increment_value=-1, something_else=None)
 

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -306,10 +306,10 @@ class TestCreateCustomConstraint():
         def test_is_valid(*_):
             return pd.Series([True] * 5)
 
-        def test_transform(_, data):
+        def test_transform(dummy, data):
             return pd.DataFrame({'col': data['col'] ** 2})
 
-        def test_reverse_transform(_, data):
+        def test_reverse_transform(dummy, data):
             return pd.DataFrame({'col': data['col'] ** 1 / 2})
 
         custom_constraint = create_custom_constraint(

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -232,7 +232,8 @@ class TestCreateCustomConstraint():
         # Setup
         custom_constraint = create_custom_constraint(
             lambda _, x: pd.Series([True if x_i >= 0 else False for x_i in x['col']])
-        )('col')
+        )
+        custom_constraint = custom_constraint('col')
         data = pd.DataFrame({'col': [-10, 1, 0, 3, -.5]})
 
         # Run
@@ -255,7 +256,8 @@ class TestCreateCustomConstraint():
         # Setup
         custom_constraint = create_custom_constraint(
             lambda _, x: pd.Series([True, True, True])
-        )('col')
+        )
+        custom_constraint = custom_constraint('col')
         data = pd.DataFrame({'col': [-10, 1, 0, 3, -.5]})
 
         # Run
@@ -277,7 +279,8 @@ class TestCreateCustomConstraint():
         # Setup
         custom_constraint = create_custom_constraint(
             lambda _, x: [True if x_i >= 0 else False for x_i in x['col']]
-        )('col')
+        )
+        custom_constraint = custom_constraint('col')
         data = pd.DataFrame({'col': [-10, 1, 0, 3, -.5]})
 
         # Run
@@ -304,7 +307,8 @@ class TestCreateCustomConstraint():
             lambda _, x: pd.Series([True] * 5),
             lambda _, x: pd.DataFrame({'col': x['col'] ** 2}),
             lambda _, x: pd.DataFrame({'col': x['col'] ** 1 / 2}),
-        )('col')
+        )
+        custom_constraint = custom_constraint('col')
         data = pd.DataFrame({'col': [-10, 1, 0, 3, -.5]})
 
         # Run
@@ -327,7 +331,8 @@ class TestCreateCustomConstraint():
         # Setup
         custom_constraint = create_custom_constraint(
             lambda _, x: pd.Series([True] * 5)
-        )('col')
+        )
+        custom_constraint = custom_constraint('col')
         data = pd.DataFrame({'col': [-10, 1, 0, 3, -.5]})
 
         # Run
@@ -351,7 +356,8 @@ class TestCreateCustomConstraint():
             lambda _, x: pd.Series([True] * 5),
             lambda _, x: pd.DataFrame({'col': [1, 2, 3]}),
             sorted
-        )('col')
+        )
+        custom_constraint = custom_constraint('col')
         data = pd.DataFrame({'col': [-10, 1, 0, 3, -.5]})
 
         # Run
@@ -375,7 +381,8 @@ class TestCreateCustomConstraint():
             lambda _, x: pd.Series([True] * 5),
             lambda _: pd.DataFrame({'col': [1, 2, 3]}),
             sorted
-        )('col')
+        )
+        custom_constraint = custom_constraint('col')
         data = pd.DataFrame({'col': [-10, 1, 0, 3, -.5]})
 
         # Run
@@ -398,7 +405,8 @@ class TestCreateCustomConstraint():
             sorted,
             sorted,
             lambda _, x: pd.DataFrame({'col': x['col'] ** 2})
-        )('col')
+        )
+        custom_constraint = custom_constraint('col')
         data = pd.DataFrame({'col': [-10, 1, 0, 3, -.5]})
 
         # Run
@@ -444,7 +452,8 @@ class TestCreateCustomConstraint():
             sorted,
             sorted,
             lambda _, x: pd.DataFrame({'col': [1, 2, 3]})
-        )('col')
+        )
+        custom_constraint = custom_constraint('col')
         data = pd.DataFrame({'col': [-10, 1, 0, 3, -.5]})
 
         # Run

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -303,12 +303,18 @@ class TestCreateCustomConstraint():
         - pd.DataFrame of transformed values
         """
         # Setup
+        def test_is_valid(*_):
+            return pd.Series([True] * 5)
+
+        def test_transform(_, data):
+            return pd.DataFrame({'col': data['col'] ** 2})
+
+        def test_reverse_transform(_, data):
+            return pd.DataFrame({'col': data['col'] ** 1 / 2})
+
         custom_constraint = create_custom_constraint(
-            lambda _, x: pd.Series([True] * 5),
-            lambda _, x: pd.DataFrame({'col': x['col'] ** 2}),
-            lambda _, x: pd.DataFrame({'col': x['col'] ** 1 / 2}),
-        )
-        custom_constraint = custom_constraint('col')
+            test_is_valid, test_transform, test_reverse_transform
+        )('col')
         data = pd.DataFrame({'col': [-10, 1, 0, 3, -.5]})
 
         # Run

--- a/tests/unit/constraints/test_utils.py
+++ b/tests/unit/constraints/test_utils.py
@@ -24,7 +24,8 @@ def test_is_datetime_type_with_datetime_series():
     data = pd.Series([
         pd.to_datetime('2020-01-01'),
         pd.to_datetime('2020-01-02'),
-        pd.to_datetime('2020-01-03')],
+        pd.to_datetime('2020-01-03')
+    ],
     )
 
     # Run

--- a/tests/unit/constraints/test_utils.py
+++ b/tests/unit/constraints/test_utils.py
@@ -285,7 +285,7 @@ def test_cast_to_datetime64():
     # Assert
     expected_string_output = np.datetime64('2021-02-02')
     expected_series_output = pd.Series(np.datetime64('2021-02-02'))
-    expected_list_output = np.array([np.datetime64("NaT"), '2021-02-02'], dtype='datetime64[ns]')
+    expected_list_output = np.array([np.datetime64('NaT'), '2021-02-02'], dtype='datetime64[ns]')
     np.testing.assert_array_equal(expected_list_output, list_out)
     pd.testing.assert_series_equal(expected_series_output, series_out)
     assert expected_string_output == string_out

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -9,7 +9,7 @@ from rdt.errors import NotFittedError as RDTNotFittedError
 from rdt.transformers import FloatFormatter, LabelEncoder
 
 from sdv.constraints.errors import (
-    FunctionError, MissingConstraintColumnError, MultipleConstraintsErrors)
+    FunctionError, MissingConstraintColumnError, AggregateConstraintsError)
 from sdv.constraints.tabular import Positive
 from sdv.data_processing.data_processor import DataProcessor
 from sdv.data_processing.errors import NotFittedError
@@ -316,7 +316,7 @@ class TestDataProcessor:
             - A ``pandas.DataFrame``.
 
         Side effect:
-            - A ``MultipleConstraintsErrors`` error should be raised.
+            - A ``AggregateConstraintsError`` error should be raised.
         """
         # Setup
         data = pd.DataFrame({'a': [1, 2, 3]})
@@ -329,7 +329,7 @@ class TestDataProcessor:
 
         # Run / Assert
         error_message = re.escape('\nerror 1\n\nerror 2')
-        with pytest.raises(MultipleConstraintsErrors, match=error_message):
+        with pytest.raises(AggregateConstraintsError, match=error_message):
             dp._fit_transform_constraints(data)
 
     def test__fit_transform_constraints_transform_errors(self):
@@ -347,7 +347,7 @@ class TestDataProcessor:
             - A ``pandas.DataFrame``.
 
         Side effect:
-            - A ``MultipleConstraintsErrors`` error should be raised.
+            - A ``AggregateConstraintsError`` error should be raised.
         """
         # Setup
         data = pd.DataFrame({'a': [1, 2, 3]})
@@ -360,7 +360,7 @@ class TestDataProcessor:
 
         # Run / Assert
         error_message = re.escape('\nerror 1\n\nerror 2')
-        with pytest.raises(MultipleConstraintsErrors, match=error_message):
+        with pytest.raises(AggregateConstraintsError, match=error_message):
             dp._fit_transform_constraints(data)
 
         constraint1.fit.assert_called_once_with(data)
@@ -861,7 +861,7 @@ class TestDataProcessor:
         pd.testing.assert_frame_equal(reverse_transformed, expected_output)
 
     @patch('sdv.data_processing.data_processor.LOGGER')
-    def test_reverse_transform_hyper_Transformer_errors(self, log_mock):
+    def test_reverse_transform_hyper_transformer_errors(self, log_mock):
         """Test the ``reverse_transform`` method.
 
         A message should be logged if the ``HyperTransformer`` errors.

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -9,7 +9,7 @@ from rdt.errors import NotFittedError as RDTNotFittedError
 from rdt.transformers import FloatFormatter, LabelEncoder
 
 from sdv.constraints.errors import (
-    FunctionError, MissingConstraintColumnError, AggregateConstraintsError)
+    AggregateConstraintsError, FunctionError, MissingConstraintColumnError)
 from sdv.constraints.tabular import Positive
 from sdv.data_processing.data_processor import DataProcessor
 from sdv.data_processing.errors import NotFittedError

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -142,7 +142,8 @@ class TestDataProcessor:
         assert isinstance(instance.metadata, SingleTableMetadata)
         assert instance.metadata._columns == {'col': {'sdtype': 'numerical'}}
         assert instance.metadata._constraints == [
-            {'constraint_name': 'Positive', 'column_name': 'col'}]
+            {'constraint_name': 'Positive', 'column_name': 'col'}
+        ]
         assert len(instance._constraints) == 1
         assert isinstance(instance._constraints[0], Positive)
 

--- a/tests/unit/lite/test_tabular.py
+++ b/tests/unit/lite/test_tabular.py
@@ -442,10 +442,12 @@ class TestTabularPreset:
         """
         # Setup
         out = io.StringIO()
-        expected = ('Available presets:\n{\'FAST_ML\': \'Use this preset to minimize the time '
-                    'needed to create a synthetic data model.\'}\n\nSupply the desired '
-                    'preset using the `name` parameter.\n\nHave any requests for '
-                    'custom presets? Contact the SDV team to learn more an SDV Premium license.')
+        expected = (
+            'Available presets:\n{\'FAST_ML\': \'Use this preset to minimize the time '
+            'needed to create a synthetic data model.\'}\n\nSupply the desired '
+            'preset using the `name` parameter.\n\nHave any requests for '
+            'custom presets? Contact the SDV team to learn more an SDV Premium license.'
+        )
 
         # Run
         TabularPreset.list_available_presets(out)

--- a/tests/unit/lite/test_tabular.py
+++ b/tests/unit/lite/test_tabular.py
@@ -443,8 +443,8 @@ class TestTabularPreset:
         # Setup
         out = io.StringIO()
         expected = (
-            'Available presets:\n{\'FAST_ML\': \'Use this preset to minimize the time '
-            'needed to create a synthetic data model.\'}\n\nSupply the desired '
+            "Available presets:\n{'FAST_ML': 'Use this preset to minimize the time "
+            "needed to create a synthetic data model.'}\n\nSupply the desired "
             'preset using the `name` parameter.\n\nHave any requests for '
             'custom presets? Contact the SDV team to learn more an SDV Premium license.'
         )

--- a/tests/unit/lite/test_tabular.py
+++ b/tests/unit/lite/test_tabular.py
@@ -226,7 +226,7 @@ class TestTabularPreset:
         model.fit.assert_called_once_with(DataFrameMatcher(pd.DataFrame()))
         assert preset._null_percentages is None
 
-    def test_fit_null_column_True(self):
+    def test_fit_null_column_true(self):
         """Test the ``TabularPreset.fit`` method with modeling null columns.
 
         Expect that the model's fit method is called with the expected args when

--- a/tests/unit/metadata/test_dataset.py
+++ b/tests/unit/metadata/test_dataset.py
@@ -434,8 +434,8 @@ class TestMetadata(TestCase):
         }
         assert result.keys() == expected.keys()
 
-        for k, v in result.items():
-            pd.testing.assert_frame_equal(v, expected[k])
+        for key, value in result.items():
+            pd.testing.assert_frame_equal(value, expected[key])
 
     def test_get_fields(self):
         """Test get fields"""

--- a/tests/unit/metadata/test_dataset.py
+++ b/tests/unit/metadata/test_dataset.py
@@ -229,7 +229,7 @@ class TestMetadata(TestCase):
         mock_meta.assert_called_once_with({'some': 'meta'})
         mock_relationships.assert_called_once_with()
         assert metadata.root_path == '.'
-        assert metadata._hyper_transformers == dict()
+        assert metadata._hyper_transformers == {}
 
     def test_get_children(self):
         """Test get children"""
@@ -562,14 +562,14 @@ class TestMetadata(TestCase):
         # Setup
         metadata = Mock(spec_set=Metadata)
         metadata.get_tables.return_value = ['a_table', 'b_table']
-        metadata._metadata = {'tables': dict()}
+        metadata._metadata = {'tables': {}}
 
         # Run
         Metadata.add_table(metadata, 'x_table')
 
         # Asserts
         expected_table_meta = {
-            'fields': dict()
+            'fields': {}
         }
 
         assert metadata._metadata['tables']['x_table'] == expected_table_meta
@@ -582,14 +582,14 @@ class TestMetadata(TestCase):
         # Setup
         metadata = Mock(spec_set=Metadata)
         metadata.get_tables.return_value = ['a_table', 'b_table']
-        metadata._metadata = {'tables': dict()}
+        metadata._metadata = {'tables': {}}
 
         # Run
         Metadata.add_table(metadata, 'x_table', primary_key='id')
 
         # Asserts
         expected_table_meta = {
-            'fields': dict()
+            'fields': {}
         }
 
         assert metadata._metadata['tables']['x_table'] == expected_table_meta
@@ -602,14 +602,14 @@ class TestMetadata(TestCase):
         # Setup
         metadata = Mock(spec_set=Metadata)
         metadata.get_tables.return_value = ['a_table', 'b_table']
-        metadata._metadata = {'tables': dict()}
+        metadata._metadata = {'tables': {}}
 
         # Run
         Metadata.add_table(metadata, 'x_table', parent='users')
 
         # Asserts
         expected_table_meta = {
-            'fields': dict()
+            'fields': {}
         }
 
         assert metadata._metadata['tables']['x_table'] == expected_table_meta
@@ -622,7 +622,7 @@ class TestMetadata(TestCase):
         # Setup
         metadata = Mock(spec_set=Metadata)
         metadata.get_tables.return_value = ['a_table', 'b_table']
-        metadata._metadata = {'tables': dict()}
+        metadata._metadata = {'tables': {}}
 
         # Run
         fields_metadata = {
@@ -648,7 +648,7 @@ class TestMetadata(TestCase):
         # Setup
         metadata = Mock(spec_set=Metadata)
         metadata.get_tables.return_value = ['a_table', 'b_table']
-        metadata._metadata = {'tables': dict()}
+        metadata._metadata = {'tables': {}}
 
         # Run
         fields = ['a_field', 'b_field']
@@ -657,7 +657,7 @@ class TestMetadata(TestCase):
 
         # Asserts
         expected_table_meta = {
-            'fields': dict()
+            'fields': {}
         }
 
         assert metadata._metadata['tables']['x_table'] == expected_table_meta
@@ -667,7 +667,7 @@ class TestMetadata(TestCase):
         # Setup
         metadata = Mock(spec_set=Metadata)
         metadata.get_tables.return_value = ['a_table', 'b_table']
-        metadata._metadata = {'tables': dict()}
+        metadata._metadata = {'tables': {}}
         metadata._get_field_details.return_value = {
             'a_field': {'type': 'numerical', 'subtype': 'integer'},
             'b_field': {'type': 'boolean'}
@@ -697,7 +697,7 @@ class TestMetadata(TestCase):
         # Setup
         metadata = Mock(spec_set=Metadata)
         metadata.get_tables.return_value = ['a_table', 'b_table']
-        metadata._metadata = {'tables': dict()}
+        metadata._metadata = {'tables': {}}
         metadata._get_field_details.return_value = {
             'a_field': {'type': 'numerical', 'subtype': 'integer'},
             'b_field': {'type': 'boolean'},
@@ -729,7 +729,7 @@ class TestMetadata(TestCase):
         # Setup
         metadata = Mock(spec_set=Metadata)
         metadata.get_tables.return_value = ['a_table', 'b_table']
-        metadata._metadata = {'tables': dict()}
+        metadata._metadata = {'tables': {}}
         mock_read_csv.return_value = pd.DataFrame({
             'a_field': [0, 1],
             'b_field': [True, False],
@@ -776,7 +776,7 @@ class TestMetadata(TestCase):
         # Setup
         metadata = Mock(spec_set=Metadata)
         metadata.get_tables.return_value = ['a_table', 'b_table']
-        metadata._metadata = {'tables': dict()}
+        metadata._metadata = {'tables': {}}
 
         # Run
         fields_metadata = {
@@ -826,7 +826,7 @@ class TestMetadata(TestCase):
         """Add relationship table no exist"""
         # Setup
         metadata = Mock(spec_set=Metadata)
-        metadata.get_tables.return_value = list()
+        metadata.get_tables.return_value = []
 
         # Run
         with pytest.raises(ValueError):
@@ -847,7 +847,7 @@ class TestMetadata(TestCase):
         # Setup
         metadata = Mock(spec_set=Metadata)
         metadata.get_tables.return_value = ['a_table', 'b_table']
-        metadata.get_parents.return_value = set(['b_table'])
+        metadata.get_parents.return_value = {'b_table'}
 
         # Run
         with pytest.raises(ValueError):
@@ -870,7 +870,7 @@ class TestMetadata(TestCase):
         """Set primary key table no exist"""
         # Setup
         metadata = Mock(spec_set=Metadata)
-        metadata.get_tables.return_value = list()
+        metadata.get_tables.return_value = []
         metadata.get_fields.return_value = {'a_field': {'type': 'id', 'subtype': 'integer'}}
         metadata._metadata = {
             'tables': {
@@ -892,10 +892,10 @@ class TestMetadata(TestCase):
         """Add field table no exist"""
         # Setup
         metadata = Mock(spec_set=Metadata)
-        metadata.get_tables.return_value = list()
+        metadata.get_tables.return_value = []
         metadata._metadata = {
             'tables': {
-                'a_table': {'fields': dict()}
+                'a_table': {'fields': {}}
             }
         }
 

--- a/tests/unit/metadata/test_dataset.py
+++ b/tests/unit/metadata/test_dataset.py
@@ -478,7 +478,7 @@ class TestMetadata(TestCase):
     def test_get_foreign_keys(self):
         """Test get foreign key"""
         # Setup
-        metadata = Metadata({
+        metadata = {
             'tables': {
                 'parent': {
                     'fields': {
@@ -507,7 +507,8 @@ class TestMetadata(TestCase):
                     }
                 }
             }
-        })
+        }
+        metadata = Metadata(metadata)
 
         # Run
         result = Metadata.get_foreign_keys(metadata, 'parent', 'child')

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -434,12 +434,14 @@ class TestMultiTableMetadata:
             'users': parent_table,
             'sessions': child_table,
         }
-        instance._relationships = [{
-            'parent_table_name': 'users',
-            'child_table_name': 'sessions',
-            'parent_primary_key': 'id',
-            'child_foreign_key': 'user_id',
-        }]
+        instance._relationships = [
+            {
+                'parent_table_name': 'users',
+                'child_table_name': 'sessions',
+                'parent_primary_key': 'id',
+                'child_foreign_key': 'user_id',
+            }
+        ]
 
         instance._validate_relationship_sdtypes = Mock()
         instance._validate_missing_relationship_keys = Mock()
@@ -509,12 +511,14 @@ class TestMultiTableMetadata:
         instance.add_relationship('users', 'sessions', 'id', 'user_id')
 
         # Assert
-        instance._relationships == [{
-            'parent_table_name': 'users',
-            'child_table_name': 'sessiosns',
-            'parent_primary_key': 'id',
-            'child_foreign_key': 'user_id',
-        }]
+        instance._relationships == [
+            {
+                'parent_table_name': 'users',
+                'child_table_name': 'sessiosns',
+                'parent_primary_key': 'id',
+                'child_foreign_key': 'user_id',
+            }
+        ]
         instance._validate_child_map_circular_relationship.assert_called_once_with(
             {'users': {'sessions'}})
 
@@ -801,12 +805,14 @@ class TestMultiTableMetadata:
             'accounts': table_accounts,
             'branches': table_branches
         }
-        instance._relationships = [{
-            'parent_table_name': 'accounts',
-            'parent_primary_key': 'id',
-            'child_table_name': 'branches',
-            'chil_foreign_key': 'branch_id',
-        }]
+        instance._relationships = [
+            {
+                'parent_table_name': 'accounts',
+                'parent_primary_key': 'id',
+                'child_table_name': 'branches',
+                'chil_foreign_key': 'branch_id',
+            }
+        ]
 
         # Run
         result = instance.to_dict()
@@ -826,12 +832,14 @@ class TestMultiTableMetadata:
                     'name': {'sdtype': 'text'},
                 }
             },
-            'relationships': [{
-                'parent_table_name': 'accounts',
-                'parent_primary_key': 'id',
-                'child_table_name': 'branches',
-                'chil_foreign_key': 'branch_id',
-            }]
+            'relationships': [
+                {
+                    'parent_table_name': 'accounts',
+                    'parent_primary_key': 'id',
+                    'child_table_name': 'branches',
+                    'chil_foreign_key': 'branch_id',
+                }
+            ]
         }
         assert result == expected_result
 
@@ -865,12 +873,14 @@ class TestMultiTableMetadata:
                     'name': {'sdtype': 'text'},
                 }
             },
-            'relationships': [{
-                'parent_table_name': 'accounts',
-                'parent_primary_key': 'id',
-                'child_table_name': 'branches',
-                'chil_foreign_key': 'branch_id',
-            }]
+            'relationships': [
+                {
+                    'parent_table_name': 'accounts',
+                    'parent_primary_key': 'id',
+                    'child_table_name': 'branches',
+                    'chil_foreign_key': 'branch_id',
+                }
+            ]
         }
 
         single_table_accounts = object()
@@ -891,12 +901,14 @@ class TestMultiTableMetadata:
             'branches': single_table_branches
         }
 
-        assert instance._relationships == [{
-            'parent_table_name': 'accounts',
-            'parent_primary_key': 'id',
-            'child_table_name': 'branches',
-            'chil_foreign_key': 'branch_id',
-        }]
+        assert instance._relationships == [
+            {
+                'parent_table_name': 'accounts',
+                'parent_primary_key': 'id',
+                'child_table_name': 'branches',
+                'chil_foreign_key': 'branch_id',
+            }
+        ]
 
     @patch('sdv.metadata.multi_table.SingleTableMetadata')
     def test__load_from_dict(self, mock_singletablemetadata):
@@ -932,12 +944,14 @@ class TestMultiTableMetadata:
                     'name': {'sdtype': 'text'},
                 }
             },
-            'relationships': [{
-                'parent_table_name': 'accounts',
-                'parent_primary_key': 'id',
-                'child_table_name': 'branches',
-                'child_foreign_key': 'branch_id',
-            }]
+            'relationships': [
+                {
+                    'parent_table_name': 'accounts',
+                    'parent_primary_key': 'id',
+                    'child_table_name': 'branches',
+                    'child_foreign_key': 'branch_id',
+                }
+            ]
         }
 
         single_table_accounts = object()
@@ -956,12 +970,14 @@ class TestMultiTableMetadata:
             'branches': single_table_branches
         }
 
-        assert instance._relationships == [{
-            'parent_table_name': 'accounts',
-            'parent_primary_key': 'id',
-            'child_table_name': 'branches',
-            'child_foreign_key': 'branch_id',
-        }]
+        assert instance._relationships == [
+            {
+                'parent_table_name': 'accounts',
+                'parent_primary_key': 'id',
+                'child_table_name': 'branches',
+                'child_foreign_key': 'branch_id',
+            }
+        ]
 
     @patch('sdv.metadata.multi_table.json')
     def test___repr__(self, mock_json):
@@ -1578,9 +1594,11 @@ class TestMultiTableMetadata:
                         }
                     },
                     'primary_key': 'animals',
-                    'constraints': [{
-                        'my_constraint': 'my_params'
-                    }],
+                    'constraints': [
+                        {
+                            'my_constraint': 'my_params'
+                        }
+                    ],
                     'SCHEMA_VERSION': 'SINGLE_TABLE_V1'
                 }
             },

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -385,8 +385,11 @@ class TestMultiTableMetadata:
         }
 
         # Run / Assert
-        # TODO fix match error message
-        with pytest.raises(ValueError):
+        err_msg = re.escape(
+            'The relationships in the dataset describe a circular dependency between tables '
+            "['users', 'sessions']."
+        )
+        with pytest.raises(ValueError, match=err_msg):
             instance._validate_child_map_circular_relationship(child_map)
 
     @patch(
@@ -666,8 +669,8 @@ class TestMultiTableMetadata:
             child_map[parent_name].add(child_name)
 
         # Run
-        error_msg = (
-            "The relationships in the dataset are disjointed. Table {'accounts'} "
+        error_msg = re.escape(
+            "The relationships in the dataset are disjointed. Table ['accounts'] "
             'is not connected to any of the other tables.'
         )
         with pytest.raises(ValueError, match=error_msg):
@@ -721,7 +724,11 @@ class TestMultiTableMetadata:
             child_map[parent_name].add(child_name)
 
         # Run
-        with pytest.raises(ValueError):
+        err_msg = re.escape(
+            "The relationships in the dataset are disjointed. Tables ['accounts', 'branches'] "
+            'are not connected to any of the other tables.'
+        )
+        with pytest.raises(ValueError, match=err_msg):
             MultiTableMetadata._validate_all_tables_connected(instance, parent_map, child_map)
 
     def test_validate(self):
@@ -765,7 +772,7 @@ class TestMultiTableMetadata:
             "Please use 'set_primary_key' in order to set one."
             "\nRelationship between tables ('sessions', 'transactions') is invalid. "
             'The primary and foreign key columns are not the same type.'
-            "\nThe relationships in the dataset are disjointed. Table {'payments'} "
+            "\nThe relationships in the dataset are disjointed. Table ['payments'] "
             'is not connected to any of the other tables.'
         )
 

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -259,7 +259,7 @@ class TestSingleTableMetadata:
         with pytest.raises(ValueError, match=error_msg):
             instance._validate_column_exists('synthetic')
 
-    @pytest.mark.parametrize('column_name, sdtype, kwargs', VALID_KWARGS)
+    @pytest.mark.parametrize(('column_name', 'sdtype', 'kwargs'), VALID_KWARGS)
     def test__validate_unexpected_kwargs_valid(self, column_name, sdtype, kwargs):
         """Test the ``_validate_unexpected_kwargs`` method.
 
@@ -277,7 +277,7 @@ class TestSingleTableMetadata:
         # Run / Assert
         instance._validate_unexpected_kwargs(column_name, sdtype, **kwargs)
 
-    @pytest.mark.parametrize('column_name, sdtype, kwargs, error_msg', INVALID_KWARGS)
+    @pytest.mark.parametrize(('column_name', 'sdtype', 'kwargs', 'error_msg'), INVALID_KWARGS)
     def test__validate_unexpected_kwargs_invalid(self, column_name, sdtype, kwargs, error_msg):
         """Test the ``_validate_unexpected_kwargs`` method.
 

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from sdv.constraints.errors import MultipleConstraintsErrors
+from sdv.constraints.errors import AggregateConstraintsError
 from sdv.metadata.errors import InvalidMetadataError
 from sdv.metadata.single_table import SingleTableMetadata
 
@@ -1210,7 +1210,7 @@ class TestSingleTableMetadata:
         instance._alternate_keys = ['col2']
         instance._sequence_key = 'col1'
         instance._sequence_index = 'col2'
-        instance._validate_constraint = Mock(side_effect=MultipleConstraintsErrors(['cnt_error']))
+        instance._validate_constraint = Mock(side_effect=AggregateConstraintsError(['cnt_error']))
         instance._validate_key = Mock()
         instance._validate_alternate_keys = Mock()
         instance._validate_sequence_index = Mock()

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -34,20 +34,34 @@ class TestSingleTableMetadata:
     ]
 
     INVALID_KWARGS = [
-        ('age', 'numerical', {'representation': 'int', 'datetime_format': None, 'pii': True},
-         re.escape("Invalid values '(datetime_format, pii)' for numerical column 'age'."),),
-        ('start_date', 'datetime', {'datetime_format': '%Y-%d', 'pii': True},
-         re.escape("Invalid values '(pii)' for datetime column 'start_date'.")),
-        ('name', 'categorical',
-         {'pii': True, 'ordering': ['a', 'b'], 'ordered': 'numerical_values'},
-         re.escape("Invalid values '(ordered, ordering, pii)' for categorical column 'name'.")),
-        ('synthetic', 'boolean', {'pii': True},
-         re.escape("Invalid values '(pii)' for boolean column 'synthetic'.")),
-        ('phrase', 'text', {'regex_format': '[A-z]', 'pii': True, 'anonymization': True},
-         re.escape("Invalid values '(anonymization, pii)' for text column 'phrase'.")),
-        ('phone', 'phone_number', {'anonymization': True, 'order_by': 'phone_number'},
-         re.escape("Invalid values '(anonymization, order_by)' for phone_number column 'phone'."))
-    ]
+        (
+            'age', 'numerical', {'representation': 'int', 'datetime_format': None, 'pii': True},
+            re.escape("Invalid values '(datetime_format, pii)' for numerical column 'age'."),
+        ),
+        (
+            'start_date', 'datetime', {'datetime_format': '%Y-%d', 'pii': True},
+            re.escape("Invalid values '(pii)' for datetime column 'start_date'.")
+        ),
+        (
+            'name', 'categorical',
+            {'pii': True, 'ordering': ['a', 'b'], 'ordered': 'numerical_values'},
+            re.escape("Invalid values '(ordered, ordering, pii)' for categorical column 'name'.")
+        ),
+        (
+            'synthetic', 'boolean', {'pii': True},
+            re.escape("Invalid values '(pii)' for boolean column 'synthetic'.")
+        ),
+        (
+            'phrase', 'text', {'regex_format': '[A-z]', 'pii': True, 'anonymization': True},
+            re.escape("Invalid values '(anonymization, pii)' for text column 'phrase'.")
+        ),
+        (
+            'phone', 'phone_number', {'anonymization': True, 'order_by': 'phone_number'},
+            re.escape(
+                "Invalid values '(anonymization, order_by)' for phone_number column 'phone'."
+            )
+        )
+    ]  # noqa: JS102
 
     def test___init__(self):
         """Test creating an instance of ``SingleTableMetadata``."""
@@ -1419,9 +1433,11 @@ class TestSingleTableMetadata:
                 }
             },
             'primary_key': 'animals',
-            'constraints': [{
-                'my_constraint': 'my_params'
-            }],
+            'constraints': [
+                {
+                    'my_constraint': 'my_params'
+                }
+            ],
             'SCHEMA_VERSION': 'SINGLE_TABLE_V1'
         }
 
@@ -1554,11 +1570,13 @@ class TestSingleTableMetadata:
             high_column_name='start_date'
         )
 
-        assert metadata._constraints == [{
-            'constraint_name': 'Inequality',
-            'low_column_name': 'child_age',
-            'high_column_name': 'start_date'
-        }]
+        assert metadata._constraints == [
+            {
+                'constraint_name': 'Inequality',
+                'low_column_name': 'child_age',
+                'high_column_name': 'start_date'
+            }
+        ]
 
     def test_add_constraint_bad_constraint(self):
         """Test the ``add_constraint`` method with a non-existent constraint.

--- a/tests/unit/metadata/test_table.py
+++ b/tests/unit/metadata/test_table.py
@@ -268,7 +268,11 @@ class TestTable:
     def test__make_ids_fail(self):
         """Test if regex fails with more requested ids than available unique values."""
         metadata = {'subtype': 'string', 'regex': '[a-d]'}
-        with pytest.raises(ValueError):
+        err_msg = re.escape(
+            'Unable to generate 20 unique values for regex [a-d], '
+            'the maximum number of unique values is 4.'
+        )
+        with pytest.raises(ValueError, match=err_msg):
             Table._make_ids(metadata, 20)
 
     def test__make_ids_unique_field_not_unique(self):

--- a/tests/unit/metadata/test_table.py
+++ b/tests/unit/metadata/test_table.py
@@ -8,7 +8,7 @@ from faker.config import DEFAULT_LOCALE
 from rdt.transformers.numerical import FloatFormatter
 
 from sdv.constraints.errors import (
-    FunctionError, MissingConstraintColumnError, MultipleConstraintsErrors)
+    AggregateConstraintsError, FunctionError, MissingConstraintColumnError)
 from sdv.metadata import Table
 
 
@@ -383,7 +383,7 @@ class TestTable:
             - A ``pandas.DataFrame``.
 
         Side effect:
-            - A ``MultipleConstraintsErrors`` error should be raised.
+            - A ``AggregateConstraintsError`` error should be raised.
         """
         # Setup
         data = pd.DataFrame({'a': [1, 2, 3]})
@@ -396,7 +396,7 @@ class TestTable:
 
         # Run / Assert
         error_message = re.escape('\nerror 1\n\nerror 2')
-        with pytest.raises(MultipleConstraintsErrors, match=error_message):
+        with pytest.raises(AggregateConstraintsError, match=error_message):
             instance.fit(data)
 
     def test_fit_constraint_transform_errors(self):
@@ -414,7 +414,7 @@ class TestTable:
             - A ``pandas.DataFrame``.
 
         Side effect:
-            - A ``MultipleConstraintsErrors`` error should be raised.
+            - A ``AggregateConstraintsError`` error should be raised.
         """
         # Setup
         data = pd.DataFrame({'a': [1, 2, 3]})
@@ -427,7 +427,7 @@ class TestTable:
 
         # Run / Assert
         error_message = re.escape('\nerror 1\n\nerror 2')
-        with pytest.raises(MultipleConstraintsErrors, match=error_message):
+        with pytest.raises(AggregateConstraintsError, match=error_message):
             instance.fit(data)
 
         constraint1.fit.assert_called_once_with(data)

--- a/tests/unit/metadata/test_visualization.py
+++ b/tests/unit/metadata/test_visualization.py
@@ -65,9 +65,9 @@ def test__add_nodes():
 
     # Asserts
     expected_node_label = (
-        r"{demo|a_field : numerical - integer\lb_field : id\l"
-        r"c_field : id\l|Primary key: b_field\l"
-        r"Foreign key (other): c_field\l}"
+        r'{demo|a_field : numerical - integer\lb_field : id\l'
+        r'c_field : id\l|Primary key: b_field\l'
+        r'Foreign key (other): c_field\l}'
     )
 
     metadata.get_fields.assert_called_once_with('demo')

--- a/tests/unit/metadata/test_visualization.py
+++ b/tests/unit/metadata/test_visualization.py
@@ -53,7 +53,7 @@ def test__add_nodes():
     metadata.get_fields.return_value = minimock
 
     metadata.get_primary_key.return_value = 'b_field'
-    metadata.get_parents.return_value = set(['other'])
+    metadata.get_parents.return_value = {'other'}
     metadata.get_foreign_keys.return_value = ['c_field']
 
     metadata.get_table_meta.return_value = {'path': None}
@@ -86,7 +86,7 @@ def test__add_edges():
     metadata = MagicMock(spec_set=Metadata)
 
     metadata.get_tables.return_value = ['demo', 'other']
-    metadata.get_parents.side_effect = [set(['other']), set()]
+    metadata.get_parents.side_effect = [{'other'}, {}]
 
     metadata.get_foreign_keys.return_value = ['fk']
     metadata.get_primary_key.return_value = 'pk'

--- a/tests/unit/metadata/test_visualization.py
+++ b/tests/unit/metadata/test_visualization.py
@@ -120,9 +120,6 @@ def test__add_edges():
 def test_visualize(add_nodes_mock, add_edges_mock, digraph_mock):
     """Metadata visualize digraph"""
     # Setup
-    # plot = Mock(spec_set=graphviz.Digraph)
-    # graphviz_mock.Digraph.return_value = plot
-
     metadata = MagicMock(spec_set=Metadata)
 
     # Run

--- a/tests/unit/metadata/test_visualization.py
+++ b/tests/unit/metadata/test_visualization.py
@@ -8,13 +8,15 @@ from sdv.metadata import Metadata, visualization
 
 def test__get_graphviz_extension_path_without_extension():
     """Raises a ValueError when the path doesn't contains an extension."""
-    with pytest.raises(ValueError):
+    err_msg = 'Path without graphviz extension.'
+    with pytest.raises(ValueError, match=err_msg):
         visualization._get_graphviz_extension('/some/path')
 
 
 def test__get_graphviz_extension_invalid_extension():
     """Raises a ValueError when the path contains an invalid extension."""
-    with pytest.raises(ValueError):
+    err_msg = '"foo" not a valid graphviz extension format.'
+    with pytest.raises(ValueError, match=err_msg):
         visualization._get_graphviz_extension('/some/path.foo')
 
 

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -143,9 +143,9 @@ class TestBaseTabularModel:
         # Setup
         model = Mock(spec_set=CTGAN)
         valid_sampled_data = pd.DataFrame({
-            "column1": [28, 28, 21, 1, 2],
-            "column2": [37, 37, 1, 4, 5],
-            "column3": [93, 93, 6, 4, 12],
+            'column1': [28, 28, 21, 1, 2],
+            'column2': [37, 37, 1, 4, 5],
+            'column3': [93, 93, 6, 4, 12],
         })
         model._sample_rows.side_effect = [(pd.DataFrame({}), 0), (valid_sampled_data, 5)]
 

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -265,9 +265,8 @@ class TestBaseTabularModel:
         # Assert
         assert model._sample_rows.call_count == 1
         assert output == sampled_mock.head.return_value
-        assert sampled_mock.head.return_value.tail.return_value.to_csv.called_once_with(
-            call(2).tail(2).to_csv(output_file_path, index=False),
-        )
+        mock_csv = sampled_mock.head.return_value.tail.return_value.to_csv
+        assert mock_csv.called_once_with(call(2).tail(2).to_csv(output_file_path, index=False))
 
     def test__sample_in_batches(self):
         """Test the ``_sample_in_batches`` method.
@@ -1279,8 +1278,9 @@ def test__sample_with_conditions_transform_conditions_correctly():
         pd.DataFrame({'column1': condition_values}), 100, None)
 
     # Assert
-    first_condition = model._metadata.transform.mock_calls[0][1][0]['column1']
-    second_condition = model._metadata.transform.mock_calls[1][1][0]['column1']
+    mock_transform = model._metadata.transform
+    first_condition = mock_transform.mock_calls[0][1][0]['column1']
+    second_condition = mock_transform.mock_calls[1][1][0]['column1']
     pd.testing.assert_series_equal(first_condition, pd.Series([25], name='column1'))
     pd.testing.assert_series_equal(second_condition, pd.Series([30], name='column1', index=[3]))
     model._sample_batch.assert_any_call(

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -108,7 +108,8 @@ class TestBaseTabularModel:
         model._metadata.transform.return_value = pd.DataFrame({}, index=[0, 1, 2])
         model._conditionally_sample_rows.return_value = pd.DataFrame({
             'a': ['a', 'a', 'a'],
-            COND_IDX: [0, 1, 2]})
+            COND_IDX: [0, 1, 2]
+        })
         model._metadata.make_ids_unique.return_value = expected
 
         # Run

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -1317,18 +1317,18 @@ def test_fit_sets_num_rows(model):
         - ``_num_rows`` is set to the length of the data passed to ``fit``.
     """
     # Setup
-    _N_DATA_ROWS = 100
+    _n_data_rows = 100
     data = pd.DataFrame({
-        'column1': list(range(_N_DATA_ROWS)),
-        'column2': list(range(_N_DATA_ROWS)),
-        'column3': list(range(_N_DATA_ROWS))
+        'column1': list(range(_n_data_rows)),
+        'column2': list(range(_n_data_rows)),
+        'column3': list(range(_n_data_rows))
     })
 
     # Run
     model.fit(data)
 
     # Assert
-    assert model._num_rows == _N_DATA_ROWS
+    assert model._num_rows == _n_data_rows
 
 
 @pytest.mark.parametrize('model', MODELS)
@@ -1375,10 +1375,10 @@ def test__make_condition_dfs_specifying_num_rows(model):
         - Conditions as ``[DataFrame]``
     """
     # Setup
-    _NUM_ROWS = 10
+    _num_rows = 10
     column_values = {'column2': 'M'}
-    conditions = [Condition(column_values=column_values, num_rows=_NUM_ROWS)]
-    expected_conditions = pd.DataFrame([column_values] * _NUM_ROWS)
+    conditions = [Condition(column_values=column_values, num_rows=_num_rows)]
+    expected_conditions = pd.DataFrame([column_values] * _num_rows)
 
     # Run
     result_conditions_list = model._make_condition_dfs(conditions=conditions)
@@ -1387,7 +1387,7 @@ def test__make_condition_dfs_specifying_num_rows(model):
     assert len(result_conditions_list) == 1
     result_conditions = result_conditions_list[0]
     assert isinstance(result_conditions, pd.DataFrame)
-    assert len(result_conditions) == _NUM_ROWS
+    assert len(result_conditions) == _num_rows
     assert all(result_conditions == expected_conditions)
 
 

--- a/tests/unit/tabular/test_copulas.py
+++ b/tests/unit/tabular/test_copulas.py
@@ -289,7 +289,8 @@ class TestGaussianCopula:
         # asserts
         assert out is None
         assert gaussian_copula._field_distributions == {
-            'a': 'a_distribution', 'a.value': 'a_distribution'}
+            'a': 'a_distribution', 'a.value': 'a_distribution'
+        }
         gm_mock.assert_called_once_with(
             distribution={'a': 'a_distribution', 'a.value': 'a_distribution'})
 

--- a/tests/unit/tabular/test_copulas.py
+++ b/tests/unit/tabular/test_copulas.py
@@ -169,7 +169,7 @@ class TestGaussianCopula:
         """
         # Setup
         gaussian_copula = Mock(spec_set=GaussianCopula)
-        gaussian_copula._metadata.get_model_kwargs.return_value = dict()
+        gaussian_copula._metadata.get_model_kwargs.return_value = {}
         gaussian_copula._categorical_transformer = 'a_categorical_transformer_value'
         gaussian_copula._default_distribution = 'a_distribution'
         gaussian_copula.get_distributions.return_value = {

--- a/tests/unit/tabular/test_utils.py
+++ b/tests/unit/tabular/test_utils.py
@@ -99,7 +99,8 @@ def test_unflatten_dict_raises_error_row_index():
         'foo__0__1': 'some value'
     }
 
-    with pytest.raises(ValueError):
+    err_msg = 'There was an error unflattening the extension.'
+    with pytest.raises(ValueError, match=err_msg):
         unflatten_dict(flat)
 
 
@@ -110,7 +111,8 @@ def test_unflatten_dict_raises_error_column_index():
         'foo__1__0': 'some value'
     }
 
-    with pytest.raises(ValueError):
+    err_msg = 'There was an error unflattening the extension.'
+    with pytest.raises(ValueError, match=err_msg):
         unflatten_dict(flat)
 
 

--- a/tests/unit/tabular/test_utils.py
+++ b/tests/unit/tabular/test_utils.py
@@ -141,6 +141,7 @@ def test_handle_sampling_error():
     Expect that the error is raised at the end of the function.
 
     Input:
+        - True
         - a temp file
         - the sampling error
 
@@ -148,11 +149,64 @@ def test_handle_sampling_error():
         - the error is raised.
     """
     # Setup
+    error_msg = (
+        'Error: Sampling terminated. Partial results are stored in a temporary file: test.csv. '
+        'This file will be overridden the next time you sample. Please rename the file if you '
+        'wish to save these results.'
+        '\n'
+        'Test error'
+    )
+
+    # Run and assert
+    with pytest.raises(ValueError, match=error_msg):
+        handle_sampling_error(True, 'test.csv', ValueError('Test error'))
+
+
+def test_handle_sampling_error_false_temp_file():
+    """Test the ``handle_sampling_error`` function.
+
+    Expect that the error is raised at the end of the function.
+
+    Input:
+        - False
+        - a temp file
+        - the sampling error
+
+    Side Effects:
+        - the error is raised.
+    """
+    # Setup
+    error_msg = (
+        'Error: Sampling terminated. Partial results are stored in test.csv.'
+        '\n'
+        'Test error'
+    )
+
+    # Run and assert
+    with pytest.raises(ValueError, match=error_msg):
+        handle_sampling_error(False, 'test.csv', ValueError('Test error'))
+
+
+def test_handle_sampling_error_false_temp_file_none_output_file():
+    """Test the ``handle_sampling_error`` function.
+
+    Expect that only the passed error message is raised when ``is_tmp_file`` and
+    ``output_file_path`` are False/None.
+
+    Input:
+        - False
+        - None
+        - the sampling error
+
+    Side Effects:
+        - the samlping error is raised
+    """
+    # Setup
     error_msg = 'Test error'
 
     # Run and assert
     with pytest.raises(ValueError, match=error_msg):
-        handle_sampling_error(True, 'test.csv', ValueError(error_msg))
+        handle_sampling_error(False, 'test.csv', ValueError('Test error'))
 
 
 def test_handle_sampling_error_ignore():

--- a/tests/unit/tabular/test_utils.py
+++ b/tests/unit/tabular/test_utils.py
@@ -192,7 +192,8 @@ def test_check_num_rows_reject_sampling_error():
     max_tries_per_batch = 1
     error_msg = (
         'Unable to sample any rows for the given conditions. '
-        r'Try increasing `max_tries_per_batch` \(currently: 1\).')
+        r'Try increasing `max_tries_per_batch` \(currently: 1\).'
+    )
 
     # Run and assert
     with pytest.raises(ValueError, match=error_msg):
@@ -218,7 +219,8 @@ def test_check_num_rows_non_reject_sampling_error():
     max_tries = 1
     error_msg = (
         r'Unable to sample any rows for the given conditions. '
-        'This may be because the provided values are out-of-bounds in the current model.')
+        'This may be because the provided values are out-of-bounds in the current model.'
+    )
 
     # Run and assert
     with pytest.raises(ValueError, match=error_msg):
@@ -246,7 +248,8 @@ def test_check_num_rows_non_reject_sampling_warning(warning_mock):
     max_tries = 1
     error_msg = (
         'Unable to sample any rows for the given conditions. '
-        'Try increasing `max_tries` (currently: 1).')
+        'Try increasing `max_tries` (currently: 1).'
+    )
 
     # Run
     check_num_rows(num_rows, expected_num_rows, is_reject_sampling, max_tries)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -83,7 +83,8 @@ def test_get_package_versions_error(get_distribution_mock):
     # Setup
     dist_mock = Mock()
     get_distribution_mock.side_effect = [
-        dist_mock, pkg_resources.ResolutionError(), dist_mock]
+        dist_mock, pkg_resources.ResolutionError(), dist_mock
+    ]
 
     expected = {
         'sdv': dist_mock.version,


### PR DESCRIPTION
1) Reorder methods in the metadata/multi_table.py file to be similar to the metadata/single_table.py ones.

2) Reorder helper methods in both files, so they are immediately above the methods which use them.