### PR TITLE
Copy input data dict to prevent mutation when running `multi_table.fit_processed_data`

### DIFF
--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -309,7 +309,7 @@ class BaseMultiTableSynthesizer:
             processed_data (dict):
                 Dictionary mapping each table name to a preprocessed ``pandas.DataFrame``.
         """
-        self._fit(processed_data)
+        self._fit(processed_data.copy())
         self._fitted = True
         self._fitted_date = datetime.datetime.today().strftime('%Y-%m-%d')
         self._fitted_sdv_version = pkg_resources.get_distribution('sdv').version

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -291,56 +291,23 @@ def test_hma_with_inequality_constraint():
     assert all(sampled['child_table']['low_column'] < sampled['child_table']['high_column'])
 
 
-def get_data_and_metadata():
-    parent_table = pd.DataFrame(data={
-        'id': [1, 2, 3, 4, 5],
-        'column': [1.2, 2.1, 2.2, 2.1, 1.4]
-    })
-
-    child_table = pd.DataFrame(data={
-        'id': [1, 2, 3, 4, 5],
-        'parent_id': [1, 1, 3, 2, 1],
-        'low_column': [1, 3, 3, 1, 2],
-        'high_column': [2, 4, 5, 2, 4]
-    })
-
-    data = {
-        'parent_table': parent_table,
-        'child_table': child_table
-    }
-
-    metadata = MultiTableMetadata()
-    metadata.detect_table_from_dataframe(table_name='parent_table', data=parent_table)
-    metadata.detect_table_from_dataframe(table_name='child_table', data=child_table)
-
-    metadata.set_primary_key(table_name='parent_table', column_name='id')
-    metadata.set_primary_key(table_name='child_table', column_name='id')
-
-    metadata.add_relationship(
-        parent_table_name='parent_table',
-        child_table_name='child_table',
-        parent_primary_key='id',
-        child_foreign_key='parent_id'
-    )
-
-    return data, metadata
-
-
 def test_fit_processed_multiple_calls():
     """Test that ``fit_processed_data`` does not modify input data."""
     # Setup
-    data, metadata = get_data_and_metadata()
-    original_data = get_data_and_metadata()[0]
-
+    parent_data, child_data, metadata = get_custom_constraint_data_and_metadata()
     synthesizer = HMASynthesizer(metadata)
 
     # Run
-    synthesizer.fit_processed_data(data)
+    preprocessed = synthesizer.preprocess({'parent': parent_data, 'child': child_data})
+    parent_copy = preprocessed['parent'].copy()
+    child_copy = preprocessed['child'].copy()
+
+    synthesizer.fit_processed_data(preprocessed)
 
     # Assert
-    assert original_data.keys() == data.keys()
-    for key in data.keys():
-        pd.testing.assert_frame_equal(original_data[key], data[key], check_like=True)
+    assert preprocessed.keys() == {'parent', 'child'}
+    pd.testing.assert_frame_equal(parent_copy, preprocessed['parent'], check_like=True)
+    pd.testing.assert_frame_equal(child_copy, preprocessed['child'], check_like=True)
 
     # Re-run to ensure it does not error
-    synthesizer.fit_processed_data(data)
+    synthesizer.fit_processed_data(preprocessed)

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -342,5 +342,5 @@ def test_fit_processed_multiple_calls():
     for key in data.keys():
         pd.testing.assert_frame_equal(original_data[key], data[key], check_like=True)
 
-    # Re-run to ensure it doesn not error
+    # Re-run to ensure it does not error
     synthesizer.fit_processed_data(data)

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -607,6 +607,7 @@ class TestBaseMultiTableSynthesizer:
         # Setup
         instance = Mock()
         data = Mock()
+        data.copy.return_value = data
 
         # Run
         BaseMultiTableSynthesizer.fit_processed_data(instance, data)

--- a/tests/unit/multi_table/test_hma.py
+++ b/tests/unit/multi_table/test_hma.py
@@ -1,5 +1,5 @@
 import re
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import numpy as np
 import pandas as pd
@@ -227,27 +227,6 @@ class TestHMASynthesizer:
 
         # Assert
         instance._model_table.assert_called_once_with('upravna_enota', data)
-
-    def test_fit_processed_multiple_calls(self):
-        """Test that ``fit_processed_data`` calls ``_fit`` and does not modify input data."""
-        # Setup
-        metadata = get_multi_table_metadata()
-        instance = HMASynthesizer(metadata)
-        for table in instance._table_synthesizers:
-            instance._table_synthesizers[table] = Mock()
-        data = get_multi_table_data()
-
-        with patch.object(instance, '_fit', wraps=instance._fit) as wrapped__fit:
-            # Run
-            instance.fit_processed_data(data)
-
-            # Assert
-            wrapped__fit.assert_called_once()
-            original_data = get_multi_table_data()
-            assert data.keys() == original_data.keys()
-            for key in data.keys():
-                pd.testing.assert_frame_equal(data[key], data[key])
-                pd.testing.assert_frame_equal(data[key], original_data[key])
 
     def test__finalize(self):
         """Test that the finalize method applies the final touches to the generated data.


### PR DESCRIPTION
Resolve #1240 

Copy the input data dictionary when running `fit_processed_data` to avoid mutating the original dictionary during fitting.