### PR TITLE
SingleTableSynthesizer fit doesn't update rounding

### DIFF
--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -147,7 +147,7 @@ class PARSynthesizer(BaseSynthesizer):
     def _validate(self, data):
         return self._validate_context_columns(data)
 
-    def preprocess(self, data):
+    def _preprocess(self, data):
         """Transform the raw data to numerical space.
 
         For PAR, none of the sequence keys are transformed.
@@ -161,11 +161,11 @@ class PARSynthesizer(BaseSynthesizer):
                 The preprocessed data.
         """
         sequence_key_transformers = {sequence_key: None for sequence_key in self._sequence_key}
-        if self._data_processor._hyper_transformer.field_transformers == {}:
+        if not self._data_processor._prepared_for_fitting:
             self.auto_assign_transformers(data)
 
         self.update_transformers(sequence_key_transformers)
-        return super().preprocess(data)
+        return super()._preprocess(data)
 
     def update_transformers(self, column_name_to_transformer):
         """Update any of the transformers assigned to each of the column names.

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -295,6 +295,11 @@ class BaseSynthesizer:
 
         return field_transformers
 
+    def _preprocess(self, data):
+        self.validate(data)
+        self._data_processor.fit(data)
+        return self._data_processor.transform(data)
+
     def preprocess(self, data):
         """Transform the raw data to numerical space.
 
@@ -306,15 +311,13 @@ class BaseSynthesizer:
             pandas.DataFrame:
                 The preprocessed data.
         """
-        self.validate(data)
         if self._fitted:
             warnings.warn(
                 'This model has already been fitted. To use the new preprocessed data, '
                 "please refit the model using 'fit' or 'fit_processed_data'."
             )
 
-        self._data_processor.fit(data)
-        return self._data_processor.transform(data)
+        return self._preprocess(data)
 
     def _fit(self, processed_data):
         """Fit the model to the table.
@@ -344,7 +347,7 @@ class BaseSynthesizer:
             data (pandas.DataFrame):
                 The raw data (before any transformations) to fit the model to.
         """
-        processed_data = self.preprocess(data)
+        processed_data = self._preprocess(data)
         self.fit_processed_data(processed_data)
 
 

--- a/tests/unit/datasets/test_local.py
+++ b/tests/unit/datasets/test_local.py
@@ -33,10 +33,7 @@ def test_load_csvs(load_mock, warnings_mock):
     users_mock = Mock()
     orders_mock = Mock()
 
-    load_mock.side_effect = [
-        orders_mock,
-        users_mock
-    ]
+    load_mock.side_effect = lambda file: orders_mock if 'orders.csv' in file else users_mock
 
     # Run
     with TemporaryDirectory() as temp_dir:

--- a/tests/unit/datasets/test_local.py
+++ b/tests/unit/datasets/test_local.py
@@ -52,10 +52,8 @@ def test_load_csvs(load_mock, warnings_mock):
         'orders': orders_mock,
         'users': users_mock
     }
-    load_mock.assert_has_calls([
-        call(op.join(temp_dir, 'orders.csv')),
-        call(op.join(temp_dir, 'users.csv'))
-    ])
+    assert call(op.join(temp_dir, 'orders.csv')) in load_mock.mock_calls
+    assert call(op.join(temp_dir, 'users.csv')) in load_mock.mock_calls
     warnings_mock.warn.assert_called_once_with(
         f"Ignoring incompatible files ['fake.json'] in folder '{temp_dir}'.")
 

--- a/tests/unit/sequential/test_par.py
+++ b/tests/unit/sequential/test_par.py
@@ -236,7 +236,7 @@ class TestPARSynthesizer:
         with pytest.raises(InvalidDataError, match=err_msg):
             instance.validate(data)
 
-    @patch('sdv.sequential.par.BaseSynthesizer.preprocess')
+    @patch('sdv.sequential.par.BaseSynthesizer._preprocess')
     def test_preprocess_transformers_not_assigned(self, base_preprocess_mock):
         """Test that the method auto assigns the transformers if not already done.
 
@@ -261,11 +261,11 @@ class TestPARSynthesizer:
         par.update_transformers.assert_called_once_with(expected_transformers)
         base_preprocess_mock.assert_called_once_with(data)
 
-    @patch('sdv.sequential.par.BaseSynthesizer.preprocess')
+    @patch('sdv.sequential.par.BaseSynthesizer._preprocess')
     def test_preprocess(self, base_preprocess_mock):
         """Test that the method does not auto assign the transformers if it's already been done.
 
-        To test this, we set the hyper transformer to have its ``field_transformers`` set.
+        To test this, we set the hyper transformer's ``_prepared_for_fitting`` to True.
         """
         # Setup
         metadata = self.get_metadata()
@@ -274,12 +274,7 @@ class TestPARSynthesizer:
         )
         par.auto_assign_transformers = Mock()
         par.update_transformers = Mock()
-        par._data_processor._hyper_transformer.field_transformers = {
-            'time': None,
-            'gender': None,
-            'name': None,
-            'measurement': None
-        }
+        par._data_processor._prepared_for_fitting = True
         data = self.get_data()
 
         # Run


### PR DESCRIPTION
resolves #1104 

This PR does two main changes:
1. The `DataProcessor` refits everything (formatters, constraints and transformers) with every call to `preprocess` or `fit`, but it skips the fitting of the formatters and constraints when `auto_assign_transformers` is called after they've already been fit
2. The config for the `HyperTransformer` is only created if it doesn't already exist. This is because if users update the config using one of the update transformer methods, those changes should persist through consecutive fit calls. We only need to refit the formatters and constraints as certain values in the data may have changed, but the columns and sdtypes will not