### PR TITLE
 Change ValueErrors to InvalidMetadataErrors

### DIFF
--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -30,7 +30,7 @@ class MultiTableMetadata:
         parent_table = self._tables.get(parent_table_name)
         child_table = self._tables.get(child_table_name)
         if parent_table._primary_key is None:
-            raise ValueError(
+            raise InvalidMetadataError(
                 f"The parent table '{parent_table_name}' does not have a primary key set. "
                 "Please use 'set_primary_key' in order to set one."
             )
@@ -43,7 +43,7 @@ class MultiTableMetadata:
                 missing_keys.add(key)
 
         if missing_keys:
-            raise ValueError(
+            raise InvalidMetadataError(
                 f'Relationship between tables ({parent_table_name}, {child_table_name}) contains '
                 f'an unknown primary key {missing_keys}.'
             )
@@ -53,7 +53,7 @@ class MultiTableMetadata:
                 missing_keys.add(key)
 
         if missing_keys:
-            raise ValueError(
+            raise InvalidMetadataError(
                 f'Relationship between tables ({parent_table_name}, {child_table_name}) '
                 f'contains an unknown foreign key {missing_keys}.'
             )
@@ -63,9 +63,9 @@ class MultiTableMetadata:
         missing_table_names = {parent_table_name, child_table_name} - set(tables)
         if missing_table_names:
             if len(missing_table_names) == 1:
-                raise ValueError(f'Relationship contains an unknown table {missing_table_names}.')
+                raise InvalidMetadataError(f'Relationship contains an unknown table {missing_table_names}.')
             else:
-                raise ValueError(f'Relationship contains unknown tables {missing_table_names}.')
+                raise InvalidMetadataError(f'Relationship contains unknown tables {missing_table_names}.')
 
     @staticmethod
     def _validate_relationship_key_length(parent_table_name, parent_primary_key,
@@ -73,7 +73,7 @@ class MultiTableMetadata:
         pk_len = len(set(cast_to_iterable(parent_primary_key)))
         fk_len = len(set(cast_to_iterable(child_foreign_key)))
         if pk_len != fk_len:
-            raise ValueError(
+            raise InvalidMetadataError(
                 f"Relationship between tables ('{parent_table_name}', '{child_table_name}') is "
                 f'invalid. Primary key has length {pk_len} but the foreign key has '
                 f'length {fk_len}.'
@@ -87,7 +87,7 @@ class MultiTableMetadata:
         child_foreign_key = cast_to_iterable(child_foreign_key)
         for pk, fk in zip(parent_primary_key, child_foreign_key):
             if parent_table_columns[pk]['sdtype'] != child_table_columns[fk]['sdtype']:
-                raise ValueError(
+                raise InvalidMetadataError(
                     f"Relationship between tables ('{parent_table_name}', '{child_table_name}') "
                     'is invalid. The primary and foreign key columns are not the same type.'
                 )
@@ -121,7 +121,7 @@ class MultiTableMetadata:
             self._validate_circular_relationships(table_name, child_map=child_map, errors=errors)
 
         if errors:
-            raise ValueError(
+            raise InvalidMetadataError(
                 'The relationships in the dataset describe a circular dependency between '
                 f'tables {errors}.'
             )
@@ -136,7 +136,7 @@ class MultiTableMetadata:
                 relationship['child_foreign_key'] == child_foreign_key
             )
             if already_exists:
-                raise ValueError('This relationship has already been added.')
+                raise InvalidMetadataError('This relationship has already been added.')
 
     def _validate_relationship(self, parent_table_name, child_table_name,
                                parent_primary_key, child_foreign_key):
@@ -187,13 +187,13 @@ class MultiTableMetadata:
                 A string or tuple of strings representing the foreign key of the child.
 
         Raises:
-            - ``ValueError`` if a table is missing.
-            - ``ValueError`` if the ``parent_primary_key`` or ``child_foreign_key`` are missing.
-            - ``ValueError`` if the ``parent_primary_key`` and ``child_foreign_key`` have different
+            - ``InvalidMetadataError`` if a table is missing.
+            - ``InvalidMetadataError`` if the ``parent_primary_key`` or ``child_foreign_key`` are missing.
+            - ``InvalidMetadataError`` if the ``parent_primary_key`` and ``child_foreign_key`` have different
               size.
-            - ``ValueError`` if the ``parent_primary_key`` and ``child_foreign_key`` are different
+            - ``InvalidMetadataError`` if the ``parent_primary_key`` and ``child_foreign_key`` are different
               ``sdtype``.
-            - ``ValueError`` if the relationship causes a circular dependency.
+            - ``InvalidMetadataError`` if the relationship causes a circular dependency.
         """
         self._validate_relationship(
             parent_table_name, child_table_name, parent_primary_key, child_foreign_key)
@@ -217,7 +217,7 @@ class MultiTableMetadata:
 
     def _validate_table_exists(self, table_name):
         if table_name not in self._tables:
-            raise ValueError(f"Unknown table name ('{table_name}').")
+            raise InvalidMetadataError(f"Unknown table name ('{table_name}').")
 
     def add_column(self, table_name, column_name, **kwargs):
         """Add a column to a table in the ``MultiTableMetadata``.
@@ -231,11 +231,11 @@ class MultiTableMetadata:
                 Any additional key word arguments for the column, where ``sdtype`` is required.
 
         Raises:
-            - ``ValueError`` if the column already exists.
-            - ``ValueError`` if the ``kwargs`` do not contain ``sdtype``.
-            - ``ValueError`` if the column has unexpected values or ``kwargs`` for the given
+            - ``InvalidMetadataError`` if the column already exists.
+            - ``InvalidMetadataError`` if the ``kwargs`` do not contain ``sdtype``.
+            - ``InvalidMetadataError`` if the column has unexpected values or ``kwargs`` for the given
               ``sdtype``.
-            - ``ValueError`` if the table doesn't exist in the ``MultiTableMetadata``.
+            - ``InvalidMetadataError`` if the table doesn't exist in the ``MultiTableMetadata``.
         """
         self._validate_table_exists(table_name)
         table = self._tables.get(table_name)
@@ -253,10 +253,10 @@ class MultiTableMetadata:
                 Any key word arguments that describe metadata for the column.
 
         Raises:
-            - ``ValueError`` if the column doesn't already exist in the ``SingleTableMetadata``.
-            - ``ValueError`` if the column has unexpected values or ``kwargs`` for the current
+            - ``InvalidMetadataError`` if the column doesn't already exist in the ``SingleTableMetadata``.
+            - ``InvalidMetadataError`` if the column has unexpected values or ``kwargs`` for the current
               ``sdtype``.
-            - ``ValueError`` if the table doesn't exist in the ``MultiTableMetadata``.
+            - ``InvalidMetadataError`` if the table doesn't exist in the ``MultiTableMetadata``.
         """
         self._validate_table_exists(table_name)
         table = self._tables.get(table_name)
@@ -411,7 +411,7 @@ class MultiTableMetadata:
                     f'Table {disconnected_tables} is not connected to any of the other tables.'
                 )
 
-            raise ValueError(f'The relationships in the dataset are disjointed. {table_msg}')
+            raise InvalidMetadataError(f'The relationships in the dataset are disjointed. {table_msg}')
 
     def _append_relationships_errors(self, errors, method, *args, **kwargs):
         try:
@@ -463,15 +463,15 @@ class MultiTableMetadata:
                 The name of the table to add to the metadata.
 
         Raises:
-            Raises ``ValueError`` if ``table_name`` is not valid.
+            Raises ``InvalidMetadataError`` if ``table_name`` is not valid.
         """
         if not isinstance(table_name, str) or table_name == '':
-            raise ValueError(
+            raise InvalidMetadataError(
                 "Invalid table name (''). The table name must be a non-empty string."
             )
 
         if table_name in self._tables:
-            raise ValueError(
+            raise InvalidMetadataError(
                 f"Cannot add a table named '{table_name}' because it already exists in the "
                 'metadata. Please choose a different name.'
             )
@@ -587,7 +587,7 @@ class MultiTableMetadata:
                 String that represent the ``path`` to the ``json`` file to be written.
 
         Raises:
-            Raises a ``ValueError`` if the path already exists.
+            Raises a ``InvalidMetadataError`` if the path already exists.
         """
         validate_file_does_not_exist(filepath)
         metadata = self.to_dict()
@@ -663,7 +663,7 @@ class MultiTableMetadata:
                 String that represents the ``path`` to save the upgraded metadata to.
 
         Raises:
-            Raises a ``ValueError`` if the path already exists.
+            Raises a ``InvalidMetadataError`` if the path already exists.
         """
         validate_file_does_not_exist(new_filepath)
         old_metadata = read_json(old_filepath)

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -63,9 +63,11 @@ class MultiTableMetadata:
         missing_table_names = {parent_table_name, child_table_name} - set(tables)
         if missing_table_names:
             if len(missing_table_names) == 1:
-                raise InvalidMetadataError(f'Relationship contains an unknown table {missing_table_names}.')
+                raise InvalidMetadataError(
+                    f'Relationship contains an unknown table {missing_table_names}.')
             else:
-                raise InvalidMetadataError(f'Relationship contains unknown tables {missing_table_names}.')
+                raise InvalidMetadataError(
+                    f'Relationship contains unknown tables {missing_table_names}.')
 
     @staticmethod
     def _validate_relationship_key_length(parent_table_name, parent_primary_key,
@@ -188,10 +190,13 @@ class MultiTableMetadata:
 
         Raises:
             - ``InvalidMetadataError`` if a table is missing.
-            - ``InvalidMetadataError`` if the ``parent_primary_key`` or ``child_foreign_key`` are missing.
-            - ``InvalidMetadataError`` if the ``parent_primary_key`` and ``child_foreign_key`` have different
+            - ``InvalidMetadataError`` if the ``parent_primary_key`` or ``child_foreign_key`` are
+              missing.
+            - ``InvalidMetadataError`` if the ``parent_primary_key`` and ``child_foreign_key``
+              have different
               size.
-            - ``InvalidMetadataError`` if the ``parent_primary_key`` and ``child_foreign_key`` are different
+            - ``InvalidMetadataError`` if the ``parent_primary_key`` and ``child_foreign_key`` are
+              different
               ``sdtype``.
             - ``InvalidMetadataError`` if the relationship causes a circular dependency.
         """
@@ -233,8 +238,8 @@ class MultiTableMetadata:
         Raises:
             - ``InvalidMetadataError`` if the column already exists.
             - ``InvalidMetadataError`` if the ``kwargs`` do not contain ``sdtype``.
-            - ``InvalidMetadataError`` if the column has unexpected values or ``kwargs`` for the given
-              ``sdtype``.
+            - ``InvalidMetadataError`` if the column has unexpected values or ``kwargs`` for the
+              given ``sdtype``.
             - ``InvalidMetadataError`` if the table doesn't exist in the ``MultiTableMetadata``.
         """
         self._validate_table_exists(table_name)
@@ -253,9 +258,10 @@ class MultiTableMetadata:
                 Any key word arguments that describe metadata for the column.
 
         Raises:
-            - ``InvalidMetadataError`` if the column doesn't already exist in the ``SingleTableMetadata``.
-            - ``InvalidMetadataError`` if the column has unexpected values or ``kwargs`` for the current
-              ``sdtype``.
+            - ``InvalidMetadataError`` if the column doesn't already exist in the
+              ``SingleTableMetadata``.
+            - ``InvalidMetadataError`` if the column has unexpected values or ``kwargs`` for the
+              current ``sdtype``.
             - ``InvalidMetadataError`` if the table doesn't exist in the ``MultiTableMetadata``.
         """
         self._validate_table_exists(table_name)
@@ -411,7 +417,8 @@ class MultiTableMetadata:
                     f'Table {disconnected_tables} is not connected to any of the other tables.'
                 )
 
-            raise InvalidMetadataError(f'The relationships in the dataset are disjointed. {table_msg}')
+            raise InvalidMetadataError(
+                f'The relationships in the dataset are disjointed. {table_msg}')
 
     def _append_relationships_errors(self, errors, method, *args, **kwargs):
         try:

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -604,7 +604,7 @@ class MultiTableMetadata:
                 String that represent the ``path`` to the ``json`` file to be written.
 
         Raises:
-            Raises a ``InvalidMetadataError`` if the path already exists.
+            Raises a ``ValueError`` if the path already exists.
         """
         validate_file_does_not_exist(filepath)
         metadata = self.to_dict()
@@ -680,7 +680,7 @@ class MultiTableMetadata:
                 String that represents the ``path`` to save the upgraded metadata to.
 
         Raises:
-            Raises a ``InvalidMetadataError`` if the path already exists.
+            Raises a ``ValueError`` if the path already exists.
         """
         validate_file_does_not_exist(new_filepath)
         old_metadata = read_json(old_filepath)

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -543,7 +543,8 @@ class SingleTableMetadata:
                 String that represents the ``path`` to save the upgraded metadata to.
 
         Raises:
-            Raises a ``InvalidMetadataError`` if the path already exists.
+            - ``ValueError`` if the path already exists.
+            - ``InvalidMetadataError`` if multiple tables are specified in the JSON.
         """
         validate_file_does_not_exist(new_filepath)
         old_metadata = read_json(old_filepath)

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -168,8 +168,8 @@ class SingleTableMetadata:
         Raises:
             - ``InvalidMetadataError`` if the column already exists.
             - ``InvalidMetadataError`` if the ``kwargs`` do not contain ``sdtype``.
-            - ``InvalidMetadataError`` if the column has unexpected values or ``kwargs`` for the given
-              ``sdtype``.
+            - ``InvalidMetadataError`` if the column has unexpected values or ``kwargs`` for the
+              given ``sdtype``.
             - ``InvalidMetadataError`` if the ``pii`` value is not ``True`` or ``False`` when
                present.
         """
@@ -208,8 +208,10 @@ class SingleTableMetadata:
                 Any key word arguments that describe metadata for the column.
 
         Raises:
-            - ``InvalidMetadataError`` if the column doesn't already exist in the ``SingleTableMetadata``.
-            - ``InvalidMetadataError`` if the column has unexpected values or ``kwargs`` for the current
+            - ``InvalidMetadataError`` if the column doesn't already exist in the
+              ``SingleTableMetadata``.
+            - ``InvalidMetadataError`` if the column has unexpected values or ``kwargs`` for the
+              current
               ``sdtype``.
             - ``InvalidMetadataError`` if the ``pii`` value is not ``True`` or ``False`` when
                present.
@@ -304,7 +306,8 @@ class SingleTableMetadata:
         """Validate the primary and sequence keys."""
         if column_name is not None:
             if not self._validate_datatype(column_name):
-                raise InvalidMetadataError(f"'{key_type}_key' must be a string or tuple of strings.")
+                raise InvalidMetadataError(
+                    f"'{key_type}_key' must be a string or tuple of strings.")
 
             keys = {column_name} if isinstance(column_name, str) else set(column_name)
             invalid_ids = keys - set(self._columns)
@@ -408,7 +411,8 @@ class SingleTableMetadata:
 
         sdtype = self._columns[column_name].get('sdtype')
         if sdtype not in ['datetime', 'numerical']:
-            raise InvalidMetadataError("The sequence_index must be of type 'datetime' or 'numerical'.")
+            raise InvalidMetadataError(
+                "The sequence_index must be of type 'datetime' or 'numerical'.")
 
     def set_sequence_index(self, column_name):
         """Set the metadata sequence index.

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -1711,7 +1711,7 @@ class TestMultiTableMetadata:
     def test_load_from_json_path_does_not_exist(self, mock_path):
         """Test the ``load_from_json`` method.
 
-        Test that the method raises an ``InvalidMetadataError`` when the specified path does not
+        Test that the method raises a ``ValueError`` when the specified path does not
         exist.
 
         Mock:
@@ -1721,7 +1721,7 @@ class TestMultiTableMetadata:
             - String representing a filepath.
 
         Side Effects:
-            - An ``InvalidMetadataError`` is raised pointing that the ``file`` does not exist.
+            - A ``ValueError`` is raised pointing that the ``file`` does not exist.
         """
         # Setup
         mock_path.return_value.exists.return_value = False
@@ -1791,7 +1791,7 @@ class TestMultiTableMetadata:
         """Test the ``save_to_json`` method.
 
         Test that when attempting to write over a file that already exists, the method
-        raises an ``InvalidMetadataError``.
+        raises a ``ValueError``.
 
         Setup:
             - instance of ``MultiTableMetadata``.
@@ -1799,7 +1799,7 @@ class TestMultiTableMetadata:
             - Mock ``Path`` in order to point that the file does exist.
 
         Side Effects:
-            - Raise ``InvalidMetadataError`` pointing that the file does exist.
+            - Raise ``ValueError`` pointing that the file does exist.
         """
         # Setup
         instance = MultiTableMetadata()

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -107,7 +107,7 @@ class TestMultiTableMetadata:
             - ``child_foreign_key`` string.
 
         Side Effects:
-            - Raises ``ValueError`` stating that foreign key is unknown.
+            - Raises ``InvalidMetadataError`` stating that foreign key is unknown.
         """
         # Setup
         parent_table = Mock()
@@ -141,7 +141,7 @@ class TestMultiTableMetadata:
             'Relationship between tables (users, sessions) contains '
             "an unknown foreign key {'id'}."
         )
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             MultiTableMetadata._validate_missing_relationship_keys(
                 instance,
                 parent_table_name,
@@ -171,7 +171,7 @@ class TestMultiTableMetadata:
             - ``child_foreign_key`` a string that is not in the ``parent_table._columns``.
 
         Side Effects:
-            - Raises ``ValueError`` stating that primary key is unknown.
+            - Raises ``InvalidMetadataError`` stating that primary key is unknown.
         """
         # Setup
         parent_table = Mock()
@@ -186,7 +186,7 @@ class TestMultiTableMetadata:
             'Relationship between tables (users, sessions) contains '
             "an unknown primary key {'primary_key'}."
         )
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             MultiTableMetadata._validate_missing_relationship_keys(
                 parent_table,
                 parent_table_name,
@@ -211,7 +211,7 @@ class TestMultiTableMetadata:
 
         # Run
         error_msg = re.escape("Relationship contains an unknown table {'session'}.")
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             MultiTableMetadata._validate_no_missing_tables_in_relationship(
                 'users',
                 'session',
@@ -241,7 +241,7 @@ class TestMultiTableMetadata:
             "Relationship between tables ('users', 'sessions') is invalid. "
             'Primary key has length 2 but the foreign key has length 1.'
         )
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             MultiTableMetadata._validate_relationship_key_length(
                 parent_table_name,
                 parent_primary_key,
@@ -274,7 +274,7 @@ class TestMultiTableMetadata:
             - ``parent_table`` to match the ``SingleTableMetadata`` description.
 
         Side Effcts:
-            - A ``ValueError`` is being raised because the ``sdtype`` on one of the keys
+            - An ``InvalidMetadataError`` is being raised because the ``sdtype`` on one of the keys
               does not match.
         """
         # Setup
@@ -309,7 +309,7 @@ class TestMultiTableMetadata:
             "Relationship between tables ('users', 'sessions') is invalid. "
             'The primary and foreign key columns are not the same type.'
         )
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             MultiTableMetadata._validate_relationship_sdtypes(
                 instance,
                 parent_table_name,
@@ -339,7 +339,7 @@ class TestMultiTableMetadata:
 
         # Run and Assert
         error_msg = 'This relationship has already been added.'
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             metadata._validate_relationship_does_not_exist(
                 parent_table_name='sessions',
                 parent_primary_key='id',
@@ -383,7 +383,7 @@ class TestMultiTableMetadata:
     def test__validate_child_map_circular_relationship(self):
         """Test the ``_validate_child_map_circular_relationship`` method of ``MultiTableMetadata``.
 
-        Test that when a circular relationship occurs a ``ValueError`` is being raised.
+        Test that when a circular relationship occurs an ``InvalidMetadataError`` is being raised.
 
         Setup:
             - Instance of ``MultiTableMetadata``.
@@ -397,7 +397,7 @@ class TestMultiTableMetadata:
             - ``child_foreign_key`` string representing the ``foreing_Key`` of the child table.
 
         Side Effects:
-            - ``ValueError`` is raised.
+            - ``InvalidMetadataError`` is raised.
         """
         # Setup
         instance = MultiTableMetadata()
@@ -418,7 +418,7 @@ class TestMultiTableMetadata:
             'The relationships in the dataset describe a circular dependency between tables '
             "['users', 'sessions']."
         )
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance._validate_child_map_circular_relationship(child_map)
 
     @patch(
@@ -664,7 +664,8 @@ class TestMultiTableMetadata:
         """Test ``_validate_all_tables_connected``.
 
         Test that ``_validate_all_tables_connected`` performs a ``DFS`` and marks nodes as
-        ``connected``. A ``ValueError`` is being raised since one colmn is not connected.
+        ``connected``. An ``InvalidMetadataError`` is being raised since one colmn is not
+        connected.
 
         Setup:
             - Create a mock instance of the ``MultiTableMetadata``.
@@ -676,7 +677,7 @@ class TestMultiTableMetadata:
             - Mock the tables as they are not being used.
 
         Side Effects:
-            - ``ValueError`` is raised stating that a ``table`` is disjointed.
+            - ``InvalidMetadataError`` is raised stating that a ``table`` is disjointed.
         """
         # Setup
         instance = Mock()
@@ -711,14 +712,15 @@ class TestMultiTableMetadata:
             "The relationships in the dataset are disjointed. Table ['accounts'] "
             'is not connected to any of the other tables.'
         )
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             MultiTableMetadata._validate_all_tables_connected(instance, parent_map, child_map)
 
     def test__validate_all_tables_connected_multiple_not_connected(self):
         """Test ``_validate_all_tables_connected``.
 
         Test that ``_validate_all_tables_connected`` performs a ``DFS`` and marks nodes as
-        ``connected``. A ``ValueError`` is being raised since two colmns are not connected.
+        ``connected``. An ``InvalidMetadataError`` is being raised since two colmns are not
+        connected.
 
         Setup:
             - Create a mock instance of the ``MultiTableMetadata``.
@@ -730,7 +732,7 @@ class TestMultiTableMetadata:
             - Mock the tables as they are not being used.
 
         Side Effects:
-            - ``ValueError`` is raised stating that more than one tables are disjointed.
+            - ``InvalidMetadataError`` is raised stating that more than one tables are disjointed.
         """
         # Setup
         instance = Mock()
@@ -766,7 +768,7 @@ class TestMultiTableMetadata:
             "The relationships in the dataset are disjointed. Tables ['accounts', 'branches'] "
             'are not connected to any of the other tables.'
         )
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             MultiTableMetadata._validate_all_tables_connected(instance, parent_map, child_map)
 
     def test_validate(self):
@@ -839,7 +841,7 @@ class TestMultiTableMetadata:
         error_message = re.escape(
             "Invalid table name (''). The table name must be a non-empty string."
         )
-        with pytest.raises(ValueError, match=error_message):
+        with pytest.raises(InvalidMetadataError, match=error_message):
             instance.add_table('')
 
     def test_add_table_not_string(self):
@@ -851,7 +853,7 @@ class TestMultiTableMetadata:
         error_message = re.escape(
             "Invalid table name (''). The table name must be a non-empty string."
         )
-        with pytest.raises(ValueError, match=error_message):
+        with pytest.raises(InvalidMetadataError, match=error_message):
             instance.add_table(Mock())
 
     def test_add_table_table_already_exists(self):
@@ -865,7 +867,7 @@ class TestMultiTableMetadata:
             "Cannot add a table named 'users' because it already exists in the metadata. Please "
             'choose a different name.'
         )
-        with pytest.raises(ValueError, match=error_message):
+        with pytest.raises(InvalidMetadataError, match=error_message):
             instance.add_table('users')
 
     def test_to_dict(self):
@@ -1285,7 +1287,7 @@ class TestMultiTableMetadata:
 
         # Run
         error_message = re.escape("Unknown table name ('table')")
-        with pytest.raises(ValueError, match=error_message):
+        with pytest.raises(InvalidMetadataError, match=error_message):
             metadata.add_column('table', 'column', sdtype='numerical', pii=False)
 
     def test_update_column(self):
@@ -1333,7 +1335,7 @@ class TestMultiTableMetadata:
 
         # Run
         error_message = re.escape("Unknown table name ('table')")
-        with pytest.raises(ValueError, match=error_message):
+        with pytest.raises(InvalidMetadataError, match=error_message):
             metadata.update_column('table', 'column', sdtype='numerical', pii=False)
 
     @patch('sdv.metadata.multi_table.LOGGER')
@@ -1482,7 +1484,7 @@ class TestMultiTableMetadata:
             - Table name
 
         Raises:
-            - ``ValueError`` if the table name is not in the metadata.
+            - ``InvalidMetadataError`` if the table name is not in the metadata.
         """
         # Setup
         metadata = MultiTableMetadata()
@@ -1493,7 +1495,7 @@ class TestMultiTableMetadata:
 
         # Assert
         err_msg = re.escape("Unknown table name ('table3').")
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             metadata._validate_table_exists('table3')
 
     def test_set_primary_key(self):
@@ -1650,7 +1652,7 @@ class TestMultiTableMetadata:
 
         # Run
         error_message = re.escape("Unknown table name ('table')")
-        with pytest.raises(ValueError, match=error_message):
+        with pytest.raises(InvalidMetadataError, match=error_message):
             metadata.add_constraint(
                 'table', 'Inequality', low_column_name='a', high_column_name='b')
 
@@ -1658,7 +1660,8 @@ class TestMultiTableMetadata:
     def test_load_from_json_path_does_not_exist(self, mock_path):
         """Test the ``load_from_json`` method.
 
-        Test that the method raises a ``ValueError`` when the specified path does not exist.
+        Test that the method raises an ``InvalidMetadataError`` when the specified path does not
+        exist.
 
         Mock:
             - Mock the ``Path`` library in order to return ``False``, that the file does not exist.
@@ -1667,7 +1670,7 @@ class TestMultiTableMetadata:
             - String representing a filepath.
 
         Side Effects:
-            - A ``ValueError`` is raised pointing that the ``file`` does not exist.
+            - An ``InvalidMetadataError`` is raised pointing that the ``file`` does not exist.
         """
         # Setup
         mock_path.return_value.exists.return_value = False
@@ -1737,7 +1740,7 @@ class TestMultiTableMetadata:
         """Test the ``save_to_json`` method.
 
         Test that when attempting to write over a file that already exists, the method
-        raises a ``ValueError``.
+        raises an ``InvalidMetadataError``.
 
         Setup:
             - instance of ``MultiTableMetadata``.
@@ -1745,7 +1748,7 @@ class TestMultiTableMetadata:
             - Mock ``Path`` in order to point that the file does exist.
 
         Side Effects:
-            - Raise ``ValueError`` pointing that the file does exist.
+            - Raise ``InvalidMetadataError`` pointing that the file does exist.
         """
         # Setup
         instance = MultiTableMetadata()

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -95,8 +95,8 @@ class TestSingleTableMetadata:
 
         Side Effects:
             - Passes when no ``computer_representation`` is provided
-            - ``ValueError`` is raised stating that the ``computer_representation`` is not
-            supported.
+            - ``InvalidMetadataError`` is raised stating that the ``computer_representation`` is
+              not supported.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -105,7 +105,7 @@ class TestSingleTableMetadata:
         instance._validate_numerical('age')
 
         error_msg = re.escape("Invalid value for 'computer_representation' '36' for column 'age'.")
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             instance._validate_numerical('age', computer_representation=36)
 
     @pytest.mark.parametrize(
@@ -124,7 +124,8 @@ class TestSingleTableMetadata:
 
         Side Effects:
             - Passes with the correct ``computer_representation``
-            - ``ValueError`` is raised stating that the ``computer_representation`` is wrong.
+            - ``InvalidMetadataError`` is raised stating that the ``computer_representation`` is
+              wrong.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -145,7 +146,7 @@ class TestSingleTableMetadata:
             - Invalid ``datetime_format``.
 
         Side Effects:
-            - ``ValueError`` indicating the format ``%`` that has not been formatted.
+            - ``InvalidMetadataError`` indicating the format ``%`` that has not been formatted.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -156,7 +157,7 @@ class TestSingleTableMetadata:
 
         error_msg = re.escape(
             "Invalid datetime format string '%1-%Y-%m-%d-%' for datetime column 'start_date'.")
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             instance._validate_datetime('start_date', datetime_format='%1-%Y-%m-%d-%')
 
     def test__validate_categorical(self):
@@ -173,9 +174,10 @@ class TestSingleTableMetadata:
             - An invalid ``order_by`` and ``order``.
 
         Side Effects:
-            - ``ValueError`` when both ``order`` and ``order_by`` are present.
-            - ``ValueError`` when ``order`` is an empty list or a random string.
-            - ``ValueError`` when ``order_by`` is not ``numerical_value`` or ``alphabetical``.
+            - ``InvalidMetadataError`` when both ``order`` and ``order_by`` are present.
+            - ``InvalidMetadataError`` when ``order`` is an empty list or a random string.
+            - ``InvalidMetadataError`` when ``order_by`` is not ``numerical_value`` or
+              ``alphabetical``.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -190,24 +192,24 @@ class TestSingleTableMetadata:
             "Categorical column 'name' has both an 'order' and 'order_by' "
             'attribute. Only 1 is allowed.'
         )
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             instance._validate_categorical('name', order_by='alphabetical', order=['a', 'b', 'c'])
 
         error_msg_order_by = re.escape(
             "Unknown ordering method 'my_ordering' provided for categorical column "
             "'name'. Ordering method must be 'numerical_value' or 'alphabetical'."
         )
-        with pytest.raises(ValueError, match=error_msg_order_by):
+        with pytest.raises(InvalidMetadataError, match=error_msg_order_by):
             instance._validate_categorical('name', order_by='my_ordering')
 
         error_msg_order = re.escape(
             "Invalid order value provided for categorical column 'name'. "
             "The 'order' must be a list with 1 or more elements."
         )
-        with pytest.raises(ValueError, match=error_msg_order):
+        with pytest.raises(InvalidMetadataError, match=error_msg_order):
             instance._validate_categorical('name', order='my_ordering')
 
-        with pytest.raises(ValueError, match=error_msg_order):
+        with pytest.raises(InvalidMetadataError, match=error_msg_order):
             instance._validate_categorical('name', order=[])
 
     def test__validate_text(self):
@@ -223,7 +225,7 @@ class TestSingleTableMetadata:
             - Invalid ``regex_format``.
 
         Side Effects:
-            - ``ValueError``
+            - ``InvalidMetadataError``
         """
         # Setup
         instance = SingleTableMetadata()
@@ -231,7 +233,7 @@ class TestSingleTableMetadata:
         # Run / Assert
         instance._validate_text('phrase', regex_format='[A-z]')
         error_msg = re.escape("Invalid regex format string '[A-z{' for text column 'phrase'.")
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             instance._validate_text('phrase', regex_format='[A-z{')
 
     def test__validate_column_exists(self):
@@ -245,7 +247,7 @@ class TestSingleTableMetadata:
             - Column name.
 
         Side Effects:
-            - ``ValueError`` when the column is not in the ``instance._columns``.
+            - ``InvalidMetadataError`` when the column is not in the ``instance._columns``.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -262,7 +264,7 @@ class TestSingleTableMetadata:
             "Column name ('synthetic') does not exist in the table. "
             "Use 'add_column' to add new column."
         )
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             instance._validate_column_exists('synthetic')
 
     @pytest.mark.parametrize(('column_name', 'sdtype', 'kwargs'), VALID_KWARGS)
@@ -296,13 +298,13 @@ class TestSingleTableMetadata:
             - unexpected kwargs
 
         Side Effects:
-            - ``ValueError`` is being raised for each sdtype.
+            - ``InvalidMetadataError`` is being raised for each sdtype.
         """
         # Setup
         instance = SingleTableMetadata()
 
         # Run / Assert
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             instance._validate_unexpected_kwargs(column_name, sdtype, **kwargs)
 
     def test__validate_column_invalid_sdtype(self):
@@ -319,7 +321,7 @@ class TestSingleTableMetadata:
             "Invalid sdtype : 'fake_type' is not recognized. Please use one of the "
             'supported SDV sdtypes.'
         )
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             instance._validate_column('column', 'fake_type')
 
     @patch('sdv.metadata.single_table.SingleTableMetadata._validate_unexpected_kwargs')
@@ -531,7 +533,8 @@ class TestSingleTableMetadata:
         """Test ``add_column`` method.
 
         Test that when calling ``add_column`` with a column that is already in
-        ``instance._columns`` raises a ``ValueError`` stating to use the ``update_column`` instead.
+        ``instance._columns`` raises an ``InvalidMetadataError`` stating to use the
+        ``update_column`` instead.
 
         Setup:
             - Instance of ``SingleTableMetadata``.
@@ -541,7 +544,7 @@ class TestSingleTableMetadata:
             - A column name that is already in ``instance._columns``.
 
         Side Effects:
-            - ``ValueError`` is being raised stating that the column exists.
+            - ``InvalidMetadataError`` is being raised stating that the column exists.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -550,14 +553,14 @@ class TestSingleTableMetadata:
         # Run / Assert
         error_msg = re.escape(
             "Column name 'age' already exists. Use 'update_column' to update an existing column.")
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             instance.add_column('age')
 
     def test_add_column_sdtype_not_in_kwargs(self):
         """Test ``add_column`` method.
 
-        Test that when calling ``add_column`` without an sdtype a ``ValueError`` stating that
-        it must be provided is raised.
+        Test that when calling ``add_column`` without an sdtype an ``InvalidMetadataError`` stating
+        that it must be provided is raised.
 
         Setup:
             - Instance of ``SingleTableMetadata``.
@@ -566,14 +569,14 @@ class TestSingleTableMetadata:
             - A column name.
 
         Side Effects:
-            - ``ValueError`` is being raised stating that sdtype must be provided.
+            - ``InvalidMetadataError`` is being raised stating that sdtype must be provided.
         """
         # Setup
         instance = SingleTableMetadata()
 
         # Run / Assert
         error_msg = re.escape("Please provide a 'sdtype' for column 'synthetic'.")
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             instance.add_column('synthetic')
 
     def test_add_column_invalid_sdtype(self):
@@ -590,7 +593,7 @@ class TestSingleTableMetadata:
             "Invalid sdtype : 'fake_type' is not recognized. Please use one of the "
             'supported SDV sdtypes.'
         )
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             instance.add_column('column', sdtype='fake_type')
 
     def test_add_column(self):
@@ -713,14 +716,15 @@ class TestSingleTableMetadata:
     def test_detect_from_dataframe_raises_value_error(self):
         """Test the ``detect_from_dataframe`` method.
 
-        Test that if there are existing columns in the metadata, this raises a ``ValueError``.
+        Test that if there are existing columns in the metadata, this raises an
+        ``InvalidMetadataError``.
 
         Setup:
             - instance of ``SingleTableMetadata``.
             - Add some value to ``instance._columns``.
 
         Side Effects:
-            Raises a ``ValueError`` stating that ``metadata`` already exists.
+            Raises an ``InvalidMetadataError`` stating that ``metadata`` already exists.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -732,7 +736,7 @@ class TestSingleTableMetadata:
             'object to detect from other data sources.'
         )
 
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.detect_from_dataframe('dataframe')
 
     @patch('sdv.metadata.single_table.LOGGER')
@@ -784,14 +788,15 @@ class TestSingleTableMetadata:
     def test_detect_from_csv_raises_value_error(self):
         """Test the ``detect_from_csv`` method.
 
-        Test that if there are existing columns in the metadata, this raises a ``ValueError``.
+        Test that if there are existing columns in the metadata, this raises an
+        ``InvalidMetadataError``.
 
         Setup:
             - instance of ``SingleTableMetadata``.
             - Add some value to ``instance._columns``.
 
         Side Effects:
-            Raises a ``ValueError`` stating that ``metadata`` already exists.
+            Raises an ``InvalidMetadataError`` stating that ``metadata`` already exists.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -803,7 +808,7 @@ class TestSingleTableMetadata:
             'object to detect from other data sources.'
         )
 
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.detect_from_csv('filepath')
 
     @patch('sdv.metadata.single_table.LOGGER')
@@ -986,7 +991,7 @@ class TestSingleTableMetadata:
             - A tuple with non-string values.
 
         Side Effect:
-            - A ``ValueError`` should be raised.
+            - An ``InvalidMetadataError`` should be raised.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -995,7 +1000,7 @@ class TestSingleTableMetadata:
             "'primary_key' must be a string or tuple of strings."
         )
         # Run / Assert
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.set_primary_key(('1', 2, '3'))
 
     def test_set_primary_key_validation_columns(self):
@@ -1008,7 +1013,7 @@ class TestSingleTableMetadata:
             - A tuple with columns not present in ``_columns``.
 
         Side Effect:
-            - A ``ValueError`` should be raised.
+            - An ``InvalidMetadataError`` should be raised.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -1019,7 +1024,7 @@ class TestSingleTableMetadata:
             ' Keys should be columns that exist in the table.'
         )
         # Run / Assert
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.set_primary_key(('a', 'b', 'd'))
             # NOTE: used to be ('a', 'b', 'd', 'c')
 
@@ -1030,7 +1035,7 @@ class TestSingleTableMetadata:
             - A tuple of keys, some of which have sdtype categorical.
 
         Side Effect:
-            - A ``ValueError`` should be raised.
+            - An ``InvalidMetadataError`` should be raised.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -1042,7 +1047,7 @@ class TestSingleTableMetadata:
             "The primary_keys ['column1', 'column2'] cannot be type 'categorical' or 'boolean'."
         )
         # Run / Assert
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.set_primary_key(('column1', 'column2', 'column3'))
 
     def test_set_primary_key(self):
@@ -1126,14 +1131,14 @@ class TestSingleTableMetadata:
             - A tuple with non-string values.
 
         Side Effect:
-            - A ``ValueError`` should be raised.
+            - An ``InvalidMetadataError`` should be raised.
         """
         # Setup
         instance = SingleTableMetadata()
 
         err_msg = "'sequence_key' must be a string or tuple of strings."
         # Run / Assert
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.set_sequence_key(('1', 2, '3'))
 
     def test_set_sequence_key_validation_columns(self):
@@ -1146,7 +1151,7 @@ class TestSingleTableMetadata:
             - A tuple with columns not present in ``_columns``.
 
         Side Effect:
-            - A ``ValueError`` should be raised.
+            - An ``InvalidMetadataError`` should be raised.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -1157,7 +1162,7 @@ class TestSingleTableMetadata:
             ' Keys should be columns that exist in the table.'
         )
         # Run / Assert
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.set_sequence_key(('a', 'b', 'd'))
             # NOTE: used to be ('a', 'b', 'd', 'c')
 
@@ -1168,7 +1173,7 @@ class TestSingleTableMetadata:
             - A tuple of keys, some of which have sdtype categorical.
 
         Side Effect:
-            - A ``ValueError`` should be raised.
+            - An ``InvalidMetadataError`` should be raised.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -1180,7 +1185,7 @@ class TestSingleTableMetadata:
             "The sequence_keys ['column1', 'column2'] cannot be type 'categorical' or 'boolean'."
         )
         # Run / Assert
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.set_sequence_key(('column1', 'column2', 'column3'))
 
     def test_set_sequence_key(self):
@@ -1240,14 +1245,14 @@ class TestSingleTableMetadata:
             - A list with tuples with non-string values.
 
         Side Effect:
-            - A ``ValueError`` should be raised.
+            - An ``InvalidMetadataError`` should be raised.
         """
         # Setup
         instance = SingleTableMetadata()
 
         err_msg = "'alternate_keys' must be a list of strings or a list of tuples of strings."
         # Run / Assert
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.add_alternate_keys(['col1', ('1', 2, '3'), 'col3'])
 
     def test_add_alternate_keys_validation_columns(self):
@@ -1260,7 +1265,7 @@ class TestSingleTableMetadata:
             - A tuple with non-string values.
 
         Side Effect:
-            - A ``ValueError`` should be raised.
+            - An ``InvalidMetadataError`` should be raised.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -1271,7 +1276,7 @@ class TestSingleTableMetadata:
             ' Keys should be columns that exist in the table.'
         )
         # Run / Assert
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.add_alternate_keys(['abc', ('123', '213', '312')])
             # NOTE: used to be ['abc', ('123', '213', '312'), 'bca']
 
@@ -1282,7 +1287,7 @@ class TestSingleTableMetadata:
             - A list of keys, some of which have sdtype categorical.
 
         Side Effect:
-            - A ``ValueError`` should be raised.
+            - An ``InvalidMetadataError`` should be raised.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -1294,13 +1299,14 @@ class TestSingleTableMetadata:
             "The alternate_keys ['column1', 'column2'] cannot be type 'categorical' or 'boolean'."
         )
         # Run / Assert
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.add_alternate_keys([('column1', 'column2'), 'column3'])
 
     def test_add_alternate_keys_validation_primary_key(self):
         """Test that ``add_alternate_keys`` crashes when the key is a primary key.
 
-        If the ``_primary_key`` is set to be the same as the key being added, a ``ValueError``
+        If the ``_primary_key`` is set to be the same as the key being added, an
+        ``InvalidMetadataError``
         should be raised.
         """
         # Setup
@@ -1312,7 +1318,7 @@ class TestSingleTableMetadata:
             "Invalid alternate key 'column1'. The key is already specified as a primary key."
         )
         # Run / Assert
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.add_alternate_keys(['column1'])
 
     def test_add_alternate_keys(self):
@@ -1358,14 +1364,14 @@ class TestSingleTableMetadata:
             - A non-string value.
 
         Side Effect:
-            - A ``ValueError`` should be raised.
+            - An ``InvalidMetadataError`` should be raised.
         """
         # Setup
         instance = SingleTableMetadata()
 
         err_msg = "'sequence_index' must be a string."
         # Run / Assert
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.set_sequence_index(('column1', 'column2'))
 
     def test_set_sequence_index_validation_columns(self):
@@ -1378,7 +1384,7 @@ class TestSingleTableMetadata:
             - A string not present in ``_columns``.
 
         Side Effect:
-            - A ``ValueError`` should be raised.
+            - An ``InvalidMetadataError`` should be raised.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -1389,7 +1395,7 @@ class TestSingleTableMetadata:
             ' Keys should be columns that exist in the table.'
         )
         # Run / Assert
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance.set_sequence_index('column')
 
     def test_set_sequence_index_column_not_numerical_or_datetime(self):
@@ -1403,7 +1409,7 @@ class TestSingleTableMetadata:
 
         # Run / Assert
         error_message = "The sequence_index must be of type 'datetime' or 'numerical'."
-        with pytest.raises(ValueError, match=error_message):
+        with pytest.raises(InvalidMetadataError, match=error_message):
             instance.set_sequence_index('d')
 
     def test_set_sequence_index(self):
@@ -1430,7 +1436,7 @@ class TestSingleTableMetadata:
             ' These columns must be different.'
         )
         # Run / Assert
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(InvalidMetadataError, match=err_msg):
             instance._validate_sequence_index_not_in_sequence_key()
 
     def test_validate(self):
@@ -1456,7 +1462,7 @@ class TestSingleTableMetadata:
         instance._validate_alternate_keys = Mock()
         instance._validate_sequence_index = Mock()
         instance._validate_sequence_index_not_in_sequence_key = Mock()
-        instance._validate_column = Mock(side_effect=ValueError('column_error'))
+        instance._validate_column = Mock(side_effect=InvalidMetadataError('column_error'))
 
         err_msg = re.escape(
             'The following errors were found in the metadata:'
@@ -1532,7 +1538,8 @@ class TestSingleTableMetadata:
     def test_load_from_json_path_does_not_exist(self, mock_path):
         """Test the ``load_from_json`` method.
 
-        Test that the method raises a ``ValueError`` when the specified path does not exist.
+        Test that the method raises an ``InvalidMetadataError`` when the specified path does not
+        exist.
 
         Mock:
             - Mock the ``Path`` library in order to return ``False``, that the file does not exist.
@@ -1541,7 +1548,7 @@ class TestSingleTableMetadata:
             - String representing a filepath.
 
         Side Effects:
-            - A ``ValueError`` is raised pointing that the ``file`` does not exist.
+            - An ``InvalidMetadataError`` is raised pointing that the ``file`` does not exist.
         """
         # Setup
         mock_path.return_value.exists.return_value = False
@@ -1560,8 +1567,8 @@ class TestSingleTableMetadata:
     def test_load_from_json_schema_not_present(self, mock_json, mock_path, mock_open):
         """Test the ``load_from_json`` method.
 
-        Test that the method raises a ``ValueError`` when the specified ``json`` file does
-        not contain a ``METADATA_SPEC_VERSION`` in it.
+        Test that the method raises an ``InvalidMetadataError`` when the specified ``json`` file
+        does not contain a ``METADATA_SPEC_VERSION`` in it.
 
         Mock:
             - Mock the ``Path`` library in order to return ``True``, so the file exists.
@@ -1572,8 +1579,8 @@ class TestSingleTableMetadata:
             - String representing a filepath.
 
         Side Effects:
-            - A ``ValueError`` is raised pointing that the given metadata configuration is not
-              compatible with the current version.
+            - An ``InvalidMetadataError`` is raised pointing that the given metadata configuration
+              is not compatible with the current version.
         """
         # Setup
         mock_path.return_value.exists.return_value = True
@@ -1592,7 +1599,7 @@ class TestSingleTableMetadata:
             'This metadata file is incompatible with the ``SingleTableMetadata`` '
             'class and version.'
         )
-        with pytest.raises(ValueError, match=error_msg):
+        with pytest.raises(InvalidMetadataError, match=error_msg):
             SingleTableMetadata.load_from_json('filepath.json')
 
     @patch('sdv.metadata.utils.open')
@@ -1646,7 +1653,7 @@ class TestSingleTableMetadata:
         """Test the ``save_to_json`` method.
 
         Test that when attempting to write over a file that already exists, the method
-        raises a ``ValueError``.
+        raises an ``InvalidMetadataError``.
 
         Setup:
             - instance of ``SingleTableMetadata``.
@@ -1654,7 +1661,7 @@ class TestSingleTableMetadata:
             - Mock ``Path`` in order to point that the file does exist.
 
         Side Effects:
-            - Raise ``ValueError`` pointing that the file does exist.
+            - Raise ``InvalidMetadataError`` pointing that the file does exist.
         """
         # Setup
         instance = SingleTableMetadata()
@@ -1822,7 +1829,7 @@ class TestSingleTableMetadata:
             - A fake new filepath.
 
         Side effect:
-            - A ``ValueError`` should be raised.
+            - An ``InvalidMetadataError`` should be raised.
         """
         # Setup
         validate_mock.return_value = True
@@ -1838,7 +1845,7 @@ class TestSingleTableMetadata:
             'There are multiple tables specified in the JSON. '
             'Try using the MultiTableMetadata class to upgrade this file.'
         )
-        with pytest.raises(ValueError, match=message):
+        with pytest.raises(InvalidMetadataError, match=message):
             SingleTableMetadata.upgrade_metadata('old', 'new')
 
     @patch('sdv.metadata.single_table.warnings')

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -713,7 +713,7 @@ class TestSingleTableMetadata:
         mock__validate_column.assert_called_once_with(
             'age', 'numerical', computer_representation='Float')
 
-    def test_detect_from_dataframe_raises_value_error(self):
+    def test_detect_from_dataframe_raises_error(self):
         """Test the ``detect_from_dataframe`` method.
 
         Test that if there are existing columns in the metadata, this raises an
@@ -785,7 +785,7 @@ class TestSingleTableMetadata:
         ]
         mock_log.info.assert_has_calls(expected_log_calls)
 
-    def test_detect_from_csv_raises_value_error(self):
+    def test_detect_from_csv_raises_error(self):
         """Test the ``detect_from_csv`` method.
 
         Test that if there are existing columns in the metadata, this raises an
@@ -1538,7 +1538,7 @@ class TestSingleTableMetadata:
     def test_load_from_json_path_does_not_exist(self, mock_path):
         """Test the ``load_from_json`` method.
 
-        Test that the method raises an ``InvalidMetadataError`` when the specified path does not
+        Test that the method raises a ``ValueError`` when the specified path does not
         exist.
 
         Mock:
@@ -1548,7 +1548,7 @@ class TestSingleTableMetadata:
             - String representing a filepath.
 
         Side Effects:
-            - An ``InvalidMetadataError`` is raised pointing that the ``file`` does not exist.
+            - A ``ValueError`` is raised pointing that the ``file`` does not exist.
         """
         # Setup
         mock_path.return_value.exists.return_value = False
@@ -1653,7 +1653,7 @@ class TestSingleTableMetadata:
         """Test the ``save_to_json`` method.
 
         Test that when attempting to write over a file that already exists, the method
-        raises an ``InvalidMetadataError``.
+        raises a ``ValueError``.
 
         Setup:
             - instance of ``SingleTableMetadata``.
@@ -1661,7 +1661,7 @@ class TestSingleTableMetadata:
             - Mock ``Path`` in order to point that the file does exist.
 
         Side Effects:
-            - Raise ``InvalidMetadataError`` pointing that the file does exist.
+            - Raise ``ValueError`` pointing that the file does exist.
         """
         # Setup
         instance = SingleTableMetadata()


### PR DESCRIPTION
Change `ValueError`s in  single_ and multi_table validation methods to `InvalidMetadataError`s

Resolve #1251 