### PR TITLE
Fix setting with copy warning

### DIFF
--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -559,7 +559,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
             if column_values.dtype.kind == 'f':
                 distance = value * float_rtol
                 sampled = sampled[np.abs(column_values - value) <= distance]
-                sampled[column] = value
+                sampled.loc[:, column] = value
             else:
                 sampled = sampled[column_values == value]
 


### PR DESCRIPTION
Resolves #1436 

Feel free attempting to replicate it with:
 
```python
from sdv.sampling import Condition
from sdv.datasets.demo import download_demo
from sdv.single_table import GaussianCopulaSynthesizer

data, metadata = download_demo(
    modality='single_table',
    dataset_name='fake_hotel_guests'
)

synthesizer = GaussianCopulaSynthesizer(metadata, enforce_min_max_values=False)
synthesizer.fit(data)

my_condition = Condition(
    num_rows=250,
    column_values={ 'amenities_fee': 100.00 }
)

synthesizer.sample_from_conditions(conditions=[my_condition],
                                   max_tries_per_batch=1,
                                   batch_size=10)
```