### PR TITLE
Make evaluate methods return the actual object

### DIFF
--- a/sdv/evaluation/multi_table.py
+++ b/sdv/evaluation/multi_table.py
@@ -19,12 +19,12 @@ def evaluate_quality(real_data, synthetic_data, metadata, verbose=True):
             Defaults to True.
 
     Returns:
-        float:
-            The overall quality score.
+        QualityReport:
+            Multi table quality report object.
     """
     quality_report = QualityReport()
     quality_report.generate(real_data, synthetic_data, metadata.to_dict(), verbose)
-    return quality_report.get_score()
+    return quality_report
 
 
 def run_diagnostic(real_data, synthetic_data, metadata, verbose=True):
@@ -42,12 +42,12 @@ def run_diagnostic(real_data, synthetic_data, metadata, verbose=True):
             Defaults to True.
 
     Returns:
-        dict:
-            The diagonstic results.
+        DiagnosticReport:
+            Multi table diagnostic report object.
     """
     quality_report = DiagnosticReport()
     quality_report.generate(real_data, synthetic_data, metadata.to_dict(), verbose)
-    return quality_report.get_results()
+    return quality_report
 
 
 def get_column_plot(real_data, synthetic_data, metadata, table_name, column_name):

--- a/sdv/evaluation/multi_table.py
+++ b/sdv/evaluation/multi_table.py
@@ -45,9 +45,9 @@ def run_diagnostic(real_data, synthetic_data, metadata, verbose=True):
         DiagnosticReport:
             Multi table diagnostic report object.
     """
-    quality_report = DiagnosticReport()
-    quality_report.generate(real_data, synthetic_data, metadata.to_dict(), verbose)
-    return quality_report
+    diagnostic_report = DiagnosticReport()
+    diagnostic_report.generate(real_data, synthetic_data, metadata.to_dict(), verbose)
+    return diagnostic_report
 
 
 def get_column_plot(real_data, synthetic_data, metadata, table_name, column_name):

--- a/sdv/evaluation/single_table.py
+++ b/sdv/evaluation/single_table.py
@@ -46,9 +46,9 @@ def run_diagnostic(real_data, synthetic_data, metadata, verbose=True):
         DiagnosticReport:
             Single table diagnostic report object.
     """
-    quality_report = DiagnosticReport()
-    quality_report.generate(real_data, synthetic_data, metadata.to_dict(), verbose)
-    return quality_report
+    diagnostic_report = DiagnosticReport()
+    diagnostic_report.generate(real_data, synthetic_data, metadata.to_dict(), verbose)
+    return diagnostic_report
 
 
 def get_column_plot(real_data, synthetic_data, metadata, column_name):

--- a/sdv/evaluation/single_table.py
+++ b/sdv/evaluation/single_table.py
@@ -20,12 +20,12 @@ def evaluate_quality(real_data, synthetic_data, metadata, verbose=True):
             Defaults to True.
 
     Returns:
-        float
-            The overall quality score.
+        QualityReport:
+            Single table quality report object.
     """
     quality_report = QualityReport()
     quality_report.generate(real_data, synthetic_data, metadata.to_dict(), verbose)
-    return quality_report.get_score()
+    return quality_report
 
 
 def run_diagnostic(real_data, synthetic_data, metadata, verbose=True):
@@ -43,12 +43,12 @@ def run_diagnostic(real_data, synthetic_data, metadata, verbose=True):
             Defaults to True.
 
     Returns:
-        dict:
-            The diagonstic results.
+        DiagnosticReport:
+            Single table diagnostic report object.
     """
     quality_report = DiagnosticReport()
     quality_report.generate(real_data, synthetic_data, metadata.to_dict(), verbose)
-    return quality_report.get_results()
+    return quality_report
 
 
 def get_column_plot(real_data, synthetic_data, metadata, column_name):

--- a/tests/integration/evaluation/test_multi_table.py
+++ b/tests/integration/evaluation/test_multi_table.py
@@ -18,10 +18,10 @@ def test_evaluation():
     # Run and Assert
     synthesizer.fit(data)
     samples = synthesizer.sample()
-    score = evaluate_quality(data, samples, metadata)
+    score = evaluate_quality(data, samples, metadata).get_score()
     assert score == 0.6666666666666667
 
-    diagnostic = run_diagnostic(data, samples, metadata)
+    diagnostic = run_diagnostic(data, samples, metadata).get_results()
     assert diagnostic == {
         'DANGER': ['More than 50% of the synthetic rows are copies of the real data'],
         'SUCCESS': [

--- a/tests/integration/evaluation/test_single_table.py
+++ b/tests/integration/evaluation/test_single_table.py
@@ -17,10 +17,10 @@ def test_evaluation():
     # Run and Assert
     synthesizer.fit(data)
     samples = synthesizer.sample(10)
-    score = evaluate_quality(data, samples, metadata)
+    score = evaluate_quality(data, samples, metadata).get_score()
     assert score == 0.8333333333333334
 
-    diagnostic = run_diagnostic(data, samples, metadata)
+    diagnostic = run_diagnostic(data, samples, metadata).get_results()
     assert diagnostic == {
         'DANGER': ['More than 50% of the synthetic rows are copies of the real data'],
         'SUCCESS': [

--- a/tests/unit/evaluation/test_multi_table.py
+++ b/tests/unit/evaluation/test_multi_table.py
@@ -10,7 +10,7 @@ from sdv.metadata.multi_table import MultiTableMetadata
 
 
 def test_evaluate_quality():
-    """Test the correct score is returned."""
+    """Test ``generate`` is called for the ``QualityReport`` object."""
     # Setup
     table = pd.DataFrame({'col': [1, 2, 3]})
     data1 = {'table': table}
@@ -18,19 +18,16 @@ def test_evaluate_quality():
     metadata = MultiTableMetadata()
     metadata.detect_table_from_dataframe('table', table)
     QualityReport.generate = Mock()
-    QualityReport.get_score = Mock(return_value=123)
 
     # Run
-    score = evaluate_quality(data1, data2, metadata)
+    evaluate_quality(data1, data2, metadata)
 
     # Assert
     QualityReport.generate.assert_called_once_with(data1, data2, metadata.to_dict(), True)
-    QualityReport.get_score.assert_called_once_with()
-    assert score == 123
 
 
 def test_run_diagnostic():
-    """Test the correct diagnostic is returned."""
+    """Test ``generate`` is called for the ``DiagnosticReport`` object."""
     # Setup
     table = pd.DataFrame({'col': [1, 2, 3]})
     data1 = {'table': table}
@@ -38,15 +35,12 @@ def test_run_diagnostic():
     metadata = MultiTableMetadata()
     metadata.detect_table_from_dataframe('table', table)
     DiagnosticReport.generate = Mock()
-    DiagnosticReport.get_results = Mock(return_value={'err_type': 'str'})
 
     # Run
-    diagnostic = run_diagnostic(data1, data2, metadata)
+    run_diagnostic(data1, data2, metadata)
 
     # Assert
     DiagnosticReport.generate.assert_called_once_with(data1, data2, metadata.to_dict(), True)
-    DiagnosticReport.get_results.assert_called_once_with()
-    assert diagnostic == {'err_type': 'str'}
 
 
 @patch('sdmetrics.reports.utils.get_column_plot')

--- a/tests/unit/evaluation/test_single_table.py
+++ b/tests/unit/evaluation/test_single_table.py
@@ -19,7 +19,7 @@ def test_evaluate_quality():
     QualityReport.generate = Mock()
 
     # Run
-    quality_report = evaluate_quality(data1, data2, metadata)
+    evaluate_quality(data1, data2, metadata)
 
     # Assert
     QualityReport.generate.assert_called_once_with(data1, data2, metadata.to_dict(), True)

--- a/tests/unit/evaluation/test_single_table.py
+++ b/tests/unit/evaluation/test_single_table.py
@@ -10,41 +10,35 @@ from sdv.metadata.single_table import SingleTableMetadata
 
 
 def test_evaluate_quality():
-    """Test the correct score is returned."""
+    """Test ``generate`` is called for the ``QualityReport`` object."""
     # Setup
     data1 = pd.DataFrame({'col': [1, 2, 3]})
     data2 = pd.DataFrame({'col': [2, 1, 3]})
     metadata = SingleTableMetadata()
     metadata.add_column('col', sdtype='numerical')
     QualityReport.generate = Mock()
-    QualityReport.get_score = Mock(return_value=123)
 
     # Run
-    score = evaluate_quality(data1, data2, metadata)
+    quality_report = evaluate_quality(data1, data2, metadata)
 
     # Assert
     QualityReport.generate.assert_called_once_with(data1, data2, metadata.to_dict(), True)
-    QualityReport.get_score.assert_called_once_with()
-    assert score == 123
 
 
 def test_run_diagnostic():
-    """Test the correct diagnostic is returned."""
+    """Test ``generate`` is called for the ``DiagnosticReport`` object."""
     # Setup
     data1 = pd.DataFrame({'col': [1, 2, 3]})
     data2 = pd.DataFrame({'col': [2, 1, 3]})
     metadata = SingleTableMetadata()
     metadata.add_column('col', sdtype='numerical')
-    DiagnosticReport.generate = Mock()
-    DiagnosticReport.get_results = Mock(return_value={'err_type': 'str'})
+    DiagnosticReport.generate = Mock(return_value=123)
 
     # Run
-    diagnostic = run_diagnostic(data1, data2, metadata)
+    run_diagnostic(data1, data2, metadata)
 
     # Assert
     DiagnosticReport.generate.assert_called_once_with(data1, data2, metadata.to_dict(), True)
-    DiagnosticReport.get_results.assert_called_once_with()
-    assert diagnostic == {'err_type': 'str'}
 
 
 @patch('sdmetrics.reports.utils.get_column_plot')
@@ -58,7 +52,6 @@ def test_get_column_plot(mock_plot):
     mock_plot.return_value = 'plot'
 
     # Run
-    # method produces non uniform for [1,2,3] data, maybe bugged?
     plot = get_column_plot(data1, data2, metadata, 'col')
 
     # Assert


### PR DESCRIPTION
Resolve #1190.

Make the evaluate methods return the actual object (`QualityReport` and `DiagnosticReport`) instead of only the score/result.