### PR TITLE
Migrate base integration tests

### DIFF
--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -1282,8 +1282,8 @@ class Unique(Constraint):
         for key in metadata._alternate_keys:
             if isinstance(key, tuple):
                 keys.update(key)
-        else:
-            keys.add(key)
+            else:
+                keys.add(key)
 
         if len(set(column_names) - keys) == 0:
             raise ConstraintMetadataError(

--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -417,8 +417,13 @@ class DataProcessor:
         if not self.fitted:
             raise NotFittedError()
 
+        # Filter columns that can be transformed
+        columns = [
+            column for column in self.get_sdtypes(primary_keys=not is_condition)
+            if column in data.columns
+        ]
         LOGGER.debug(f'Transforming constraints for table {self.table_name}')
-        data = self._transform_constraints(data, is_condition)
+        data = self._transform_constraints(data[columns], is_condition)
 
         LOGGER.debug(f'Transforming table {self.table_name}')
         if self._primary_key and not is_condition:

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -695,7 +695,7 @@ class BaseSynthesizer:
     def _validate_conditions(self, conditions):
         """Validate the user-passed conditions."""
         for column in conditions.columns:
-            if column not in self._data_processor.get_fields():
+            if column not in self._data_processor.get_sdtypes():
                 raise ValueError(f"Unexpected column name '{column}'. "
                                  f'Use a column name that was present in the original data.')
 

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -13,6 +13,7 @@ import copulas
 import numpy as np
 import pandas as pd
 import tqdm
+from copulas.multivariate import GaussianMultivariate
 
 from sdv.data_processing.data_processor import DataProcessor
 from sdv.errors import ConstraintsNotMetError, InvalidPreprocessingError
@@ -578,8 +579,7 @@ class BaseSynthesizer:
                 'Unable to sample any rows for the given conditions '
                 f"'{transformed_condition}'. "
             )
-            if hasattr(self, '_model') and isinstance(
-                    self._model, copulas.multivariate.GaussianMultivariate):
+            if hasattr(self, '_model') and isinstance(self._model, GaussianMultivariate):
                 user_msg = user_msg + (
                     'This may be because the provided values are out-of-bounds in the '
                     'current model. \nPlease try again with a different set of values.'
@@ -828,8 +828,8 @@ class BaseSynthesizer:
                     )
                     sampled = pd.concat([sampled, sampled_for_condition], ignore_index=True)
 
-            is_reject_sampling = (hasattr(self, '_model') and not isinstance(
-                self._model, copulas.multivariate.GaussianMultivariate))
+            is_reject_sampling = bool(
+                hasattr(self, '_model') and not isinstance(self._model, GaussianMultivariate))
             check_num_rows(
                 num_rows=len(sampled),
                 expected_num_rows=num_rows,

--- a/tests/integration/single_table/test_base.py
+++ b/tests/integration/single_table/test_base.py
@@ -4,25 +4,23 @@ import pandas as pd
 import pytest
 from copulas.multivariate.gaussian import GaussianMultivariate
 
-from sdv.constraints import FixedCombinations, Unique
-from sdv.demo import load_tabular_demo
-from sdv.sampling import Condition
 from sdv.metadata import SingleTableMetadata
+from sdv.sampling import Condition
 from sdv.single_table.copulagan import CopulaGANSynthesizer
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
 from sdv.single_table.ctgan import CTGANSynthesizer, TVAESynthesizer
 
 METADATA = SingleTableMetadata._load_from_dict({
-    "SCHEMA_VERSION": "SINGLE_TABLE_V1",
-    "columns": {
-        "column1": {
-            "sdtype": "numerical"
+    'SCHEMA_VERSION': 'SINGLE_TABLE_V1',
+    'columns': {
+        'column1': {
+            'sdtype': 'numerical'
         },
-        "column2": {
-            "sdtype": "numerical"
+        'column2': {
+            'sdtype': 'numerical'
         },
-        "column3": {
-            "sdtype": "numerical"
+        'column3': {
+            'sdtype': 'numerical'
         }
     }
 })
@@ -42,44 +40,44 @@ def _isinstance_side_effect(*args, **kwargs):
         return isinstance(args[0], args[1])
 
 
-# @pytest.mark.parametrize('model', MODELS)
-# def test_conditional_sampling_graceful_reject_sampling_true_dict(model):
-#     data = pd.DataFrame({
-#         'column1': list(range(100)),
-#         'column2': list(range(100)),
-#         'column3': list(range(100))
-#     })
-# 
-#     model.fit(data)
-#     conditions = [
-#         Condition({
-#             'column1': 28,
-#             'column2': 37,
-#             'column3': 93
-#         })
-#     ]
-# 
-#     with pytest.raises(ValueError):  # noqa: PT011
-#         model.sample_conditions(conditions=conditions)
-# 
-# 
-# @pytest.mark.parametrize('model', MODELS)
-# def test_conditional_sampling_graceful_reject_sampling_true_dataframe(model):
-#     data = pd.DataFrame({
-#         'column1': list(range(100)),
-#         'column2': list(range(100)),
-#         'column3': list(range(100))
-#     })
-# 
-#     model.fit(data)
-#     conditions = pd.DataFrame({
-#         'column1': [28],
-#         'column2': [37],
-#         'column3': [93]
-#     })
-# 
-#     with pytest.raises(ValueError, match='a'):
-#         model.sample_remaining_columns(conditions)
+@pytest.mark.parametrize('model', MODELS)
+def test_conditional_sampling_graceful_reject_sampling_true_dict(model):
+    data = pd.DataFrame({
+        'column1': list(range(100)),
+        'column2': list(range(100)),
+        'column3': list(range(100))
+    })
+
+    model.fit(data)
+    conditions = [
+        Condition({
+            'column1': 28,
+            'column2': 37,
+            'column3': 93
+        })
+    ]
+
+    with pytest.raises(ValueError):  # noqa: PT011
+        model.sample_conditions(conditions=conditions)
+
+
+@pytest.mark.parametrize('model', MODELS)
+def test_conditional_sampling_graceful_reject_sampling_true_dataframe(model):
+    data = pd.DataFrame({
+        'column1': list(range(100)),
+        'column2': list(range(100)),
+        'column3': list(range(100))
+    })
+
+    model.fit(data)
+    conditions = pd.DataFrame({
+        'column1': [28],
+        'column2': [37],
+        'column3': [93]
+    })
+
+    with pytest.raises(ValueError, match='a'):
+        model.sample_remaining_columns(conditions)
 
 
 def test_fit_with_unique_constraint_on_data_with_only_index_column():
@@ -273,7 +271,6 @@ def test_conditional_sampling_constraint_uses_reject_sampling(gm_mock, isinstanc
     """
     # Setup
     isinstance_mock.side_effect = _isinstance_side_effect
-    constraint = FixedCombinations(column_names=['city', 'state'])
     data = pd.DataFrame({
         'city': ['LA', 'SF', 'CHI', 'LA', 'LA'],
         'state': ['CA', 'CA', 'IL', 'CA', 'CA'],

--- a/tests/integration/single_table/test_base.py
+++ b/tests/integration/single_table/test_base.py
@@ -1,0 +1,411 @@
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from copulas.multivariate.gaussian import GaussianMultivariate
+
+from sdv.constraints import FixedCombinations, Unique
+from sdv.demo import load_tabular_demo
+from sdv.sampling import Condition
+from sdv.metadata import SingleTableMetadata
+from sdv.single_table.copulagan import CopulaGANSynthesizer
+from sdv.single_table.copulas import GaussianCopulaSynthesizer
+from sdv.single_table.ctgan import CTGANSynthesizer, TVAESynthesizer
+
+METADATA = SingleTableMetadata._load_from_dict({
+    "SCHEMA_VERSION": "SINGLE_TABLE_V1",
+    "columns": {
+        "column1": {
+            "sdtype": "numerical"
+        },
+        "column2": {
+            "sdtype": "numerical"
+        },
+        "column3": {
+            "sdtype": "numerical"
+        }
+    }
+})
+
+MODELS = [
+    pytest.param(CTGANSynthesizer(METADATA, epochs=1), id='CTGANSynthesizer'),
+    pytest.param(TVAESynthesizer(METADATA, epochs=1), id='TVAESynthesizer'),
+    pytest.param(GaussianCopulaSynthesizer(METADATA), id='GaussianCopulaSynthesizer'),
+    pytest.param(CopulaGANSynthesizer(METADATA, epochs=1), id='CopulaGANSynthesizer'),
+]
+
+
+def _isinstance_side_effect(*args, **kwargs):
+    if isinstance(args[0], GaussianMultivariate):
+        return True
+    else:
+        return isinstance(args[0], args[1])
+
+
+# @pytest.mark.parametrize('model', MODELS)
+# def test_conditional_sampling_graceful_reject_sampling_true_dict(model):
+#     data = pd.DataFrame({
+#         'column1': list(range(100)),
+#         'column2': list(range(100)),
+#         'column3': list(range(100))
+#     })
+# 
+#     model.fit(data)
+#     conditions = [
+#         Condition({
+#             'column1': 28,
+#             'column2': 37,
+#             'column3': 93
+#         })
+#     ]
+# 
+#     with pytest.raises(ValueError):  # noqa: PT011
+#         model.sample_conditions(conditions=conditions)
+# 
+# 
+# @pytest.mark.parametrize('model', MODELS)
+# def test_conditional_sampling_graceful_reject_sampling_true_dataframe(model):
+#     data = pd.DataFrame({
+#         'column1': list(range(100)),
+#         'column2': list(range(100)),
+#         'column3': list(range(100))
+#     })
+# 
+#     model.fit(data)
+#     conditions = pd.DataFrame({
+#         'column1': [28],
+#         'column2': [37],
+#         'column3': [93]
+#     })
+# 
+#     with pytest.raises(ValueError, match='a'):
+#         model.sample_remaining_columns(conditions)
+
+
+def test_fit_with_unique_constraint_on_data_with_only_index_column():
+    """Test that the ``fit`` method runs without error when metadata specifies unique constraint,
+    ``fit`` is called on data containing a column named index.
+
+    The ``fit`` method is expected to fit the model to data,
+    taking into account the metadata and the ``Unique`` constraint.
+
+    Setup:
+    - The model is passed the unique constraint and
+    the primary key column.
+
+    Input:
+    - Data, Unique constraint
+
+    Github Issue:
+    - Tests that https://github.com/sdv-dev/SDV/issues/616 does not occur
+    """
+    # Setup
+    test_df = pd.DataFrame({
+        'key': [
+            1,
+            2,
+            3,
+            4,
+            5,
+        ],
+        'index': [
+            'A',
+            'B',
+            'C',
+            'D',
+            'E',
+        ]
+    })
+
+    metadata = SingleTableMetadata()
+    metadata.add_column('key', sdtype='numerical')
+    metadata.add_column('index', sdtype='categorical')
+    metadata.set_primary_key('key')
+    metadata.add_constraint('Unique', column_names=['index'])
+
+    model = GaussianCopulaSynthesizer(metadata)
+
+    # Run
+    model.fit(test_df)
+    samples = model.sample(2)
+
+    # Assert
+    assert len(samples) == 2
+    assert samples['index'].is_unique
+
+
+def test_fit_with_unique_constraint_on_data_which_has_index_column():
+    """Test that the ``fit`` method runs without error when metadata specifies unique constraint,
+    ``fit`` is called on data containing a column named index and other columns.
+
+    The ``fit`` method is expected to fit the model to data,
+    taking into account the metadata and the ``Unique`` constraint.
+
+    Setup:
+    - The model is passed the unique constraint and
+    the primary key column.
+    - The unique constraint is set on the ``test_column``
+
+    Input:
+    - Data, Unique constraint
+
+    Github Issue:
+    - Tests that https://github.com/sdv-dev/SDV/issues/616 does not occur
+    """
+    # Setup
+    test_df = pd.DataFrame({
+        'key': [
+            1,
+            2,
+            3,
+            4,
+            5,
+        ],
+        'index': [
+            'A',
+            'B',
+            'C',
+            'D',
+            'E',
+        ],
+        'test_column': [
+            'A1',
+            'B2',
+            'C3',
+            'D4',
+            'E5',
+        ]
+    })
+
+    metadata = SingleTableMetadata()
+    metadata.add_column('key', sdtype='numerical')
+    metadata.add_column('index', sdtype='categorical')
+    metadata.add_column('test_column', sdtype='categorical')
+    metadata.set_primary_key('key')
+    metadata.add_constraint('Unique', column_names=['test_column'])
+
+    model = GaussianCopulaSynthesizer(metadata)
+
+    # Run
+    model.fit(test_df)
+    samples = model.sample(2)
+
+    # Assert
+    assert len(samples) == 2
+    assert samples['test_column'].is_unique
+
+
+def test_fit_with_unique_constraint_on_data_subset():
+    """Test that the ``fit`` method runs without error when metadata specifies unique constraint,
+    ``fit`` is called on a subset of the original data.
+
+    The ``fit`` method is expected to fit the model to the subset of data,
+    taking into account the metadata and the ``Unique`` constraint.
+
+    Setup:
+    - The model is passed a ``Unique`` constraint and is
+    matched to a subset of the specified data.
+    Subdividing the data results in missing indexes in the subset contained in the original data.
+
+    Input:
+    - Subset of data, unique constraint
+
+    Github Issue:
+    - Tests that https://github.com/sdv-dev/SDV/issues/610 does not occur
+    """
+    # Setup
+    test_df = pd.DataFrame({
+        'key': [
+            1,
+            2,
+            3,
+            4,
+            5,
+        ],
+        'test_column': [
+            'A',
+            'B',
+            'C',
+            'D',
+            'E',
+        ]
+    })
+
+    metadata = SingleTableMetadata()
+    metadata.add_column('key', sdtype='numerical')
+    metadata.add_column('test_column', sdtype='categorical')
+    metadata.set_primary_key('key')
+    metadata.add_constraint('Unique', column_names=['test_column'])
+
+    test_df = test_df.iloc[[1, 3, 4]]
+    model = GaussianCopulaSynthesizer(metadata)
+
+    # Run
+    model.fit(test_df)
+    samples = model.sample(2)
+
+    # Assert
+    assert len(samples) == 2
+    assert samples['test_column'].is_unique
+
+
+@patch('sdv.tabular.base.isinstance')
+@patch('sdv.tabular.copulas.copulas.multivariate.GaussianMultivariate',
+       spec_set=GaussianMultivariate)
+def test_conditional_sampling_constraint_uses_reject_sampling(gm_mock, isinstance_mock):
+    """Test that the ``sample`` method handles constraints with conditions.
+
+    The ``sample`` method is expected to properly apply constraint
+    transformations by dropping columns that cannot be conditonally sampled
+    on due to them being part of a constraint.
+
+    Setup:
+    - The model is being passed a ``UniqueCombination`` constraint and then
+    asked to sample with two conditions, one of which the constraint depends on.
+    The constraint is expected to skip its transformations since only some of
+    the columns are provided by the conditions and the model will use reject
+    sampling to meet the constraint instead.
+
+    Input:
+    - Conditions
+    Side Effects:
+    - Correct columns to condition on are passed to underlying sample method
+    """
+    # Setup
+    isinstance_mock.side_effect = _isinstance_side_effect
+    constraint = FixedCombinations(column_names=['city', 'state'])
+    data = pd.DataFrame({
+        'city': ['LA', 'SF', 'CHI', 'LA', 'LA'],
+        'state': ['CA', 'CA', 'IL', 'CA', 'CA'],
+        'age': [27, 28, 26, 21, 30]
+    })
+
+    metadata = SingleTableMetadata()
+    metadata.add_column('city', sdtype='categorical')
+    metadata.add_column('state', sdtype='categorical')
+    metadata.add_column('age', sdtype='numerical')
+    metadata.add_constraint('FixedCombinations', column_names=['city', 'state'])
+
+    model = GaussianCopulaSynthesizer(metadata)
+    sampled_numeric_data = [
+        pd.DataFrame({
+            'city#state.value': [0, 1, 2, 0, 0],
+            'age.value': [30, 30, 30, 30, 30]
+        }),
+        pd.DataFrame({
+            'city#state.value': [1],
+            'age.value': [30]
+        })
+    ]
+    gm_mock.return_value.sample.side_effect = sampled_numeric_data
+    model.fit(data)
+
+    # Run
+    conditions = [Condition({'age': 30, 'state': 'CA'}, num_rows=5)]
+    sampled_data = model.sample_conditions(conditions=conditions)
+
+    # Assert
+    expected_transformed_conditions = {'age.value': 30}
+    expected_data = pd.DataFrame({
+        'city': ['LA', 'SF', 'LA', 'LA', 'SF'],
+        'state': ['CA', 'CA', 'CA', 'CA', 'CA'],
+        'age': [30, 30, 30, 30, 30]
+    })
+    sample_calls = model._model.sample.mock_calls
+    assert len(sample_calls) == 2
+    model._model.sample.assert_any_call(5, conditions=expected_transformed_conditions)
+    pd.testing.assert_frame_equal(sampled_data, expected_data)
+
+
+def test_sample_conditions_with_batch_size():
+    """Test the ``sample_conditions`` method with a different ``batch_size``.
+
+    If a smaller ``batch_size`` is passed, then the conditions should be broken down into
+    batches of that size. If the ``batch_size`` is larger than the condition length, then
+    the condition length should be used.
+
+    - Input:
+        - Conditions one of length 100 and another of length 10
+        - Batch size of length 50
+
+    - Output:
+        - Sampled data
+    """
+    # Setup
+    data = pd.DataFrame({
+        'column1': list(range(100)),
+        'column2': list(range(100)),
+        'column3': list(range(100))
+    })
+
+    metadata = SingleTableMetadata()
+    metadata.add_column('column1', sdtype='numerical')
+    metadata.add_column('column2', sdtype='numerical')
+    metadata.add_column('column3', sdtype='numerical')
+
+    model = GaussianCopulaSynthesizer(metadata)
+    model.fit(data)
+    conditions = [
+        Condition({'column1': 10}, num_rows=100),
+        Condition({'column1': 50}, num_rows=10)
+    ]
+
+    # Run
+    sampled_data = model.sample_conditions(conditions, batch_size=50)
+
+    # Assert
+    expected = pd.Series([10] * 100 + [50] * 10, name='column1')
+    pd.testing.assert_series_equal(sampled_data['column1'], expected)
+
+
+@pytest.mark.parametrize('model', MODELS)
+def test_sampling_with_randomize_samples_true(model):
+    data = pd.DataFrame({
+        'column1': list(range(100)),
+        'column2': list(range(100)),
+        'column3': list(range(100))
+    })
+
+    model.fit(data)
+
+    sampled1 = model.sample(10, randomize_samples=True)
+    sampled2 = model.sample(10, randomize_samples=True)
+
+    assert not sampled1.equals(sampled2)
+
+
+@pytest.mark.parametrize('model', MODELS)
+def test_sampling_with_randomize_samples_false(model):
+    data = pd.DataFrame({
+        'column1': list(range(100)),
+        'column2': list(range(100)),
+        'column3': list(range(100))
+    })
+
+    model.fit(data)
+
+    sampled1 = model.sample(10, randomize_samples=False)
+    sampled2 = model.sample(10, randomize_samples=False)
+
+    pd.testing.assert_frame_equal(sampled1, sampled2)
+
+
+@pytest.mark.parametrize('model', MODELS)
+def test_sampling_with_randomize_samples_alternating(model):
+    data = pd.DataFrame({
+        'column1': list(range(100)),
+        'column2': list(range(100)),
+        'column3': list(range(100))
+    })
+
+    model.fit(data)
+
+    sampled_fixed1 = model.sample(10, randomize_samples=False)
+    sampled_random1 = model.sample(10, randomize_samples=True)
+    sampled_fixed2 = model.sample(10, randomize_samples=False)
+    sampled_random2 = model.sample(10, randomize_samples=True)
+
+    pd.testing.assert_frame_equal(sampled_fixed1, sampled_fixed2)
+    assert not sampled_random1.equals(sampled_fixed1)
+    assert not sampled_random1.equals(sampled_random2)
+    assert not sampled_random2.equals(sampled_fixed1)

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -902,6 +902,11 @@ class TestDataProcessor:
         dp._transform_constraints = Mock()
         dp._transform_constraints.return_value = data
         dp._hyper_transformer = Mock()
+        dp.get_sdtypes = Mock()
+        dp.get_sdtypes.return_value = {
+            'item 0': 'numerical',
+            'item 1': 'boolean'
+        }
         dp._hyper_transformer.transform_subset.return_value = data
         dp.fitted = True
 
@@ -1013,6 +1018,12 @@ class TestDataProcessor:
         dp._hyper_transformer = Mock()
         dp._hyper_transformer.transform_subset.return_value = data
         dp._hyper_transformer.field_transformers = {'id': object()}
+        dp.get_sdtypes = Mock()
+        dp.get_sdtypes.return_value = {
+            'id': 'categorical',
+            'item 0': 'numerical',
+            'item 1': 'boolean'
+        }
 
         dp.fitted = True
         dp._primary_key = 'id'
@@ -1091,6 +1102,11 @@ class TestDataProcessor:
         dp._transform_constraints.return_value = data
         dp._hyper_transformer = Mock()
         dp._hyper_transformer.transform_subset.side_effect = Error()
+        dp.get_sdtypes = Mock()
+        dp.get_sdtypes.return_value = {
+            'item 0': 'numerical',
+            'item 1': 'boolean'
+        }
         dp.fitted = True
 
         # Run

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -1377,20 +1377,26 @@ class TestBaseSynthesizer:
         """Test that conditions are within the ``data_processor`` fields."""
         # Setup
         instance = Mock()
-        instance._data_processor.get_fields.return_value = ['name', 'surname']
+        instance._data_processor.get_sdtypes.return_value = {
+            'name': 'categorical',
+            'surname': 'categorical',
+        }
         conditions = pd.DataFrame({'name': ['Johanna'], 'surname': ['Doe']})
 
         # Run
         BaseSynthesizer._validate_conditions(instance, conditions)
 
         # Assert
-        instance._data_processor.get_fields.assert_called()
+        instance._data_processor.get_sdtypes.assert_called()
 
     def test__validate_conditions_raises_error(self):
         """Test that conditions are not in the ``data_processor`` fields."""
         # Setup
         instance = Mock()
-        instance._data_processor.get_fields.return_value = ['name', 'surname']
+        instance._data_processor.get_sdtypes.return_value = {
+            'name': 'categorical',
+            'surname': 'categorical',
+        }
         conditions = pd.DataFrame({'name.value': ['Johanna'], 'surname.value': ['Doe']})
 
         # Run and Assert


### PR DESCRIPTION
Fix sampling bugs:
* Rename `get_fields` to `get_sdtypes`.
* Fix indentation on `else`.
* Fix transformation not being performed when unknown columns are passed (filter columns that can be transformed).