### PR TITLE
Change set_alternate_keys to add_alternate_keys and add error handling

### DIFF
--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -311,7 +311,7 @@ class MultiTableMetadata:
         warnings.warn('Sequential modeling is not yet supported on SDV Multi Table models.')
         self._tables[table_name].set_sequence_key(column_name)
 
-    def set_alternate_keys(self, table_name, column_names):
+    def add_alternate_keys(self, table_name, column_names):
         """Set the alternate keys of a table.
 
         Args:
@@ -321,7 +321,7 @@ class MultiTableMetadata:
                 List of names (or tuple of names) of the alternate key columns.
         """
         self._validate_table_exists(table_name)
-        self._tables[table_name].set_alternate_keys(column_names)
+        self._tables[table_name].add_alternate_keys(column_names)
 
     def set_sequence_index(self, table_name, column_name):
         """Set the sequence index of a table.

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -319,6 +319,12 @@ class SingleTableMetadata:
                 Name (or tuple of names) of the primary key column(s).
         """
         self._validate_key(column_name, 'primary')
+        if column_name in self._alternate_keys:
+            warnings.warn(
+                f'{column_name} is currently set as an alternate key and will be removed from '
+                'that list.')
+            self._alternate_keys.remove(column_name)
+
         if self._primary_key is not None:
             warnings.warn(
                 f'There is an existing primary key {self._primary_key}.'
@@ -361,9 +367,15 @@ class SingleTableMetadata:
                 ' Keys should be columns that exist in the table.'
             )
 
+        if self._primary_key in column_names:
+            raise ValueError(
+                f"Invalid alternate key '{self._primary_key}'. The key is "
+                'already specified as a primary key.'
+            )
+
         self._validate_keys_sdtype(keys, 'alternate')
 
-    def set_alternate_keys(self, column_names):
+    def add_alternate_keys(self, column_names):
         """Set the metadata alternate keys.
 
         Args:
@@ -371,7 +383,7 @@ class SingleTableMetadata:
                 List of names (or tuple of names) of the alternate key columns.
         """
         self._validate_alternate_keys(column_names)
-        self._alternate_keys = column_names
+        self._alternate_keys += column_names
 
     def _validate_sequence_index(self, column_name):
         if not isinstance(column_name, str):

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -322,7 +322,8 @@ class SingleTableMetadata:
         if column_name in self._alternate_keys:
             warnings.warn(
                 f'{column_name} is currently set as an alternate key and will be removed from '
-                'that list.')
+                'that list.'
+            )
             self._alternate_keys.remove(column_name)
 
         if self._primary_key is not None:
@@ -383,7 +384,11 @@ class SingleTableMetadata:
                 List of names (or tuple of names) of the alternate key columns.
         """
         self._validate_alternate_keys(column_names)
-        self._alternate_keys += column_names
+        for column in column_names:
+            if column in self._alternate_keys:
+                warnings.warn(f'{column} is already an alternate key.')
+            else:
+                self._alternate_keys.append(column)
 
     def _validate_sequence_index(self, column_name):
         if not isinstance(column_name, str):

--- a/tests/integration/metadata/test_single_table.py
+++ b/tests/integration/metadata/test_single_table.py
@@ -55,7 +55,7 @@ def test_validate():
         value=10
     )
     instance.set_primary_key('col1')
-    instance.set_alternate_keys([('col1', 'col2')])
+    instance.add_alternate_keys([('col1', 'col2')])
     instance.set_sequence_index('col1')
     instance.set_sequence_key('col2')
 

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -1435,11 +1435,11 @@ class TestMultiTableMetadata:
         metadata._validate_table_exists.assert_called_once_with('table1')
         metadata._tables['table1'].set_sequence_key.assert_called_once_with('col')
 
-    def test_set_alternate_keys(self):
-        """Test ``set_alternate_keys``.
+    def test_add_alternate_keys(self):
+        """Test ``add_alternate_keys``.
 
         The method should validate the table exists and call
-        ``SingleTableMetadata.set_alternate_keys``.
+        ``SingleTableMetadata.add_alternate_keys``.
 
         Setup:
             - Instantiate ``MultiTableMetadata`` with some ``_tables``.
@@ -1455,11 +1455,11 @@ class TestMultiTableMetadata:
         metadata._validate_table_exists = Mock()
 
         # Run
-        metadata.set_alternate_keys('table1', ['col1', 'col2'])
+        metadata.add_alternate_keys('table1', ['col1', 'col2'])
 
         # Assert
         metadata._validate_table_exists.assert_called_once_with('table1')
-        metadata._tables['table1'].set_alternate_keys.assert_called_once_with(['col1', 'col2'])
+        metadata._tables['table1'].add_alternate_keys.assert_called_once_with(['col1', 'col2'])
 
     def test_set_sequence_index(self):
         """Test ``set_sequence_index``.

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -992,7 +992,7 @@ class TestSingleTableMetadata:
         assert instance._primary_key == ('col1', 'col2')
 
     @patch('sdv.tabular.utils.warnings')
-    def test_set_primary_key_warning(self, warning_mock):
+    def test_set_primary_key_already_exists_warning(self, warning_mock):
         """Test that ``set_primary_key`` raises a warning when a primary key already exists.
 
         Setup:
@@ -1016,6 +1016,30 @@ class TestSingleTableMetadata:
         warning_msg = "There is an existing primary key 'column0'. This key will be removed."
         assert warning_mock.warn.called_once_with(warning_msg)
         assert instance._primary_key == 'column1'
+
+    @patch('sdv.tabular.utils.warnings')
+    def test_set_primary_key_in_alternate_keys_warning(self, warning_mock):
+        """Test that ``set_primary_key`` raises a warning the key is in ``self._alternate_keys``.
+
+        Setup:
+            Set the ``self._alternate_keys`` list to contain the key being added.
+        """
+        # Setup
+        instance = SingleTableMetadata()
+        instance._columns = {'column1': {'sdtype': 'numerical'}}
+        instance._primary_key = 'column0'
+        instance._alternate_keys = ['column1', 'column2']
+
+        # Run
+        instance.set_primary_key('column1')
+
+        # Assert
+        warning_msg = (
+            'column1 is currently set as an alternate key and will be removed from that list.'
+        )
+        assert warning_mock.warn.called_once_with(warning_msg)
+        assert instance._primary_key == 'column1'
+        assert instance._alternate_keys == ['column2']
 
     def test_set_sequence_key_validation_dtype(self):
         """Test that ``set_sequence_key`` crashes for invalid arguments.
@@ -1131,8 +1155,8 @@ class TestSingleTableMetadata:
         assert warning_mock.warn.called_once_with(warning_msg)
         assert instance._sequence_key == 'column1'
 
-    def test_set_alternate_keys_validation_dtype(self):
-        """Test that ``set_alternate_keys`` crashes for invalid arguments.
+    def test_add_alternate_keys_validation_dtype(self):
+        """Test that ``add_alternate_keys`` crashes for invalid arguments.
 
         Input:
             - A list with tuples with non-string values.
@@ -1146,10 +1170,10 @@ class TestSingleTableMetadata:
         err_msg = "'alternate_keys' must be a list of strings or a list of tuples of strings."
         # Run / Assert
         with pytest.raises(ValueError, match=err_msg):
-            instance.set_alternate_keys(['col1', ('1', 2, '3'), 'col3'])
+            instance.add_alternate_keys(['col1', ('1', 2, '3'), 'col3'])
 
-    def test_set_alternate_keys_validation_columns(self):
-        """Test that ``set_alternate_keys`` crashes for invalid arguments.
+    def test_add_alternate_keys_validation_columns(self):
+        """Test that ``add_alternate_keys`` crashes for invalid arguments.
 
         Setup:
             - A ``SingleTableMetadata`` instance with ``_columns`` set.
@@ -1170,11 +1194,11 @@ class TestSingleTableMetadata:
         )
         # Run / Assert
         with pytest.raises(ValueError, match=err_msg):
-            instance.set_alternate_keys(['abc', ('123', '213', '312')])
+            instance.add_alternate_keys(['abc', ('123', '213', '312')])
             # NOTE: used to be ['abc', ('123', '213', '312'), 'bca']
 
-    def test_set_alternate_keys_validation_categorical(self):
-        """Test that ``set_alternate_keys`` crashes when its sdtype is categorical.
+    def test_add_alternate_keys_validation_categorical(self):
+        """Test that ``add_alternate_keys`` crashes when its sdtype is categorical.
 
         Input:
             - A list of keys, some of which have sdtype categorical.
@@ -1193,10 +1217,28 @@ class TestSingleTableMetadata:
         )
         # Run / Assert
         with pytest.raises(ValueError, match=err_msg):
-            instance.set_alternate_keys([('column1', 'column2'), 'column3'])
+            instance.add_alternate_keys([('column1', 'column2'), 'column3'])
 
-    def test_set_alternate_keys(self):
-        """Test that ``set_alternate_keys`` sets the ``_alternate_keys`` value."""
+    def test_add_alternate_keys_validation_primary_key(self):
+        """Test that ``add_alternate_keys`` crashes when the key is a primary key.
+
+        If the ``_primary_key`` is set to be the same as the key being added, a ``ValueError``
+        should be raised.
+        """
+        # Setup
+        instance = SingleTableMetadata()
+        instance._columns = {'column1': {'sdtype': 'numerical'}}
+        instance._primary_key = 'column1'
+
+        err_msg = re.escape(
+            "Invalid alternate key 'column1'. The key is already specified as a primary key."
+        )
+        # Run / Assert
+        with pytest.raises(ValueError, match=err_msg):
+            instance.add_alternate_keys(['column1'])
+
+    def test_add_alternate_keys(self):
+        """Test that ``add_alternate_keys`` sets the ``_alternate_keys`` value."""
         # Setup
         instance = SingleTableMetadata()
         instance._columns = {
@@ -1206,7 +1248,7 @@ class TestSingleTableMetadata:
         }
 
         # Run
-        instance.set_alternate_keys(['column1', ('column2', 'column3')])
+        instance.add_alternate_keys(['column1', ('column2', 'column3')])
 
         # Assert
         assert instance._alternate_keys == ['column1', ('column2', 'column3')]

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -1238,7 +1238,7 @@ class TestSingleTableMetadata:
             instance.add_alternate_keys(['column1'])
 
     def test_add_alternate_keys(self):
-        """Test that ``add_alternate_keys`` sets the ``_alternate_keys`` value."""
+        """Test that ``add_alternate_keys`` adds the columns to the ``_alternate_keys``."""
         # Setup
         instance = SingleTableMetadata()
         instance._columns = {
@@ -1252,6 +1252,26 @@ class TestSingleTableMetadata:
 
         # Assert
         assert instance._alternate_keys == ['column1', ('column2', 'column3')]
+
+    @patch('sdv.metadata.single_table.warnings')
+    def test_add_alternate_keys_duplicate(self, warnings_mock):
+        """Test that the method does not add columns that are already in ``_alternate_keys``."""
+        # Setup
+        instance = SingleTableMetadata()
+        instance._columns = {
+            'column1': {'sdtype': 'numerical'},
+            'column2': {'sdtype': 'numerical'},
+            'column3': {'sdtype': 'numerical'}
+        }
+        instance._alternate_keys = ['column3']
+
+        # Run
+        instance.add_alternate_keys(['column1', 'column2', 'column3'])
+
+        # Assert
+        assert instance._alternate_keys == ['column3', 'column1', 'column2']
+        message = 'column3 is already an alternate key.'
+        warnings_mock.warn.assert_called_once_with(message)
 
     def test_set_sequence_index_validation(self):
         """Test that ``set_sequence_index`` crashes for invalid arguments.


### PR DESCRIPTION
resolves #1029 

We do not need to handle the case where the keys are tuples since this will not be initially supported