### PR TITLE
Add `validate` to `BaseSynthesizer`

### DIFF
--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -39,9 +39,8 @@ import pandas as pd
 from sdv.constraints.base import Constraint
 from sdv.constraints.errors import (
     AggregateConstraintsError, ConstraintMetadataError, FunctionError, InvalidFunctionError)
-from sdv.constraints.utils import (
-    cast_to_datetime64, get_datetime_format, is_datetime_type, logit, matches_datetime_format,
-    sigmoid)
+from sdv.constraints.utils import cast_to_datetime64, logit, matches_datetime_format, sigmoid
+from sdv.utils import get_datetime_format, is_datetime_type
 
 INEQUALITY_TO_OPERATION = {
     '>': np.greater,

--- a/sdv/constraints/utils.py
+++ b/sdv/constraints/utils.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 
 import numpy as np
 import pandas as pd
-from pandas.core.tools.datetimes import _guess_datetime_format_for_array
 
 
 def cast_to_datetime64(value):
@@ -32,29 +31,6 @@ def cast_to_datetime64(value):
     return value
 
 
-def get_datetime_format(value):
-    """Get the ``strftime`` format for a given ``value``.
-
-    This function returns the ``strftime`` format of a given ``value`` when possible.
-    If the ``_guess_datetime_format_for_array`` from ``pandas.core.tools.datetimes`` is
-    able to detect the ``strftime`` it will return it as a ``string`` if not, a ``None``
-    will be returned.
-
-    Args:
-        value (pandas.Series, np.ndarray, list, or str):
-            Input to attempt detecting the format.
-
-    Return:
-        String representing the datetime format in ``strftime`` format or ``None`` if not detected.
-    """
-    if isinstance(value, pd.Series):
-        value = value.astype(str).to_list()
-    if not isinstance(value, (list, np.ndarray)):
-        value = [value]
-
-    return _guess_datetime_format_for_array(value)
-
-
 def matches_datetime_format(value, datetime_format):
     """Check if datetime value matches the provided format.
 
@@ -73,28 +49,6 @@ def matches_datetime_format(value, datetime_format):
         return False
 
     return True
-
-
-def is_datetime_type(value):
-    """Determine if the input is a datetime type or not.
-
-    Args:
-        value (pandas.DataFrame, int, str or datetime):
-            Input to evaluate.
-
-    Returns:
-        bool:
-            True if the input is a datetime type, False if not.
-    """
-    if isinstance(value, (np.ndarray, pd.Series, list)):
-        value = value[0]
-
-    return (
-        pd.api.types.is_datetime64_any_dtype(value)
-        or isinstance(value, pd.Timestamp)
-        or isinstance(value, datetime)
-        or bool(get_datetime_format([value]))
-    )
 
 
 def _cast_to_type(data, dtype):

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -144,6 +144,7 @@ class BaseSynthesizer:
         return errors
 
     def _validate_context_columns(self, data):
+        # NOTE: move method to PARSynthesizer when it has been implemented
         errors = []
         context_column_names = self._data_processor._model_kwargs.get('context_columns')
         if context_column_names:

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -50,7 +50,6 @@ class BaseSynthesizer:
 
     def preprocess(self, data):
         """Transform the raw data to numerical space."""
-        pass
 
     def _fit(self, processed_data):
         """Fit the model to the table.
@@ -79,7 +78,7 @@ class BaseSynthesizer:
         """
         processed_data = self.preprocess(data)
         self.fit_processed_data(processed_data)
-    
+
     def _validate_metadata_matches_data(self, columns):
         errors = []
         metadata_columns = self.metadata._columns or []

--- a/sdv/single_table/errors.py
+++ b/sdv/single_table/errors.py
@@ -3,6 +3,7 @@
 
 class InvalidDataError(Exception):
     """Error to raise when data is not valid."""
+
     def __init__(self, errors):
         self.errors = errors
 

--- a/sdv/single_table/errors.py
+++ b/sdv/single_table/errors.py
@@ -1,0 +1,10 @@
+"""SingleTable Exceptions."""
+
+
+class InvalidDataError(Exception):
+    """Error to raise when data is not valid."""
+    def __init__(self, errors):
+        self.errors = errors
+
+    def __str__(self):
+        return '\n' + '\n\n'.join(map(str, self.errors))

--- a/sdv/single_table/errors.py
+++ b/sdv/single_table/errors.py
@@ -8,4 +8,7 @@ class InvalidDataError(Exception):
         self.errors = errors
 
     def __str__(self):
-        return '\n' + '\n\n'.join(map(str, self.errors))
+        return (
+            'The provided data does not match the metadata:\n' +
+            '\n\n'.join(map(str, self.errors))
+        )

--- a/sdv/single_table/import pandas as pd.py
+++ b/sdv/single_table/import pandas as pd.py
@@ -1,4 +1,0 @@
-import pandas as pd
-
-column = pd.Series[1,2,3]
-print(column[pd.isna(column) | pd.to_numeric(column, errors='coerce')])

--- a/sdv/single_table/import pandas as pd.py
+++ b/sdv/single_table/import pandas as pd.py
@@ -1,0 +1,4 @@
+import pandas as pd
+
+column = pd.Series[1,2,3]
+print(column[pd.isna(column) | pd.to_numeric(column, errors='coerce')])

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -161,3 +161,31 @@ def is_datetime_type(value):
         or isinstance(value, datetime)
         or bool(get_datetime_format([value]))
     )
+
+
+def is_numerical_type(value):
+    """Determine if the input is numerical or not.
+
+    Args:
+        value (int, str, datetime, bool):
+            Input to evaluate.
+
+    Returns:
+        bool:
+            True if the input is numerical, False if not.
+    """
+    return pd.isna(value) | pd.api.types.is_float(value) | pd.api.types.is_integer(value)
+
+
+def is_boolean_type(value):
+    """Determine if the input is a boolean or not.
+
+    Args:
+        value (int, str, datetime, bool):
+            Input to evaluate.
+
+    Returns:
+        bool:
+            True if the input is a boolean, False if not.
+    """
+    return True if pd.isna(value) | (value is True) | (value is False) else False

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -1,7 +1,11 @@
 """Miscellaneous utility functions."""
 import warnings
+from datetime import datetime
 
+import numpy as np
+import pandas as pd
 import pkg_resources
+from pandas.core.tools.datetimes import _guess_datetime_format_for_array
 
 
 def display_tables(tables, max_rows=10, datetime_fmt='%Y-%m-%d %H:%M:%S', row=True):
@@ -112,3 +116,48 @@ def throw_version_mismatch_warning(package_versions):
 
     if len(mismatched_details) > 0:
         warnings.warn(f'{warning_str}{mismatched_details}')
+
+
+def get_datetime_format(value):
+    """Get the ``strftime`` format for a given ``value``.
+
+    This function returns the ``strftime`` format of a given ``value`` when possible.
+    If the ``_guess_datetime_format_for_array`` from ``pandas.core.tools.datetimes`` is
+    able to detect the ``strftime`` it will return it as a ``string`` if not, a ``None``
+    will be returned.
+
+    Args:
+        value (pandas.Series, np.ndarray, list, or str):
+            Input to attempt detecting the format.
+
+    Return:
+        String representing the datetime format in ``strftime`` format or ``None`` if not detected.
+    """
+    if isinstance(value, pd.Series):
+        value = value.astype(str).to_list()
+    if not isinstance(value, (list, np.ndarray)):
+        value = [value]
+
+    return _guess_datetime_format_for_array(value)
+
+
+def is_datetime_type(value):
+    """Determine if the input is a datetime type or not.
+
+    Args:
+        value (pandas.DataFrame, int, str or datetime):
+            Input to evaluate.
+
+    Returns:
+        bool:
+            True if the input is a datetime type, False if not.
+    """
+    if isinstance(value, (np.ndarray, pd.Series, list)):
+        value = value[0]
+
+    return (
+        pd.api.types.is_datetime64_any_dtype(value)
+        or isinstance(value, pd.Timestamp)
+        or isinstance(value, datetime)
+        or bool(get_datetime_format([value]))
+    )

--- a/tests/unit/constraints/test_utils.py
+++ b/tests/unit/constraints/test_utils.py
@@ -6,8 +6,8 @@ import numpy as np
 import pandas as pd
 
 from sdv.constraints.utils import (
-    _cast_to_type, cast_to_datetime64, get_datetime_format, is_datetime_type, logit,
-    matches_datetime_format, sigmoid)
+    _cast_to_type, cast_to_datetime64, logit, matches_datetime_format, sigmoid)
+from sdv.utils import get_datetime_format, is_datetime_type
 
 
 def test_is_datetime_type_with_datetime_series():

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -116,7 +116,7 @@ class TestBaseSynthesizer:
         instance.fit_processed_data.assert_called_once_with(instance.preprocess.return_value)
 
     def test_validate_type(self):
-        """When data is not of type ``pd.DataFrame``, an error should be raised."""
+        """Test error is raised if data is not ``pd.DataFrame``."""
         # Setup
         data = np.ndarray([])
         metadata = SingleTableMetadata()
@@ -128,7 +128,7 @@ class TestBaseSynthesizer:
             instance.validate(data)
 
     def test_validate_data_columns_in_empty_metadata(self):
-        """When data is passed and metadata is empty, an error should be raised."""
+        """Test error is raised if data is passed and metadata is empty."""
         # Setup
         data = pd.DataFrame({
             'col1': [1, 2, 3],
@@ -146,7 +146,7 @@ class TestBaseSynthesizer:
             instance.validate(data)
 
     def test_validate_data_columns_in_metadata(self):
-        """When data columns don't match metadata columns, an error should be raised."""
+        """Test error is raised if data columns don't match metadata columns."""
         # Setup
         data = pd.DataFrame({
             'col1': [1, 2, 3],
@@ -170,7 +170,7 @@ class TestBaseSynthesizer:
             instance.validate(data)
 
     def test_validate_keys_with_missing_values(self):
-        """When keys contain missing values, an error should be raised.
+        """Test error is raised if keys contain missing values.
 
         Setup:
             A ``SingleTableMetadata`` instance with one primary key and multiple sequence
@@ -217,7 +217,7 @@ class TestBaseSynthesizer:
             instance.validate(data)
 
     def test_validate_keys_with_missing2(self):
-        """When keys contain missing values, an error should be raised.
+        """Test error is raised if keys contain missing values.
 
         Test the case with a single sequence key.
         """
@@ -241,7 +241,7 @@ class TestBaseSynthesizer:
             instance.validate(data)
 
     def test_validate_keys_not_unique(self):
-        """When primary or alternate keys are not unique, an error should be raised."""
+        """Test error is raised if primary or alternate keys are not unique."""
         data = pd.DataFrame({
             'pk_col': [0, 1, 1, 0, 2],
             'ak_col1': [0, 1, 0, 3, 3],
@@ -270,7 +270,7 @@ class TestBaseSynthesizer:
             instance.validate(data)
 
     def test_validate_context_columns_unique_per_sequence_key(self):
-        """If context column values are not the same for each tuple of sequence keys, crash.
+        """Test error is raised if context column values vary for each tuple of sequence keys.
 
         Setup:
             A ``SingleTableMetadata`` instance where the context columns vary for different
@@ -307,7 +307,7 @@ class TestBaseSynthesizer:
             instance.validate(data)
 
     def test_validate_empty(self):
-        """When data is empty, it should pass.
+        """Test method doesn't raise when data is empty.
 
         Setup:
             ``SingleTableMetadata`` with one column for each sdtype and for each key.
@@ -336,7 +336,7 @@ class TestBaseSynthesizer:
         instance.validate(data)
 
     def test_validate_no_keys(self):
-        """It should pass even if no keys are passed."""
+        """Test method passes even if no keys are passed."""
         data = pd.DataFrame({
             'bool_col': [1, 2, 3],
             'num_col': [1, 2, 3],
@@ -352,7 +352,7 @@ class TestBaseSynthesizer:
         instance.validate(data)
 
     def test_validate_empty_dataframe(self):
-        """An empty DataFrame should be acceptable as input."""
+        """Test method doesn't raise when data is an empty dataframe."""
         data = pd.DataFrame()
         metadata = SingleTableMetadata()
         instance = BaseSynthesizer(metadata)
@@ -361,7 +361,7 @@ class TestBaseSynthesizer:
         instance.validate(data)
 
     def test_validate_sdtypes(self):
-        """When column values don't satistfy their sdtype, raise an error.
+        """Test error is raised if column values don't satistfy their sdtype.
 
         Setup:
             A ``SingleTableMetadata`` instance with two columns of each sdtype: numerical,
@@ -406,7 +406,7 @@ class TestBaseSynthesizer:
             instance.validate(data)
 
     def test_validate(self):
-        """Test the method doesn't crash when the passed data is vaild
+        """Test the method doesn't crash when the passed data is vaild.
 
         Setup:
             ``SingleTableMetadata`` describing at least one valid column of each key and sdtype.

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -1,16 +1,17 @@
+import re
 from datetime import datetime
-
 from unittest.mock import Mock, patch
 
 import pytest
 
 from sdv.single_table.base import BaseSynthesizer
 from sdv.metadata.single_table import SingleTableMetadata
+import numpy as np
 import pandas as pd
 import pytest
-import re
-import numpy as np
 
+from sdv.metadata.single_table import SingleTableMetadata
+from sdv.single_table.base import BaseSynthesizer
 from sdv.single_table.errors import InvalidDataError
 
 
@@ -113,12 +114,6 @@ class TestBaseSynthesizer:
         # Assert
         instance.preprocess.assert_called_once_with(processed_data)
         instance.fit_processed_data.assert_called_once_with(instance.preprocess.return_value)
-    
-    def test_validate_keys(self):
-        data = pd.DataFrame({
-            'pk_col': [0,1,2,3,4,5],
-            'sk_col': [0,1,2,3,4,5],
-            'ak_col': [0,1,2,3,4,5],
 
     def test_validate_type(self):
         """When data is not of type ``pd.DataFrame``, an error should be raised."""
@@ -131,13 +126,13 @@ class TestBaseSynthesizer:
         err_msg = "Data must be a DataFrame, not a <class 'numpy.ndarray'>."
         with pytest.raises(ValueError, match=err_msg):
             instance.validate(data)
-    
+
     def test_validate_data_columns_in_empty_metadata(self):
         """When data is passed and metadata is empty, an error should be raised."""
         # Setup
         data = pd.DataFrame({
-            'col1': [1,2,3],
-            'col2': [4,5,6],
+            'col1': [1, 2, 3],
+            'col2': [4, 5, 6],
         })
         metadata = SingleTableMetadata()
         instance = BaseSynthesizer(metadata)
@@ -146,14 +141,14 @@ class TestBaseSynthesizer:
         err_msg = re.escape("\nThe columns ['col1', 'col2'] are not present in the metadata.")
         with pytest.raises(InvalidDataError, match=err_msg):
             instance.validate(data)
-    
+
     def test_validate_data_columns_in_metadata(self):
         """When data columns don't match metadata columns, an error should be raised."""
         # Setup
         data = pd.DataFrame({
-            'col1': [1,2,3],
-            'col2': [4,5,6],
-            'col3': [7,8,9],
+            'col1': [1, 2, 3],
+            'col2': [4, 5, 6],
+            'col3': [7, 8, 9],
         })
         metadata = SingleTableMetadata()
         metadata.add_column('col1', sdtype='numerical')
@@ -169,10 +164,10 @@ class TestBaseSynthesizer:
         )
         with pytest.raises(InvalidDataError, match=err_msg):
             instance.validate(data)
-    
+
     def test_validate_keys_with_missing_values(self):
         """When keys contain missing values, an error should be raised.
-        
+
         Setup:
             A ``SingleTableMetadata`` instance with one primary key and multiple sequence
             and alternate keys. All the columns contain missing values except for one
@@ -180,13 +175,13 @@ class TestBaseSynthesizer:
             in the error message.
         """
         data = pd.DataFrame({
-            'pk_col': [0,1,np.nan],
-            'sk_col1': [0,1,None],
-            'sk_col2': [0,1,np.nan],
-            'sk_col3': [0,1,2],
-            'ak_col1': [0,1,None],
-            'ak_col2': [0,1,np.nan],
-            'ak_col3': [0,1,2]
+            'pk_col': [0, 1, np.nan],
+            'sk_col1': [0, 1, None],
+            'sk_col2': [0, 1, np.nan],
+            'sk_col3': [0, 1, 2],
+            'ak_col1': [0, 1, None],
+            'ak_col2': [0, 1, np.nan],
+            'ak_col3': [0, 1, 2]
         })
         metadata = SingleTableMetadata()
         metadata.add_column('pk_col', sdtype='numerical')
@@ -215,10 +210,10 @@ class TestBaseSynthesizer:
         )
         with pytest.raises(InvalidDataError, match=err_msg):
             instance.validate(data)
-    
+
     def test_validate_keys_with_missing2(self):
         """When keys contain missing values, an error should be raised.
-        
+
         Test the case with a single sequence key.
         """
         data = pd.DataFrame({
@@ -236,14 +231,14 @@ class TestBaseSynthesizer:
         err_msg = re.escape("\nKey column 'sk_col' contains missing values.")
         with pytest.raises(InvalidDataError, match=err_msg):
             instance.validate(data)
-    
+
     def test_validate_keys_not_unique(self):
         """When primary or alternate keys are not unique, an error should be raised."""
         data = pd.DataFrame({
-            'pk_col': [0,1,1,0,2],
-            'ak_col1': [0,1,0,3,3],
-            'ak_col2': [2,2,2,2,2],
-            'ak_col3': [0,1,2,3,4]
+            'pk_col': [0, 1, 1, 0, 2],
+            'ak_col1': [0, 1, 0, 3, 3],
+            'ak_col2': [2, 2, 2, 2, 2],
+            'ak_col3': [0, 1, 2, 3, 4]
         })
         metadata = SingleTableMetadata()
         metadata.add_column('pk_col', sdtype='numerical')
@@ -264,20 +259,20 @@ class TestBaseSynthesizer:
         )
         with pytest.raises(InvalidDataError, match=err_msg):
             instance.validate(data)
-    
+
     def test_validate_context_columns_unique_per_sequence_key(self):
         """If context column values are not the same for each tuple of sequence keys, crash.
-        
+
         Setup:
             A ``SingleTableMetadata`` instance where the context columns vary for different
-            combinations of values of the sequence keys. 
+            combinations of values of the sequence keys.
         """
         # Setup
         data = pd.DataFrame({
-            'sk_col1': [1,1,2,2,2],
-            'sk_col2': [1,1,2,2,3],
-            'ct_col1': [1,2,2,3,2],
-            'ct_col2': [3,3,4,3,2],
+            'sk_col1': [1, 1, 2, 2, 2],
+            'sk_col2': [1, 1, 2, 2, 3],
+            'ct_col1': [1, 2, 2, 3, 2],
+            'ct_col2': [3, 3, 4, 3, 2],
         })
         metadata = SingleTableMetadata()
         metadata.add_column('sk_col1', sdtype='numerical')
@@ -287,7 +282,8 @@ class TestBaseSynthesizer:
         metadata.set_sequence_key(('sk_col1', 'sk_col2'))
         instance = BaseSynthesizer(metadata)
         instance._data_processor._model_kwargs = {
-            'context_columns': ['ct_col1', 'ct_col2']}  # NOTE
+            'context_columns': ['ct_col1', 'ct_col2']  # NOTE: change to actual value
+        }
 
         # Run and Assert
         err_msg = re.escape(
@@ -299,10 +295,10 @@ class TestBaseSynthesizer:
         )
         with pytest.raises(InvalidDataError, match=err_msg):
             instance.validate(data)
-    
+
     def test_validate_empty(self):
         """When data is empty, it should pass.
-        
+
         Setup:
             ``SingleTableMetadata`` with one column for each sdtype and for each key.
         """
@@ -332,9 +328,9 @@ class TestBaseSynthesizer:
     def test_validate_no_keys(self):
         """It should pass even if no keys are passed."""
         data = pd.DataFrame({
-            'bool_col': [1,2,3],
-            'num_col': [1,2,3],
-            'date_col': [1,2,3],
+            'bool_col': [1, 2, 3],
+            'num_col': [1, 2, 3],
+            'date_col': [1, 2, 3],
         })
         metadata = SingleTableMetadata()
         metadata.add_column('bool_col', sdtype='numerical')
@@ -344,7 +340,7 @@ class TestBaseSynthesizer:
 
         # Run
         instance.validate(data)
-    
+
     def test_validate_empty_dataframe(self):
         """An empty DataFrame should be acceptable as input."""
         data = pd.DataFrame()
@@ -356,7 +352,7 @@ class TestBaseSynthesizer:
 
     def test_validate_sdtypes(self):
         """When column values don't satistfy their sdtype, raise an error.
-        
+
         Setup:
             A ``SingleTableMetadata`` instance with two columns of each sdtype: numerical,
             boolean and datetime. The first column of each will have 4 invalid values,
@@ -365,11 +361,11 @@ class TestBaseSynthesizer:
         # Setup
         data = pd.DataFrame({
             'date1': ['10', True, 'b', 'bla', None],
-            'date2': ['2021-10-10', '05-10-2021', pd.Timestamp(1), datetime(1,1,1), '2020-1-33'],
+            'date2': ['2021-10-10', '05-10-2021', pd.Timestamp(1), datetime(1, 1, 1), '2020-1-33'],
             'bool1': ['a', 0, '10', True, 'b'],
             'bool2': ['True', False, np.nan, float('nan'), None],
             'num1': ['a', 0, '10', True, False],
-            'num2': [-1.2, datetime(1,1,1), np.nan, float('nan'), None],
+            'num2': [-1.2, datetime(1, 1, 1), np.nan, float('nan'), None],
         })
         metadata = SingleTableMetadata()
         metadata.add_column('date1', sdtype='datetime')
@@ -392,24 +388,25 @@ class TestBaseSynthesizer:
             '\n'
             "\nInvalid values found for numerical column 'num1': ['10', False, True, '+ 1 more']."
             '\n'
-            "\nInvalid values found for numerical column 'num2': [datetime.datetime(1, 1, 1, 0, 0)]."
+            "\nInvalid values found for numerical column 'num2': "
+            '[datetime.datetime(1, 1, 1, 0, 0)].'
         )
         with pytest.raises(InvalidDataError, match=err_msg):
             instance.validate(data)
 
     def test_validate(self):
         """Test the method doesn't crash when the passed data is vaild
-        
+
         Setup:
             ``SingleTableMetadata`` describing at least one valid column of each key and sdtype.
         """
         # Setup
         data = pd.DataFrame({
-            'pk_col': [0,1,2],
-            'sk_col1': [0,1,2],
-            'sk_col2': [0,1,2],
-            'ak_col1': [0,1,2],
-            'ak_col2': [0,1,2],
+            'pk_col': [0, 1, 2],
+            'sk_col1': [0, 1, 2],
+            'sk_col2': [0, 1, 2],
+            'ak_col1': [0, 1, 2],
+            'ak_col2': [0, 1, 2],
             'numerical_col': [np.nan, -1, 1.54],
             'date_col': [np.nan, '2021-02-10', '2021-05-10'],
             'bool_col': [np.nan, True, False],

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from unittest.mock import Mock, patch
 
 import pytest
@@ -6,7 +8,10 @@ from sdv.single_table.base import BaseSynthesizer
 from sdv.metadata.single_table import SingleTableMetadata
 import pandas as pd
 import pytest
+import re
 import numpy as np
+
+from sdv.single_table.errors import InvalidDataError
 
 
 class TestBaseSynthesizer:
@@ -115,27 +120,204 @@ class TestBaseSynthesizer:
             'sk_col': [0,1,2,3,4,5],
             'ak_col': [0,1,2,3,4,5],
 
-        })
+    def test_validate_type(self):
+        """When data is not of type ``pd.DataFrame``, an error should be raised."""
+        # Setup
+        data = np.ndarray([])
         metadata = SingleTableMetadata()
-        metadata.add_column('pk_col', sdtype='numerical')
-        metadata.add_column('sk_col', sdtype='numerical')
-        metadata.add_column('ak_col', sdtype='numerical')
-        metadata.set_primary_key('pk_col')
-        metadata.set_sequence_key('sk_col')
-        metadata.set_alternate_keys(['ak_col'])
         instance = BaseSynthesizer(metadata)
 
-        # Run
-        instance.validate(data)
+        # Run and Assert
+        err_msg = "Data must be a DataFrame, not a <class 'numpy.ndarray'>."
+        with pytest.raises(ValueError, match=err_msg):
+            instance.validate(data)
+    
+    def test_validate_data_columns_in_empty_metadata(self):
+        """When data is passed and metadata is empty, an error should be raised."""
+        # Setup
+        data = pd.DataFrame({
+            'col1': [1,2,3],
+            'col2': [4,5,6],
+        })
+        metadata = SingleTableMetadata()
+        instance = BaseSynthesizer(metadata)
 
+        # Run and Assert
+        err_msg = re.escape("\nThe columns ['col1', 'col2'] are not present in the metadata.")
+        with pytest.raises(InvalidDataError, match=err_msg):
+            instance.validate(data)
+    
+    def test_validate_data_columns_in_metadata(self):
+        """When data columns don't match metadata columns, an error should be raised."""
+        # Setup
+        data = pd.DataFrame({
+            'col1': [1,2,3],
+            'col2': [4,5,6],
+            'col3': [7,8,9],
+        })
+        metadata = SingleTableMetadata()
+        metadata.add_column('col1', sdtype='numerical')
+        metadata.add_column('col4', sdtype='numerical')
+        metadata.add_column('col5', sdtype='numerical')
+        instance = BaseSynthesizer(metadata)
+
+        # Run and Assert
+        err_msg = re.escape(
+            "\nThe columns ['col2', 'col3'] are not present in the metadata."
+            '\n'
+            "\nThe metadata columns ['col4', 'col5'] are not present in the data."
+        )
+        with pytest.raises(InvalidDataError, match=err_msg):
+            instance.validate(data)
+    
     def test_validate_keys_with_missing_values(self):
+        """When keys contain missing values, an error should be raised.
+        
+        Setup:
+            A ``SingleTableMetadata`` instance with one primary key and multiple sequence
+            and alternate keys. All the columns contain missing values except for one
+            squence key and one alternate key, so we can ensure those don't show up
+            in the error message.
+        """
         data = pd.DataFrame({
-            'pk_col': [0,1,2,3,4,np.nan],
-            'sk_col': [0,1,2,3,4,np.nan],
-            'ak_col': [0,1,2,3,4,np.nan],
-
+            'pk_col': [0,1,np.nan],
+            'sk_col1': [0,1,None],
+            'sk_col2': [0,1,np.nan],
+            'sk_col3': [0,1,2],
+            'ak_col1': [0,1,None],
+            'ak_col2': [0,1,np.nan],
+            'ak_col3': [0,1,2]
         })
         metadata = SingleTableMetadata()
+        metadata.add_column('pk_col', sdtype='numerical')
+        metadata.add_column('sk_col1', sdtype='numerical')
+        metadata.add_column('sk_col2', sdtype='numerical')
+        metadata.add_column('sk_col3', sdtype='numerical')
+        metadata.add_column('ak_col1', sdtype='numerical')
+        metadata.add_column('ak_col2', sdtype='numerical')
+        metadata.add_column('ak_col3', sdtype='numerical')
+        metadata.set_primary_key('pk_col')
+        metadata.set_sequence_key(('sk_col1', 'sk_col2', 'sk_col3'))
+        metadata.set_alternate_keys(['ak_col1', 'ak_col2', 'ak_col3'])
+        instance = BaseSynthesizer(metadata)
+
+        # Run and Assert
+        err_msg = re.escape(
+            "\nKey column 'ak_col1' contains missing values."
+            '\n'
+            "\nKey column 'ak_col2' contains missing values."
+            '\n'
+            "\nKey column 'pk_col' contains missing values."
+            '\n'
+            "\nKey column 'sk_col1' contains missing values."
+            '\n'
+            "\nKey column 'sk_col2' contains missing values."
+        )
+        with pytest.raises(InvalidDataError, match=err_msg):
+            instance.validate(data)
+    
+    def test_validate_keys_with_missing2(self):
+        """When keys contain missing values, an error should be raised.
+        
+        Test the case with a single sequence key.
+        """
+        data = pd.DataFrame({
+            'pk_col': [1],
+            'sk_col': [None]
+        })
+        metadata = SingleTableMetadata()
+        metadata.add_column('pk_col', sdtype='numerical')
+        metadata.add_column('sk_col', sdtype='numerical')
+        metadata.set_primary_key('pk_col')
+        metadata.set_sequence_key('sk_col')
+        instance = BaseSynthesizer(metadata)
+
+        # Run and Assert
+        err_msg = re.escape("\nKey column 'sk_col' contains missing values.")
+        with pytest.raises(InvalidDataError, match=err_msg):
+            instance.validate(data)
+    
+    def test_validate_keys_not_unique(self):
+        """When primary or alternate keys are not unique, an error should be raised."""
+        data = pd.DataFrame({
+            'pk_col': [0,1,1,0,2],
+            'ak_col1': [0,1,0,3,3],
+            'ak_col2': [2,2,2,2,2],
+            'ak_col3': [0,1,2,3,4]
+        })
+        metadata = SingleTableMetadata()
+        metadata.add_column('pk_col', sdtype='numerical')
+        metadata.add_column('ak_col1', sdtype='numerical')
+        metadata.add_column('ak_col2', sdtype='numerical')
+        metadata.add_column('ak_col3', sdtype='numerical')
+        metadata.set_primary_key('pk_col')
+        metadata.set_alternate_keys(['ak_col1', 'ak_col2', 'ak_col3'])
+        instance = BaseSynthesizer(metadata)
+
+        # Run and Assert
+        err_msg = re.escape(
+            "\nKey column 'ak_col1' contains repeating values: [0, 3]"
+            '\n'
+            "\nKey column 'ak_col2' contains repeating values: [2]"
+            '\n'
+            "\nKey column 'pk_col' contains repeating values: [0, 1]"
+        )
+        with pytest.raises(InvalidDataError, match=err_msg):
+            instance.validate(data)
+    
+    def test_validate_context_columns_unique_per_sequence_key(self):
+        """If context column values are not the same for each tuple of sequence keys, crash.
+        
+        Setup:
+            A ``SingleTableMetadata`` instance where the context columns vary for different
+            combinations of values of the sequence keys. 
+        """
+        # Setup
+        data = pd.DataFrame({
+            'sk_col1': [1,1,2,2,2],
+            'sk_col2': [1,1,2,2,3],
+            'ct_col1': [1,2,2,3,2],
+            'ct_col2': [3,3,4,3,2],
+        })
+        metadata = SingleTableMetadata()
+        metadata.add_column('sk_col1', sdtype='numerical')
+        metadata.add_column('sk_col2', sdtype='numerical')
+        metadata.add_column('ct_col1', sdtype='numerical')
+        metadata.add_column('ct_col2', sdtype='numerical')
+        metadata.set_sequence_key(('sk_col1', 'sk_col2'))
+        instance = BaseSynthesizer(metadata)
+        instance._data_processor._model_kwargs = {
+            'context_columns': ['ct_col1', 'ct_col2']}  # NOTE
+
+        # Run and Assert
+        err_msg = re.escape(
+            "\nContext column(s) {'ct_col1': {1, 2}} are changing inside the "
+            "sequence keys (['sk_col1', 'sk_col2']: (1, 1))."
+            '\n'
+            "\nContext column(s) {'ct_col1': {2, 3}, 'ct_col2': {3, 4}} are changing inside the "
+            "sequence keys (['sk_col1', 'sk_col2']: (2, 2))."
+        )
+        with pytest.raises(InvalidDataError, match=err_msg):
+            instance.validate(data)
+    
+    def test_validate_empty(self):
+        """When data is empty, it should pass.
+        
+        Setup:
+            ``SingleTableMetadata`` with one column for each sdtype and for each key.
+        """
+        data = pd.DataFrame({
+            'pk_col': [],
+            'sk_col': [],
+            'ak_col': [],
+            'bool_col': [],
+            'num_col': [],
+            'date_col': [],
+        })
+        metadata = SingleTableMetadata()
+        metadata.add_column('bool_col', sdtype='boolean')
+        metadata.add_column('num_col', sdtype='numerical')
+        metadata.add_column('date_col', sdtype='datetime')
         metadata.add_column('pk_col', sdtype='numerical')
         metadata.add_column('sk_col', sdtype='numerical')
         metadata.add_column('ak_col', sdtype='numerical')
@@ -144,46 +326,108 @@ class TestBaseSynthesizer:
         metadata.set_alternate_keys(['ak_col'])
         instance = BaseSynthesizer(metadata)
 
-        # Run and Assert
+        # Run
         instance.validate(data)
-        
 
-    
-    def test_validate(self):
-        """Test it doesn't crash."""
-        # Setup
+    def test_validate_no_keys(self):
+        """It should pass even if no keys are passed."""
         data = pd.DataFrame({
-            'numerical_col': [np.nan, None, float('nan'), -1, 0, 1.54],
-            'date_col': [np.nan, None, float('nan'), '2021-02-10', '2021-05-10', '2021-08-11'],
-            'bool_col': [np.nan, None, float('nan'), True, False, True],
-
+            'bool_col': [1,2,3],
+            'num_col': [1,2,3],
+            'date_col': [1,2,3],
         })
         metadata = SingleTableMetadata()
-        metadata.add_column('numerical_col', sdtype='numerical')
-        metadata.add_column('date_col', sdtype='datetime')
-        metadata.add_column('bool_col', sdtype='boolean')
+        metadata.add_column('bool_col', sdtype='numerical')
+        metadata.add_column('num_col', sdtype='numerical')
+        metadata.add_column('date_col', sdtype='numerical')
         instance = BaseSynthesizer(metadata)
 
         # Run
         instance.validate(data)
     
-    def test_validate_all_together(self):
-        ...
-    
-    def test_validate_raises(self):
-        """Test it crashes with right error."""
+    def test_validate_empty_dataframe(self):
+        """An empty DataFrame should be acceptable as input."""
+        data = pd.DataFrame()
+        metadata = SingleTableMetadata()
+        instance = BaseSynthesizer(metadata)
+
+        # Run
+        instance.validate(data)
+
+    def test_validate_sdtypes(self):
+        """When column values don't satistfy their sdtype, raise an error.
+        
+        Setup:
+            A ``SingleTableMetadata`` instance with two columns of each sdtype: numerical,
+            boolean and datetime. The first column of each will have 4 invalid values,
+            while the second column will have at most 3.
+        """
         # Setup
         data = pd.DataFrame({
-            'numerical_col': ['a', 1, '10', 5, True, 'b'],
-            'date_col': ['10', 10, True, '2021-05-10', '10-10-10-10', 'Bla'],
-            'bool_col': ['a', 1, '10', 5, True, 'b'],
+            'date1': ['10', True, 'b', 'bla', None],
+            'date2': ['2021-10-10', '05-10-2021', pd.Timestamp(1), datetime(1,1,1), '2020-1-33'],
+            'bool1': ['a', 0, '10', True, 'b'],
+            'bool2': ['True', False, np.nan, float('nan'), None],
+            'num1': ['a', 0, '10', True, False],
+            'num2': [-1.2, datetime(1,1,1), np.nan, float('nan'), None],
         })
         metadata = SingleTableMetadata()
-        metadata.add_column('numerical_col', sdtype='numerical')
-        metadata.add_column('date_col', sdtype='datetime')
-        metadata.add_column('bool_col', sdtype='boolean')
+        metadata.add_column('date1', sdtype='datetime')
+        metadata.add_column('date2', sdtype='datetime')
+        metadata.add_column('bool1', sdtype='boolean')
+        metadata.add_column('bool2', sdtype='boolean')
+        metadata.add_column('num1', sdtype='numerical')
+        metadata.add_column('num2', sdtype='numerical')
         instance = BaseSynthesizer(metadata)
 
         # Run and Assert
-        instance.validate(data)
+        err_msg = re.escape(
+            "\nInvalid values found for datetime column 'date1': ['10', True, 'b', '+ 1 more']."
+            '\n'
+            "\nInvalid values found for datetime column 'date2': ['2020-1-33']."
+            '\n'
+            "\nInvalid values found for boolean column 'bool1': [0, '10', 'a', '+ 1 more']."
+            '\n'
+            "\nInvalid values found for boolean column 'bool2': ['True']."
+            '\n'
+            "\nInvalid values found for numerical column 'num1': ['10', False, True, '+ 1 more']."
+            '\n'
+            "\nInvalid values found for numerical column 'num2': [datetime.datetime(1, 1, 1, 0, 0)]."
+        )
+        with pytest.raises(InvalidDataError, match=err_msg):
+            instance.validate(data)
+
+    def test_validate(self):
+        """Test the method doesn't crash when the passed data is vaild
         
+        Setup:
+            ``SingleTableMetadata`` describing at least one valid column of each key and sdtype.
+        """
+        # Setup
+        data = pd.DataFrame({
+            'pk_col': [0,1,2],
+            'sk_col1': [0,1,2],
+            'sk_col2': [0,1,2],
+            'ak_col1': [0,1,2],
+            'ak_col2': [0,1,2],
+            'numerical_col': [np.nan, -1, 1.54],
+            'date_col': [np.nan, '2021-02-10', '2021-05-10'],
+            'bool_col': [np.nan, True, False],
+
+        })
+        metadata = SingleTableMetadata()
+        metadata.add_column('pk_col', sdtype='numerical')
+        metadata.add_column('sk_col1', sdtype='numerical')
+        metadata.add_column('sk_col2', sdtype='numerical')
+        metadata.add_column('ak_col1', sdtype='numerical')
+        metadata.add_column('ak_col2', sdtype='numerical')
+        metadata.add_column('numerical_col', sdtype='numerical')
+        metadata.add_column('date_col', sdtype='datetime')
+        metadata.add_column('bool_col', sdtype='boolean')
+        metadata.set_primary_key('pk_col')
+        metadata.set_sequence_key(('sk_col1', 'sk_col2'))
+        metadata.set_alternate_keys(['ak_col1', 'ak_col2'])
+        instance = BaseSynthesizer(metadata)
+
+        # Run
+        instance.validate(data)

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -138,7 +138,10 @@ class TestBaseSynthesizer:
         instance = BaseSynthesizer(metadata)
 
         # Run and Assert
-        err_msg = re.escape("\nThe columns ['col1', 'col2'] are not present in the metadata.")
+        err_msg = re.escape(
+            'The provided data does not match the metadata:'
+            "\nThe columns ['col1', 'col2'] are not present in the metadata."
+        )
         with pytest.raises(InvalidDataError, match=err_msg):
             instance.validate(data)
 
@@ -158,6 +161,7 @@ class TestBaseSynthesizer:
 
         # Run and Assert
         err_msg = re.escape(
+            'The provided data does not match the metadata:'
             "\nThe columns ['col2', 'col3'] are not present in the metadata."
             '\n'
             "\nThe metadata columns ['col4', 'col5'] are not present in the data."
@@ -193,11 +197,12 @@ class TestBaseSynthesizer:
         metadata.add_column('ak_col3', sdtype='numerical')
         metadata.set_primary_key('pk_col')
         metadata.set_sequence_key(('sk_col1', 'sk_col2', 'sk_col3'))
-        metadata.set_alternate_keys(['ak_col1', 'ak_col2', 'ak_col3'])
+        metadata.add_alternate_keys(['ak_col1', 'ak_col2', 'ak_col3'])
         instance = BaseSynthesizer(metadata)
 
         # Run and Assert
         err_msg = re.escape(
+            'The provided data does not match the metadata:'
             "\nKey column 'ak_col1' contains missing values."
             '\n'
             "\nKey column 'ak_col2' contains missing values."
@@ -228,7 +233,10 @@ class TestBaseSynthesizer:
         instance = BaseSynthesizer(metadata)
 
         # Run and Assert
-        err_msg = re.escape("\nKey column 'sk_col' contains missing values.")
+        err_msg = re.escape(
+            'The provided data does not match the metadata:'
+            "\nKey column 'sk_col' contains missing values."
+        )
         with pytest.raises(InvalidDataError, match=err_msg):
             instance.validate(data)
 
@@ -246,11 +254,12 @@ class TestBaseSynthesizer:
         metadata.add_column('ak_col2', sdtype='numerical')
         metadata.add_column('ak_col3', sdtype='numerical')
         metadata.set_primary_key('pk_col')
-        metadata.set_alternate_keys(['ak_col1', 'ak_col2', 'ak_col3'])
+        metadata.add_alternate_keys(['ak_col1', 'ak_col2', 'ak_col3'])
         instance = BaseSynthesizer(metadata)
 
         # Run and Assert
         err_msg = re.escape(
+            'The provided data does not match the metadata:'
             "\nKey column 'ak_col1' contains repeating values: [0, 3]"
             '\n'
             "\nKey column 'ak_col2' contains repeating values: [2]"
@@ -287,6 +296,7 @@ class TestBaseSynthesizer:
 
         # Run and Assert
         err_msg = re.escape(
+            'The provided data does not match the metadata:'
             "\nContext column(s) {'ct_col1': {1, 2}} are changing inside the "
             "sequence keys (['sk_col1', 'sk_col2']: (1, 1))."
             '\n'
@@ -319,7 +329,7 @@ class TestBaseSynthesizer:
         metadata.add_column('ak_col', sdtype='numerical')
         metadata.set_primary_key('pk_col')
         metadata.set_sequence_key('sk_col')
-        metadata.set_alternate_keys(['ak_col'])
+        metadata.add_alternate_keys(['ak_col'])
         instance = BaseSynthesizer(metadata)
 
         # Run
@@ -378,6 +388,7 @@ class TestBaseSynthesizer:
 
         # Run and Assert
         err_msg = re.escape(
+            'The provided data does not match the metadata:'
             "\nInvalid values found for datetime column 'date1': ['10', True, 'b', '+ 1 more']."
             '\n'
             "\nInvalid values found for datetime column 'date2': ['2020-1-33']."
@@ -423,7 +434,7 @@ class TestBaseSynthesizer:
         metadata.add_column('bool_col', sdtype='boolean')
         metadata.set_primary_key('pk_col')
         metadata.set_sequence_key(('sk_col1', 'sk_col2'))
-        metadata.set_alternate_keys(['ak_col1', 'ak_col2'])
+        metadata.add_alternate_keys(['ak_col1', 'ak_col2'])
         instance = BaseSynthesizer(metadata)
 
         # Run

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -361,7 +361,7 @@ class TestBaseSynthesizer:
         instance.validate(data)
 
     def test_validate_sdtypes(self):
-        """Test error is raised if column values don't satistfy their sdtype.
+        """Test error is raised if column values don't satisfy their sdtype.
 
         Setup:
             A ``SingleTableMetadata`` instance with two columns of each sdtype: numerical,
@@ -406,7 +406,7 @@ class TestBaseSynthesizer:
             instance.validate(data)
 
     def test_validate(self):
-        """Test the method doesn't crash when the passed data is vaild.
+        """Test the method doesn't crash when the passed data is valid.
 
         Setup:
             ``SingleTableMetadata`` describing at least one valid column of each key and sdtype.

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -2,10 +2,6 @@ import re
 from datetime import datetime
 from unittest.mock import Mock, patch
 
-import pytest
-
-from sdv.single_table.base import BaseSynthesizer
-from sdv.metadata.single_table import SingleTableMetadata
 import numpy as np
 import pandas as pd
 import pytest


### PR DESCRIPTION
Resolve #1014.

**Note**: as described in the issue, the validate only checks for `numerical`, `boolean` and `datetime` sdtypes. `categorical`, `text` or any others are not being validated. 