### PR TITLE
Fix conditioning on negative float values.

### DIFF
--- a/sdv/tabular/base.py
+++ b/sdv/tabular/base.py
@@ -187,7 +187,7 @@ class BaseTabularModel:
         for column, value in conditions.items():
             column_values = sampled[column]
             if column_values.dtype.kind == 'f':
-                distance = value * float_rtol
+                distance = abs(value * float_rtol)
                 sampled = sampled[np.abs(column_values - value) <= distance]
                 sampled[column] = value
             else:

--- a/tests/integration/tabular/test_base.py
+++ b/tests/integration/tabular/test_base.py
@@ -394,3 +394,22 @@ def test_sampling_with_randomize_samples_alternating(model):
     assert not sampled_random1.equals(sampled_fixed1)
     assert not sampled_random1.equals(sampled_random2)
     assert not sampled_random2.equals(sampled_fixed1)
+
+
+def test_sampling_with_negative_float_values():
+    """
+    Test that the conditional sampling works for float columns, when condition value is a negative
+    float.
+    """
+    data = pd.DataFrame({
+        'column1': [-float(x) for x in list(range(100))],
+        'column2': list(range(100))
+    })
+
+    model = GaussianCopula()
+    model.fit(data)
+
+    sampled = model.sample_conditions([Condition({'column1': -50.0})])
+
+    assert len(sampled) == 1
+    assert sampled.loc[0, 'column1'] == -50.0

--- a/tests/unit/tabular/test_base.py
+++ b/tests/unit/tabular/test_base.py
@@ -1077,6 +1077,22 @@ class TestBaseTabularModel:
                 'Use a column name that was present in the original data.')):
             BaseTabularModel._validate_conditions(model, conditions)
 
+    def test__filter_conditions_with_negative_float_value(self):
+        # Setup
+        conditions = {'cola': -1.0}
+        sampled = pd.DataFrame.from_records([
+            {'cola': -1.09, 'colb': 1},  # within allowed tolerance
+            {'cola': -2.0, 'colb': 2},  # should be filtered out
+        ])
+        expected = pd.DataFrame({'cola': [-1.0], 'colb': [1]})
+
+        # Run
+        filtered = BaseTabularModel._filter_conditions(sampled, conditions, float_rtol=0.1)
+
+        # Assert
+        assert len(filtered) == 1
+        pd.testing.assert_frame_equal(filtered, expected)
+
     @patch('sdv.tabular.base.os.path')
     def test__validate_file_path(self, path_mock):
         """Test the `BaseTabularModel._validate_file_path` method.


### PR DESCRIPTION
Fixes #1161

The problem was that for negative condition values, the `distance` was negative, but it was compared against the result of `np.abs(a - b)`, which will always be >= 0.

The fix is to use `abs` on the distance as well.