### PR TITLE
Removing python 3.7 macos builds

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - os: macos-latest
+            python-version: '3.7'
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/minimum.yml
+++ b/.github/workflows/minimum.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - os: macos-latest
+            python-version: '3.7'
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - os: macos-latest
+            python-version: '3.7'
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('HISTORY.md', encoding='utf-8') as history_file:
 install_requires = [
     'Faker>=10,<15',
     'graphviz>=0.13.2,<1',
-    "numpy>=1.20.0,<2;python_version<'3.10'",
+    "numpy>=1.20.0,<1.25.0;python_version<'3.10'",
     "numpy>=1.23.3,<2;python_version>='3.10'",
     "pandas>=1.1.3;python_version<'3.10'",
     "pandas>=1.5.0;python_version>='3.10'",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     'Faker>=10,<15',
     'graphviz>=0.13.2,<1',
     "numpy>=1.20.0,<1.25.0;python_version<'3.10'",
-    "numpy>=1.23.3,<2;python_version>='3.10'",
+    "numpy>=1.23.3,<1.25.0;python_version>='3.10'",
     "pandas>=1.1.3;python_version<'3.10'",
     "pandas>=1.5.0;python_version>='3.10'",
     'tqdm>=4.15,<5',


### PR DESCRIPTION
This PR:
1. Removes the 3.7 macos builds since they fail with the update from Github and we will be dropping support for 3.7 soon anyway.
2. Caps numpy under 1.25.0 since it seems to cause some [tests failures](https://github.com/sdv-dev/SDV/actions/runs/5327920491/jobs/9651939818)