### PR TITLE
Validate that the child key in a relationship is not a primary key

### DIFF
--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -126,6 +126,13 @@ class MultiTableMetadata:
                 f'tables {errors}.'
             )
 
+    def _validate_foreign_child_key(self, child_table_name, child_foreign_key):
+        child_primary_key = cast_to_iterable(self._tables[child_table_name]._primary_key)
+        child_foreign_key = cast_to_iterable(child_foreign_key)
+        if set(child_foreign_key).intersection(set(child_primary_key)):
+            raise InvalidMetadataError(
+                'A relationship must be specified between a primary key and a non-primary key.')
+
     def _validate_relationship_does_not_exist(self, parent_table_name, parent_primary_key,
                                               child_table_name, child_foreign_key):
         for relationship in self._relationships:
@@ -155,6 +162,8 @@ class MultiTableMetadata:
             child_table_name,
             child_foreign_key
         )
+
+        self._validate_foreign_child_key(child_table_name, child_foreign_key)
 
         self._validate_relationship_sdtypes(
             parent_table_name,
@@ -194,6 +203,7 @@ class MultiTableMetadata:
             - ``ValueError`` if the ``parent_primary_key`` and ``child_foreign_key`` are different
               ``sdtype``.
             - ``ValueError`` if the relationship causes a circular dependency.
+            - ``InvalidMetadataError`` if ``child_foreign_key`` is a primary key.
         """
         self._validate_relationship(
             parent_table_name, child_table_name, parent_primary_key, child_foreign_key)

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -839,6 +839,7 @@ class TestMultiTableMetadata:
 
     def test_validate_child_key_is_primary_key(self):
         """Test it crashes if the child key is a primary key."""
+        # Setup
         table = pd.DataFrame({
             'pk': [1, 2, 3],
             'col1': [.1, .1, .2],

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -558,6 +558,25 @@ class TestMultiTableMetadata:
             'users', 'id', 'sessions', 'user_id'
         )
 
+    def test_add_relationship_child_key_is_primary_key(self):
+        """Test that passing a primary key as ``child_foreign_key`` crashes."""
+        # Setup
+        table = pd.DataFrame({
+            'pk': [1, 2, 3],
+            'col1': [.1, .1, .2],
+            'col2': ['a', 'b', 'c']
+        })
+        metadata = MultiTableMetadata()
+        metadata.detect_table_from_dataframe('table', table)
+        metadata.set_primary_key('table', 'pk')
+        metadata.detect_table_from_dataframe('table2', table)
+        metadata.set_primary_key('table2', 'pk')
+
+        # Run and Assert
+        err_msg = 'A relationship must be specified between a primary key and a non-primary key.'
+        with pytest.raises(InvalidMetadataError, match=err_msg):
+            metadata.add_relationship('table', 'table2', 'pk', 'pk')
+
     def test__validate_single_table(self):
         """Test ``_validate_single_table``.
 
@@ -817,6 +836,37 @@ class TestMultiTableMetadata:
         # Run / Assert
         with pytest.raises(InvalidMetadataError, match=error_msg):
             instance.validate()
+
+    def test_validate_child_key_is_primary_key(self):
+        """Test it crashes if the child key is a primary key."""
+        table = pd.DataFrame({
+            'pk': [1, 2, 3],
+            'col1': [.1, .1, .2],
+            'col2': ['a', 'b', 'c']
+        })
+        metadata = MultiTableMetadata()
+        metadata.detect_table_from_dataframe('table', table)
+        metadata.set_primary_key('table', 'pk')
+        metadata.detect_table_from_dataframe('table2', table)
+        metadata.set_primary_key('table2', 'pk')
+
+        metadata._relationships = [
+            {
+                'parent_table_name': 'table',
+                'parent_primary_key': 'pk',
+                'child_table_name': 'table2',
+                'child_foreign_key': 'pk',
+            }
+        ]
+
+        # Run and Assert
+        err_msg = re.escape(
+            'The metadata is not valid\n'
+            'Relationships:\n'
+            'A relationship must be specified between a primary key and a non-primary key.'
+        )
+        with pytest.raises(InvalidMetadataError, match=err_msg):
+            metadata.validate()
 
     @patch('sdv.metadata.multi_table.SingleTableMetadata')
     def test_add_table(self, table_metadata_mock):


### PR DESCRIPTION
Resolve #1236.