### PR TITLE
Only allow datetime and numerical sdtypes to be set as the sequence index

### DIFF
--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -383,6 +383,10 @@ class SingleTableMetadata:
                 f'Unknown sequence index value {column_name}.'
                 ' Keys should be columns that exist in the table.'
             )
+        
+        sdtype = self._columns.get(column_name).get('sdtype')
+        if sdtype not in ['datetime', 'numerical']:
+            raise ValueError("The sequence_index must be of type 'datetime' or 'numerical'.")
 
     def set_sequence_index(self, column_name):
         """Set the metadata sequence index.

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -383,7 +383,7 @@ class SingleTableMetadata:
                 f'Unknown sequence index value {column_name}.'
                 ' Keys should be columns that exist in the table.'
             )
-        
+
         sdtype = self._columns.get(column_name).get('sdtype')
         if sdtype not in ['datetime', 'numerical']:
             raise ValueError("The sequence_index must be of type 'datetime' or 'numerical'.")

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -384,7 +384,7 @@ class SingleTableMetadata:
                 ' Keys should be columns that exist in the table.'
             )
 
-        sdtype = self._columns.get(column_name).get('sdtype')
+        sdtype = self._columns[column_name].get('sdtype')
         if sdtype not in ['datetime', 'numerical']:
             raise ValueError("The sequence_index must be of type 'datetime' or 'numerical'.")
 

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -1252,12 +1252,12 @@ class TestSingleTableMetadata:
         with pytest.raises(ValueError, match=err_msg):
             instance.set_sequence_index('column')
 
-    def test_set_sequence_index_validation_columns(self):
+    def test_set_sequence_index_column_not_numerical_or_datetime(self):
         """Test that the method errors if the column is not numerical or datetime."""
         # Setup
         instance = SingleTableMetadata()
         instance._columns = {
-            'a': {'sdtype': 'numerical'}, 
+            'a': {'sdtype': 'numerical'},
             'd': {'sdtype': 'categorical'}
         }
 

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -1252,11 +1252,25 @@ class TestSingleTableMetadata:
         with pytest.raises(ValueError, match=err_msg):
             instance.set_sequence_index('column')
 
+    def test_set_sequence_index_validation_columns(self):
+        """Test that the method errors if the column is not numerical or datetime."""
+        # Setup
+        instance = SingleTableMetadata()
+        instance._columns = {
+            'a': {'sdtype': 'numerical'}, 
+            'd': {'sdtype': 'categorical'}
+        }
+
+        # Run / Assert
+        error_message = "The sequence_index must be of type 'datetime' or 'numerical'."
+        with pytest.raises(ValueError, match=error_message):
+            instance.set_sequence_index('d')
+
     def test_set_sequence_index(self):
         """Test that ``set_sequence_index`` sets the ``_sequence_index`` value."""
         # Setup
         instance = SingleTableMetadata()
-        instance._columns = {'column'}
+        instance._columns = {'column': {'sdtype': 'numerical'}}
 
         # Run
         instance.set_sequence_index('column')


### PR DESCRIPTION
resolves #1030 