### PR TITLE
Adding back and deprecating synthesizer_kwargs

### DIFF
--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -57,12 +57,19 @@ class BaseMultiTableSynthesizer:
                 **synthesizer_parameters
             )
 
-    def __init__(self, metadata, locales=None):
+    def __init__(self, metadata, locales=None, synthesizer_kwargs=None):
         self.metadata = metadata
         self.metadata.validate()
         self.locales = locales
         self._table_synthesizers = {}
         self._table_parameters = defaultdict(dict)
+        if synthesizer_kwargs is not None:
+            warn_message = (
+                'The `synthesizer_kwargs` parameter is deprecated as of SDV 1.2.0 and does not '
+                'affect the synthesizer. Please use the `set_table_parameters` method instead.'
+            )
+            warnings.warn(warn_message, FutureWarning)
+
         if self.DEFAULT_SYNTHESIZER_KWARGS:
             for table_name in self.metadata.tables:
                 self._table_parameters[table_name] = deepcopy(self.DEFAULT_SYNTHESIZER_KWARGS)

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -73,6 +73,20 @@ class TestBaseMultiTableSynthesizer:
         assert instance._table_parameters == defaultdict(dict)
         instance.metadata.validate.assert_called_once_with()
 
+    def test___init___synthesizer_kwargs_deprecated(self):
+        """Test that the ``synthesizer_kwargs`` method is deprecated."""
+        # Setup
+        metadata = get_multi_table_metadata()
+        metadata.validate = Mock()
+
+        # Run and Assert
+        warn_message = (
+            'The `synthesizer_kwargs` parameter is deprecated as of SDV 1.2.0 and does not '
+            'affect the synthesizer. Please use the `set_table_parameters` method instead.'
+        )
+        with pytest.warns(FutureWarning, match=warn_message):
+            BaseMultiTableSynthesizer(metadata, synthesizer_kwargs={})
+
     def test_get_table_parameters_empty(self):
         """Test that this method returns an empty dictionary when there are no parameters."""
         # Setup


### PR DESCRIPTION
Adding this back as a measure of good etiquette to give users a warning and opportunity to switch.