### PR TITLE
Improve metadata detection

### DIFF
--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -285,7 +285,7 @@ class SingleTableMetadata:
                 sdtype = 'datetime'
 
         except Exception:
-            if len(data) <= 10:
+            if len(data) <= 5:
                 sdtype = 'categorical'
             else:
                 unique_values = data.nunique()

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -290,18 +290,13 @@ class SingleTableMetadata:
             if len(data) <= 10:
                 sdtype = 'categorical'
             else:
-                try:
-                    number_data = data.astype('float')
-                    sdtype = self._determine_sdtype_for_numbers(number_data)
-
-                except Exception:
-                    unique_values = data.nunique()
-                    if unique_values == len(data):
-                        sdtype = 'id'
-                    elif unique_values <= round(len(data) / 5):
-                        sdtype = 'categorical'
-                    else:
-                        sdtype = 'unknown'
+                unique_values = data.nunique()
+                if unique_values == len(data):
+                    sdtype = 'id'
+                elif unique_values <= round(len(data) / 5):
+                    sdtype = 'categorical'
+                else:
+                    sdtype = 'unknown'
 
         return sdtype
 

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -36,7 +36,6 @@ class SingleTableMetadata:
 
     _DTYPES_TO_SDTYPES = {
         'b': 'categorical',
-        'c': 'categorrical',
         'M': 'datetime',
     }
 
@@ -314,14 +313,14 @@ class SingleTableMetadata:
             if dtype in self._DTYPES_TO_SDTYPES:
                 sdtype = self._DTYPES_TO_SDTYPES[dtype]
             elif dtype in ['i', 'u', 'f']:
-                sdtype = self._determine_sdtype_for_numbers(clean_data)
+                sdtype = self._determine_sdtype_for_numbers(column_data)
 
             elif dtype == 'O':
                 sdtype = self._determine_sdtype_for_objects(column_data)
 
             if sdtype is None:
                 raise InvalidMetadataError(
-                    f"Unsupported data type for column '{field}' ({dtype})."
+                    f"Unsupported data type for column '{field}' (kind: {dtype})."
                     "The valid data types are: 'object', 'int', 'float', 'datetime', 'bool'."
                 )
             column_dict = {'sdtype': deepcopy(sdtype)}

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -279,10 +279,11 @@ class SingleTableMetadata:
         """
         sdtype = None
         try:
-            datetime_format = get_datetime_format(data)
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', category=UserWarning)
+                datetime_format = get_datetime_format(data)
                 pd.to_datetime(data, format=datetime_format, errors='raise')
+
             sdtype = 'datetime'
 
         except Exception:

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -16,9 +16,7 @@ from sdv.metadata.metadata_upgrader import convert_metadata
 from sdv.metadata.utils import read_json, validate_file_does_not_exist
 from sdv.metadata.visualization import (
     create_columns_node, create_summarized_columns_node, visualize_graph)
-from sdv.utils import (
-    cast_to_iterable, format_invalid_values_string, is_boolean_type, is_datetime_type,
-    is_numerical_type, load_data_from_csv, validate_datetime_format)
+from sdv.utils import cast_to_iterable, get_datetime_format, load_data_from_csv
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -256,7 +256,6 @@ class SingleTableMetadata:
         """
         sdtype = 'numerical'
         if len(data) > 5:
-
             whole_values = (data == data.round()).loc[~data.isna()].all()
             positive_values = (data >= 0).loc[~data.isna()].all()
 
@@ -279,10 +278,9 @@ class SingleTableMetadata:
         """
         sdtype = None
         try:
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', category=UserWarning)
-                pd.to_datetime(data)
-                sdtype = 'datetime'
+            datetime_format = get_datetime_format(data)
+            pd.to_datetime(data, format=datetime_format, errors='raise')
+            sdtype = 'datetime'
 
         except Exception:
             if len(data) <= 5:

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -281,8 +281,10 @@ class SingleTableMetadata:
         """
         sdtype = None
         try:
-            pd.to_datetime(data)
-            sdtype = 'datetime'
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', category=UserWarning)
+                pd.to_datetime(data)
+                sdtype = 'datetime'
 
         except Exception:
             if len(data) <= 10:
@@ -304,6 +306,12 @@ class SingleTableMetadata:
         return sdtype
 
     def _detect_columns(self, data):
+        """Detect columns sdtype in the data.
+
+        Args:
+            data (pandas.DataFrame):
+                The data to be analyzed.
+        """
         for field in data:
             column_data = data[field]
             clean_data = column_data.dropna()

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -16,7 +16,9 @@ from sdv.metadata.metadata_upgrader import convert_metadata
 from sdv.metadata.utils import read_json, validate_file_does_not_exist
 from sdv.metadata.visualization import (
     create_columns_node, create_summarized_columns_node, visualize_graph)
-from sdv.utils import cast_to_iterable, get_datetime_format, load_data_from_csv
+from sdv.utils import (
+    cast_to_iterable, format_invalid_values_string, get_datetime_format, is_boolean_type,
+    is_datetime_type, is_numerical_type, load_data_from_csv, validate_datetime_format)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -275,7 +277,7 @@ class SingleTableMetadata:
 
         Args:
             data (pandas.Series):
-                The data to be analyzed.            
+                The data to be analyzed.
         """
         sdtype = None
         try:

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -281,8 +281,10 @@ class SingleTableMetadata:
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', category=UserWarning)
-                datetime_format = get_datetime_format(data)
-                pd.to_datetime(data, format=datetime_format, errors='raise')
+
+                data_test = data.sample(10000) if len(data) > 10000 else data
+                datetime_format = get_datetime_format(data_test)
+                pd.to_datetime(data_test, format=datetime_format, errors='raise')
 
             sdtype = 'datetime'
 

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -275,7 +275,7 @@ class SingleTableMetadata:
 
         Args:
             data (pandas.Series):
-                The data to be analyzed.
+                The data to be analyzed.            
         """
         sdtype = None
         try:
@@ -328,12 +328,12 @@ class SingleTableMetadata:
                     f"Unsupported data type for column '{field}' (kind: {dtype})."
                     "The valid data types are: 'object', 'int', 'float', 'datetime', 'bool'."
                 )
-            column_dict = {'sdtype': deepcopy(sdtype)}
+            column_dict = {'sdtype': sdtype}
 
             if sdtype == 'unknown':
                 column_dict['pii'] = True
-            elif sdtype == 'datetime':
-                datetime_format = get_datetime_format(clean_data)
+            elif sdtype == 'datetime' and dtype == 'O':
+                datetime_format = get_datetime_format(column_data.iloc[:100])
                 column_dict['datetime_format'] = datetime_format
 
             self.columns[field] = deepcopy(column_dict)

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -256,13 +256,14 @@ class SingleTableMetadata:
         """
         sdtype = 'numerical'
         if len(data) > 5:
-            whole_values = (data == data.round()).loc[~data.isna()].all()
-            positive_values = (data >= 0).loc[~data.isna()].all()
+            is_not_null = ~data.isna()
+            whole_values = (data == data.round()).loc[is_not_null].all()
+            positive_values = (data >= 0).loc[is_not_null].all()
 
             unique_values = data.nunique()
-            percentage_unique_values = unique_values <= round(len(data) / 10)
+            unique_lt_categorical_threshold = unique_values <= round(len(data) / 10)
 
-            if whole_values and positive_values and percentage_unique_values:
+            if whole_values and positive_values and unique_lt_categorical_threshold:
                 sdtype = 'categorical'
             elif unique_values == len(data) and whole_values:
                 sdtype = 'id'

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -313,7 +313,7 @@ class SingleTableMetadata:
             sdtype = None
             if dtype in self._DTYPES_TO_SDTYPES:
                 sdtype = self._DTYPES_TO_SDTYPES[dtype]
-            elif dtype in ['i', 'u', 'f']:
+            elif dtype in ['i', 'f']:
                 sdtype = self._determine_sdtype_for_numbers(column_data)
 
             elif dtype == 'O':

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -280,7 +280,9 @@ class SingleTableMetadata:
         sdtype = None
         try:
             datetime_format = get_datetime_format(data)
-            pd.to_datetime(data, format=datetime_format, errors='raise')
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', category=UserWarning)
+                pd.to_datetime(data, format=datetime_format, errors='raise')
             sdtype = 'datetime'
 
         except Exception:

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -1,5 +1,4 @@
 """Miscellaneous utility functions."""
-import warnings
 from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
@@ -68,11 +67,8 @@ def get_datetime_format(value):
 
     value = value[~value.isna()]
     value = value.astype(str).to_numpy()
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', category=UserWarning)
-        result = _guess_datetime_format_for_array(value)
 
-    return result
+    return _guess_datetime_format_for_array(value)
 
 
 def is_datetime_type(value):

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -1,4 +1,5 @@
 """Miscellaneous utility functions."""
+import warnings
 from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
@@ -67,7 +68,11 @@ def get_datetime_format(value):
 
     value = value[~value.isna()]
     value = value.astype(str).to_numpy()
-    return _guess_datetime_format_for_array(value)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=UserWarning)
+        result = _guess_datetime_format_for_array(value)
+
+    return result
 
 
 def is_datetime_type(value):

--- a/tests/integration/data_processing/test_data_processor.py
+++ b/tests/integration/data_processing/test_data_processor.py
@@ -14,343 +14,342 @@ from sdv.metadata import SingleTableMetadata
 from sdv.utils import get_datetime_format
 
 
-def test_data_processor_with_anonymized_columns():
-    """Test the ``DataProcessor``.
-
-    Test that when we update a ``pii`` column this uses ``AnonymizedFaker`` to create
-    a new set of data for that column, while it drops it on the ``transform``.
-
-    Setup:
-        - Load metadata and data.
-        - Parse the old metadata to a new metadata.
-        - Anonymize the field ``occupation``.
-
-    Run:
-        - Create a ``DataProcessor`` with the new metadata.
-        - Fit the ``DataProcessor`` instance.
-        - Transform the data.
-        - Reverse transform the data.
-
-    Assert:
-        - The column ``occupation`` has been dropped in the ``transform`` process.
-        - The column ``occupation`` has been re-created with new values from the
-          ``AnonymizedFaker`` instance.
-    """
-    # Load metadata and data
-    data, metadata = download_demo('single_table', 'adult')
-
-    # Add anonymized field
-    metadata.update_column('occupation', sdtype='job', pii=True)
-
-    # Instance ``DataProcessor``
-    dp = DataProcessor(metadata)
-
-    # Fit
-    dp.fit(data)
-
-    # Transform
-    transformed = dp.transform(data)
-
-    # Reverse Transform
-    reverse_transformed = dp.reverse_transform(transformed)
-
-    # Assert
-    assert reverse_transformed.occupation.isin(data.occupation).sum() == 0
-    assert 'occupation' not in transformed.columns
-
-
-def test_data_processor_with_anonymized_columns_and_primary_key():
-    """Test the ``DataProcessor``.
-
-    Test that when we update a ``pii`` column this uses ``AnonymizedFaker`` to create
-    a new set of data for that column, while it drops it on the ``transform`` and this values
-    can be repeated. Meanwhile, when we set a primary key this has to have a unique length
-    of the input data.
-
-    Setup:
-        - Load metadata and data.
-        - Parse the old metadata to a new metadata.
-        - Anonymize the field ``occupation``.
-        - Create ``id``.
-
-    Run:
-        - Create a ``DataProcessor`` with the new metadata.
-        - Fit the ``DataProcessor`` instance.
-        - Transform the data.
-        - Reverse transform the data.
-
-    Assert:
-        - The column ``occupation`` has been dropped in the ``transform`` process.
-        - The column ``occupation`` has been re-created with new values from the
-          ``AnonymizedFaker`` instance.
-        - The column ``id`` has been created in ``transform`` with a unique length of the data.
-    """
-    # Load metadata and data
-    data, metadata = download_demo('single_table', 'adult')
-
-    # Add anonymized field
-    metadata.update_column('occupation', sdtype='job', pii=True)
-
-    # Add primary key field
-    metadata.add_column('id', sdtype='id', regex_format='ID_\\d{4}[0-9]')
-    metadata.set_primary_key('id')
-
-    # Add id
-    size = len(data)
-    data['id'] = np.arange(0, size).astype('O')
-
-    # Instance ``DataProcessor``
-    dp = DataProcessor(metadata)
-
-    # Fit
-    dp.fit(data)
-
-    # Transform
-    transformed = dp.transform(data)
-
-    # Reverse Transform
-    reverse_transformed = dp.reverse_transform(transformed)
-
-    # Assert
-    assert transformed.index.name == 'id'
-    assert reverse_transformed.occupation.isin(data.occupation).sum() == 0
-    assert 'occupation' not in transformed.columns
-    assert 'id' not in transformed.columns
-    assert reverse_transformed.id.isin(data.id).sum() == 0
-    assert len(reverse_transformed.id.unique()) == size
-
-
-def test_data_processor_with_primary_key_numerical():
-    """End to end test for the ``DataProcessor``.
-
-    Test that when running the ``DataProcessor`` with a numerical primary key, this is able
-    to generate such a key in the ``transform`` method. The key should be the same length
-    as the input data size.
-
-    Setup:
-        - Load metadata and data.
-        - Detect the metadata from the ``dataframe``.
-        - Create ``id`` column.
-
-    Run:
-        - Create a ``DataProcessor`` with the new metadata.
-        - Fit the ``DataProcessor`` instance.
-        - Transform the data.
-        - Reverse transform the data.
-
-    Assert:
-        - The column ``id`` has been created during ``transform`` with a unique length of the data.
-          matching the original numerical ``id`` column.
-    """
-    # Load metadata and data
-    data, _ = download_demo('single_table', 'adult')
-    adult_metadata = SingleTableMetadata()
-    adult_metadata.detect_from_dataframe(data=data)
-
-    # Add primary key field
-    adult_metadata.add_column('id', sdtype='id')
-    adult_metadata.set_primary_key('id')
-
-    # Add id
-    size = len(data)
-    id_generator = itertools.count()
-    ids = [next(id_generator) for _ in range(size)]
-    data['id'] = ids
-
-    # Instance ``DataProcessor``
-    dp = DataProcessor(adult_metadata)
-
-    # Fit
-    dp.fit(data)
-
-    # Transform
-    transformed = dp.transform(data)
-
-    # Reverse Transform
-    reverse_transformed = dp.reverse_transform(transformed)
-
-    # Assert
-    assert transformed.index.name == 'id'
-    assert 'id' not in transformed.columns
-    assert reverse_transformed.index.isin(data.id).sum() == size
-    assert len(reverse_transformed.id.unique()) == size
-
-
-def test_data_processor_with_alternate_keys():
-    """Test that alternate keys are being generated in a unique way.
-
-    Test that the alternate keys are being generated and dropped the same way
-    as with the ``primary_key``.
-    """
-    # Load metadata and data
-    data, _ = download_demo('single_table', 'adult')
-    data['fnlwgt'] = data['fnlwgt'].astype(str)
-    adult_metadata = SingleTableMetadata()
-    adult_metadata.detect_from_dataframe(data=data)
-
-    # Add primary key field
-    adult_metadata.add_column('id', sdtype='id')
-    adult_metadata.set_primary_key('id')
-
-    adult_metadata.add_column('secondary_id', sdtype='id')
-    adult_metadata.update_column('fnlwgt', sdtype='id', regex_format='ID_\\d{4}[0-9]')
-
-    adult_metadata.add_alternate_keys(['secondary_id', 'fnlwgt'])
-
-    # Add id
-    size = len(data)
-    id_generator = itertools.count()
-    ids = [next(id_generator) for _ in range(size)]
-    data['id'] = ids
-    data['secondary_id'] = ids
-
-    # Instance ``DataProcessor``
-    dp = DataProcessor(adult_metadata)
-
-    # Fit
-    dp.fit(data)
-
-    # Transform
-    transformed = dp.transform(data)
-
-    # Reverse Transform
-    reverse_transformed = dp.reverse_transform(transformed)
-
-    # Assert
-    assert 'id' not in transformed.columns
-    assert 'secondary_id' not in transformed.columns
-    assert 'fnlwgt' not in transformed.columns
-    assert len(reverse_transformed.id.unique()) == size
-    assert len(reverse_transformed.secondary_id.unique()) == size
-    assert len(reverse_transformed.fnlwgt.unique()) == size
-
-
-def test_data_processor_prepare_for_fitting():
-    """Test the ``prepare_for_fitting`` method.
-
-    Test that the method sets an expected list of transformers for the given
-    data types of the ``metadata`` and also respects the extra parameters
-    that those have. In this case the columns ``start_date`` and ``end_date`` have
-    a ``datetime_format`` which has to be set to the ``UnixTimestampEncoder`` and
-    the column ``salary`` has a ``computer_representation`` set to ``Int64``.
-    """
-    # Setup
-    data, metadata = download_demo(
-        modality='single_table',
-        dataset_name='student_placements_pii'
-    )
-    dp = DataProcessor(metadata)
-
-    # Run
-    dp.prepare_for_fitting(data)
-
-    # Assert
-    field_transformers = dp._hyper_transformer.field_transformers
-    expected_transformers = {
-        'mba_spec': UniformEncoder,
-        'employability_perc': FloatFormatter,
-        'placed': UniformEncoder,
-        'student_id': RegexGenerator,
-        'experience_years': FloatFormatter,
-        'duration': UniformEncoder,
-        'salary': FloatFormatter,
-        'second_perc': FloatFormatter,
-        'start_date': UnixTimestampEncoder,
-        'address': AnonymizedFaker,
-        'gender': UniformEncoder,
-        'mba_perc': FloatFormatter,
-        'degree_type': UniformEncoder,
-        'end_date': UnixTimestampEncoder,
-        'high_spec': UniformEncoder,
-        'high_perc': FloatFormatter,
-        'work_experience': UniformEncoder,
-        'degree_perc': FloatFormatter
-    }
-    for column_name, transformer_class in expected_transformers.items():
-        if transformer_class is not None:
-            assert isinstance(field_transformers[column_name], transformer_class)
-        else:
-            assert field_transformers[column_name] is None
-
-    assert field_transformers['start_date'].datetime_format == '%Y-%m-%d'
-    assert field_transformers['end_date'].datetime_format == '%Y-%m-%d'
-    assert field_transformers['salary'].computer_representation == 'Int64'
-
-
-def test_data_processor_reverse_transform_with_formatters():
-    """End to end test using formatters."""
-    # Setup
-    data, metadata = download_demo(
-        modality='single_table',
-        dataset_name='student_placements'
-    )
-    dp = DataProcessor(metadata)
-
-    # Run
-    dp.fit(data)
-
-    transformed = dp.transform(data)
-    reverse_transformed = dp.reverse_transform(transformed)
-    reverse_transformed = reverse_transformed.drop('student_id', axis=1)
-    reverse_transformed = reverse_transformed.reset_index()
-
-    # Assert
-    assert isinstance(dp.formatters['degree_perc'], NumericalFormatter)
-    assert isinstance(dp.formatters['employability_perc'], NumericalFormatter)
-    assert isinstance(dp.formatters['experience_years'], NumericalFormatter)
-    assert isinstance(dp.formatters['high_perc'], NumericalFormatter)
-    assert isinstance(dp.formatters['mba_perc'], NumericalFormatter)
-    assert isinstance(dp.formatters['salary'], NumericalFormatter)
-    assert isinstance(dp.formatters['second_perc'], NumericalFormatter)
-    assert isinstance(dp.formatters['start_date'], DatetimeFormatter)
-    assert isinstance(dp.formatters['end_date'], DatetimeFormatter)
-
-    start_date_data_format = get_datetime_format(data['start_date'][~data['start_date'].isna()][0])
-    reversed_start_date = reverse_transformed['start_date'][
-        ~reverse_transformed['start_date'].isna()
-    ]
-    reversed_start_date_format = get_datetime_format(reversed_start_date.iloc[0])
-    assert start_date_data_format == reversed_start_date_format
-
-    end_date_data_format = get_datetime_format(data['end_date'][~data['end_date'].isna()][0])
-    reversed_end_date = reverse_transformed['end_date'][~reverse_transformed['end_date'].isna()]
-    reversed_end_date_format = get_datetime_format(reversed_end_date.iloc[0])
-    assert end_date_data_format == reversed_end_date_format
-
-
-def test_data_processor_refit_hypertransformer():
-    """Test data processor re-fits _hyper_transformer."""
-    # Setup
-    data, metadata = download_demo(
-        modality='single_table',
-        dataset_name='student_placements'
-    )
-    dp = DataProcessor(metadata)
-
-    # Run
-    dp.fit(data)
-    dp.update_transformers({'placed': BinaryEncoder()})
-
-    # Assert
-    assert dp._hyper_transformer._fitted
-    assert dp._hyper_transformer._modified_config
-
-    dp.fit(data)
-
-    transformed = dp.transform(data)
-    assert all(transformed.dtypes == float)
-
-
-def test_data_processor_localized_anonymized_columns():
-    """Test data processor uses the default locale for anonymized columns."""
-    # Setup
-    data, metadata = download_demo('single_table', 'adult')
-    metadata.update_column('occupation', sdtype='job', pii=True)
-
-    dp = DataProcessor(metadata, locales=['en_CA', 'fr_CA'])
-
-    # Run
-    dp.fit(data)
-
-    # Assert
-    assert dp._hyper_transformer.field_transformers['occupation'].locales == ['en_CA', 'fr_CA']
+class TestDataProcessor:
+    def test_with_anonymized_columns(self):
+        """Test the ``DataProcessor``.
+
+        Test that when we update a ``pii`` column this uses ``AnonymizedFaker`` to create
+        a new set of data for that column, while it drops it on the ``transform``.
+
+        Setup:
+            - Load metadata and data.
+            - Parse the old metadata to a new metadata.
+            - Anonymize the field ``occupation``.
+
+        Run:
+            - Create a ``DataProcessor`` with the new metadata.
+            - Fit the ``DataProcessor`` instance.
+            - Transform the data.
+            - Reverse transform the data.
+
+        Assert:
+            - The column ``occupation`` has been dropped in the ``transform`` process.
+            - The column ``occupation`` has been re-created with new values from the
+            ``AnonymizedFaker`` instance.
+        """
+        # Load metadata and data
+        data, metadata = download_demo('single_table', 'adult')
+
+        # Add anonymized field
+        metadata.update_column('occupation', sdtype='job', pii=True)
+
+        # Instance ``DataProcessor``
+        dp = DataProcessor(metadata)
+
+        # Fit
+        dp.fit(data)
+
+        # Transform
+        transformed = dp.transform(data)
+
+        # Reverse Transform
+        reverse_transformed = dp.reverse_transform(transformed)
+
+        # Assert
+        assert reverse_transformed.occupation.isin(data.occupation).sum() == 0
+        assert 'occupation' not in transformed.columns
+
+    def test_with_anonymized_columns_and_primary_key(self):
+        """Test the ``DataProcessor``.
+
+        Test that when we update a ``pii`` column this uses ``AnonymizedFaker`` to create
+        a new set of data for that column, while it drops it on the ``transform`` and this values
+        can be repeated. Meanwhile, when we set a primary key this has to have a unique length
+        of the input data.
+
+        Setup:
+            - Load metadata and data.
+            - Parse the old metadata to a new metadata.
+            - Anonymize the field ``occupation``.
+            - Create ``id``.
+
+        Run:
+            - Create a ``DataProcessor`` with the new metadata.
+            - Fit the ``DataProcessor`` instance.
+            - Transform the data.
+            - Reverse transform the data.
+
+        Assert:
+            - The column ``occupation`` has been dropped in the ``transform`` process.
+            - The column ``occupation`` has been re-created with new values from the
+            ``AnonymizedFaker`` instance.
+            - The column ``id`` has been created in ``transform`` with a unique length of the data.
+        """
+        # Load metadata and data
+        data, metadata = download_demo('single_table', 'adult')
+
+        # Add anonymized field
+        metadata.update_column('occupation', sdtype='job', pii=True)
+
+        # Add primary key field
+        metadata.add_column('id', sdtype='id', regex_format='ID_\\d{4}[0-9]')
+        metadata.set_primary_key('id')
+
+        # Add id
+        size = len(data)
+        data['id'] = np.arange(0, size).astype('O')
+
+        # Instance ``DataProcessor``
+        dp = DataProcessor(metadata)
+
+        # Fit
+        dp.fit(data)
+
+        # Transform
+        transformed = dp.transform(data)
+
+        # Reverse Transform
+        reverse_transformed = dp.reverse_transform(transformed)
+
+        # Assert
+        assert transformed.index.name == 'id'
+        assert reverse_transformed.occupation.isin(data.occupation).sum() == 0
+        assert 'occupation' not in transformed.columns
+        assert 'id' not in transformed.columns
+        assert reverse_transformed.id.isin(data.id).sum() == 0
+        assert len(reverse_transformed.id.unique()) == size
+
+    def test_with_primary_key_numerical(self):
+        """End to end test for the ``DataProcessor``.
+
+        Test that when running the ``DataProcessor`` with a numerical primary key, this is able
+        to generate such a key in the ``transform`` method. The key should be the same length
+        as the input data size.
+
+        Setup:
+            - Load metadata and data.
+            - Detect the metadata from the ``dataframe``.
+            - Create ``id`` column.
+
+        Run:
+            - Create a ``DataProcessor`` with the new metadata.
+            - Fit the ``DataProcessor`` instance.
+            - Transform the data.
+            - Reverse transform the data.
+
+        Assert:
+            - The column ``id`` has been created during ``transform`` with a unique length
+            of the data.
+            matching the original numerical ``id`` column.
+        """
+        # Load metadata and data
+        data, _ = download_demo('single_table', 'adult')
+        adult_metadata = SingleTableMetadata()
+        adult_metadata.detect_from_dataframe(data=data)
+
+        # Add primary key field
+        adult_metadata.add_column('id', sdtype='id')
+        adult_metadata.set_primary_key('id')
+
+        # Add id
+        size = len(data)
+        id_generator = itertools.count()
+        ids = [next(id_generator) for _ in range(size)]
+        data['id'] = ids
+
+        # Instance ``DataProcessor``
+        dp = DataProcessor(adult_metadata)
+
+        # Fit
+        dp.fit(data)
+
+        # Transform
+        transformed = dp.transform(data)
+
+        # Reverse Transform
+        reverse_transformed = dp.reverse_transform(transformed)
+
+        # Assert
+        assert transformed.index.name == 'id'
+        assert 'id' not in transformed.columns
+        assert reverse_transformed.index.isin(data.id).sum() == size
+        assert len(reverse_transformed.id.unique()) == size
+
+    def test_with_alternate_keys(self):
+        """Test that alternate keys are being generated in a unique way.
+
+        Test that the alternate keys are being generated and dropped the same way
+        as with the ``primary_key``.
+        """
+        # Load metadata and data
+        data, _ = download_demo('single_table', 'adult')
+        data['fnlwgt'] = data['fnlwgt'].astype(str)
+        adult_metadata = SingleTableMetadata()
+        adult_metadata.detect_from_dataframe(data=data)
+
+        # Add primary key field
+        adult_metadata.add_column('id', sdtype='id')
+        adult_metadata.set_primary_key('id')
+
+        adult_metadata.add_column('secondary_id', sdtype='id')
+        adult_metadata.update_column('fnlwgt', sdtype='id', regex_format='ID_\\d{4}[0-9]')
+
+        adult_metadata.add_alternate_keys(['secondary_id', 'fnlwgt'])
+
+        # Add id
+        size = len(data)
+        id_generator = itertools.count()
+        ids = [next(id_generator) for _ in range(size)]
+        data['id'] = ids
+        data['secondary_id'] = ids
+
+        # Instance ``DataProcessor``
+        dp = DataProcessor(adult_metadata)
+
+        # Fit
+        dp.fit(data)
+
+        # Transform
+        transformed = dp.transform(data)
+
+        # Reverse Transform
+        reverse_transformed = dp.reverse_transform(transformed)
+
+        # Assert
+        assert 'id' not in transformed.columns
+        assert 'secondary_id' not in transformed.columns
+        assert 'fnlwgt' not in transformed.columns
+        assert len(reverse_transformed.id.unique()) == size
+        assert len(reverse_transformed.secondary_id.unique()) == size
+        assert len(reverse_transformed.fnlwgt.unique()) == size
+
+    def test_prepare_for_fitting(self):
+        """Test the ``prepare_for_fitting`` method.
+
+        Test that the method sets an expected list of transformers for the given
+        data types of the ``metadata`` and also respects the extra parameters
+        that those have. In this case the columns ``start_date`` and ``end_date`` have
+        a ``datetime_format`` which has to be set to the ``UnixTimestampEncoder`` and
+        the column ``salary`` has a ``computer_representation`` set to ``Int64``.
+        """
+        # Setup
+        data, metadata = download_demo(
+            modality='single_table',
+            dataset_name='student_placements_pii'
+        )
+        dp = DataProcessor(metadata)
+
+        # Run
+        dp.prepare_for_fitting(data)
+
+        # Assert
+        field_transformers = dp._hyper_transformer.field_transformers
+        expected_transformers = {
+            'mba_spec': LabelEncoder,
+            'employability_perc': FloatFormatter,
+            'placed': LabelEncoder,
+            'student_id': RegexGenerator,
+            'experience_years': FloatFormatter,
+            'duration': LabelEncoder,
+            'salary': FloatFormatter,
+            'second_perc': FloatFormatter,
+            'start_date': UnixTimestampEncoder,
+            'address': AnonymizedFaker,
+            'gender': LabelEncoder,
+            'mba_perc': FloatFormatter,
+            'degree_type': LabelEncoder,
+            'end_date': UnixTimestampEncoder,
+            'high_spec': LabelEncoder,
+            'high_perc': FloatFormatter,
+            'work_experience': LabelEncoder,
+            'degree_perc': FloatFormatter
+        }
+        for column_name, transformer_class in expected_transformers.items():
+            if transformer_class is not None:
+                assert isinstance(field_transformers[column_name], transformer_class)
+            else:
+                assert field_transformers[column_name] is None
+
+        assert field_transformers['start_date'].datetime_format == '%Y-%m-%d'
+        assert field_transformers['end_date'].datetime_format == '%Y-%m-%d'
+        assert field_transformers['salary'].computer_representation == 'Int64'
+
+    def test_reverse_transform_with_formatters(self):
+        """End to end test using formatters."""
+        # Setup
+        data, metadata = download_demo(
+            modality='single_table',
+            dataset_name='student_placements'
+        )
+        dp = DataProcessor(metadata)
+
+        # Run
+        dp.fit(data)
+
+        transformed = dp.transform(data)
+        reverse_transformed = dp.reverse_transform(transformed)
+        reverse_transformed = reverse_transformed.drop('student_id', axis=1)
+        reverse_transformed = reverse_transformed.reset_index()
+
+        # Assert
+        assert isinstance(dp.formatters['degree_perc'], NumericalFormatter)
+        assert isinstance(dp.formatters['employability_perc'], NumericalFormatter)
+        assert isinstance(dp.formatters['experience_years'], NumericalFormatter)
+        assert isinstance(dp.formatters['high_perc'], NumericalFormatter)
+        assert isinstance(dp.formatters['mba_perc'], NumericalFormatter)
+        assert isinstance(dp.formatters['salary'], NumericalFormatter)
+        assert isinstance(dp.formatters['second_perc'], NumericalFormatter)
+        assert isinstance(dp.formatters['start_date'], DatetimeFormatter)
+        assert isinstance(dp.formatters['end_date'], DatetimeFormatter)
+
+        start_date_data_format = get_datetime_format(
+            data['start_date'][~data['start_date'].isna()][0]
+        )
+        reversed_start_date = reverse_transformed['start_date'][
+            ~reverse_transformed['start_date'].isna()
+        ]
+        reversed_start_date_format = get_datetime_format(reversed_start_date.iloc[0])
+        assert start_date_data_format == reversed_start_date_format
+
+        end_date_data_format = get_datetime_format(data['end_date'][~data['end_date'].isna()][0])
+        reversed_end_date = reverse_transformed['end_date'][
+            ~reverse_transformed['end_date'].isna()
+        ]
+        reversed_end_date_format = get_datetime_format(reversed_end_date.iloc[0])
+        assert end_date_data_format == reversed_end_date_format
+
+    def test_refit_hypertransformer(self):
+        """Test data processor re-fits _hyper_transformer."""
+        # Setup
+        data, metadata = download_demo(
+            modality='single_table',
+            dataset_name='student_placements'
+        )
+        dp = DataProcessor(metadata)
+
+        # Run
+        dp.fit(data)
+        dp.update_transformers({'placed': BinaryEncoder()})
+
+        # Assert
+        assert dp._hyper_transformer._fitted
+        assert dp._hyper_transformer._modified_config
+
+        dp.fit(data)
+
+        transformed = dp.transform(data)
+        assert all(transformed.dtypes == float)
+
+    def test_localized_anonymized_columns(self):
+        """Test data processor uses the default locale for anonymized columns."""
+        # Setup
+        data, metadata = download_demo('single_table', 'adult')
+        metadata.update_column('occupation', sdtype='job', pii=True)
+
+        dp = DataProcessor(metadata, locales=['en_CA', 'fr_CA'])
+
+        # Run
+        dp.fit(data)
+
+        # Assert
+        assert dp._hyper_transformer.field_transformers['occupation'].locales == ['en_CA', 'fr_CA']

--- a/tests/integration/data_processing/test_data_processor.py
+++ b/tests/integration/data_processing/test_data_processor.py
@@ -246,23 +246,23 @@ class TestDataProcessor:
         # Assert
         field_transformers = dp._hyper_transformer.field_transformers
         expected_transformers = {
-            'mba_spec': LabelEncoder,
+            'mba_spec': UniformEncoder,
             'employability_perc': FloatFormatter,
-            'placed': LabelEncoder,
+            'placed': UniformEncoder,
             'student_id': RegexGenerator,
             'experience_years': FloatFormatter,
-            'duration': LabelEncoder,
+            'duration': UniformEncoder,
             'salary': FloatFormatter,
             'second_perc': FloatFormatter,
             'start_date': UnixTimestampEncoder,
             'address': AnonymizedFaker,
-            'gender': LabelEncoder,
+            'gender': UniformEncoder,
             'mba_perc': FloatFormatter,
-            'degree_type': LabelEncoder,
+            'degree_type': UniformEncoder,
             'end_date': UnixTimestampEncoder,
-            'high_spec': LabelEncoder,
+            'high_spec': UniformEncoder,
             'high_perc': FloatFormatter,
-            'work_experience': LabelEncoder,
+            'work_experience': UniformEncoder,
             'degree_perc': FloatFormatter
         }
         for column_name, transformer_class in expected_transformers.items():
@@ -356,7 +356,7 @@ class TestDataProcessor:
         assert dp._hyper_transformer.field_transformers['occupation'].locales == ['en_CA', 'fr_CA']
 
     def test_categorical_column_with_numbers(self):
-        """Test that LabelEncoder is assigned for categorical columns represented with numbers."""
+        """Test that UniformEncoder is assigned for categorical columns defined with numbers."""
         # Setup
         data = pd.DataFrame({
             'category_col': [
@@ -375,4 +375,4 @@ class TestDataProcessor:
         dp.fit(data)
 
         # Assert
-        assert isinstance(dp._hyper_transformer.field_transformers['category_col'], LabelEncoder)
+        assert isinstance(dp._hyper_transformer.field_transformers['category_col'], UniformEncoder)

--- a/tests/integration/data_processing/test_data_processor.py
+++ b/tests/integration/data_processing/test_data_processor.py
@@ -2,6 +2,7 @@
 import itertools
 
 import numpy as np
+import pandas as pd
 from rdt.transformers import (
     AnonymizedFaker, BinaryEncoder, FloatFormatter, RegexGenerator, UniformEncoder,
     UnixTimestampEncoder)
@@ -353,3 +354,25 @@ class TestDataProcessor:
 
         # Assert
         assert dp._hyper_transformer.field_transformers['occupation'].locales == ['en_CA', 'fr_CA']
+
+    def test_categorical_column_with_numbers(self):
+        """Test that LabelEncoder is assigned for categorical columns represented with numbers."""
+        # Setup
+        data = pd.DataFrame({
+            'category_col': [
+                1, 2, 1, 2, 1, 2, 1, 1, 1, 2, 2, 2, 1, 2,
+                1, 1, 2, 1, 2, 2
+            ],
+            'numerical_col': np.random.rand(20),
+        })
+
+        metadata = SingleTableMetadata()
+        metadata.detect_from_dataframe(data)
+
+        dp = DataProcessor(metadata)
+
+        # Run
+        dp.fit(data)
+
+        # Assert
+        assert isinstance(dp._hyper_transformer.field_transformers['category_col'], LabelEncoder)

--- a/tests/integration/metadata/test_multi_table.py
+++ b/tests/integration/metadata/test_multi_table.py
@@ -149,29 +149,45 @@ def test_detect_from_dataframes():
     metadata.detect_from_dataframes(real_data)
 
     # Assert
+    metadata.update_column(
+        table_name='hotels',
+        column_name='city',
+        sdtype='categorical',
+    )
+    metadata.update_column(
+        table_name='hotels',
+        column_name='state',
+        sdtype='categorical',
+    )
+    metadata.update_column(
+        table_name='hotels',
+        column_name='classification',
+        sdtype='categorical',
+    )
+
     expected_metadata = {
         'tables': {
             'hotels': {
                 'columns': {
-                    'hotel_id': {'sdtype': 'categorical'},
+                    'hotel_id': {'sdtype': 'id'},
                     'city': {'sdtype': 'categorical'},
                     'state': {'sdtype': 'categorical'},
                     'rating': {'sdtype': 'numerical'},
                     'classification': {'sdtype': 'categorical'}
-                }
+                },
             },
             'guests': {
                 'columns': {
-                    'guest_email': {'sdtype': 'categorical'},
+                    'guest_email': {'sdtype': 'id'},
                     'hotel_id': {'sdtype': 'categorical'},
-                    'has_rewards': {'sdtype': 'boolean'},
+                    'has_rewards': {'sdtype': 'categorical'},
                     'room_type': {'sdtype': 'categorical'},
                     'amenities_fee': {'sdtype': 'numerical'},
-                    'checkin_date': {'sdtype': 'categorical'},
-                    'checkout_date': {'sdtype': 'categorical'},
+                    'checkin_date': {'sdtype': 'datetime', 'datetime_format': '%d %b %Y'},
+                    'checkout_date': {'sdtype': 'datetime', 'datetime_format': '%d %b %Y'},
                     'room_rate': {'sdtype': 'numerical'},
-                    'billing_address': {'sdtype': 'categorical'},
-                    'credit_card_number': {'sdtype': 'numerical'}
+                    'billing_address': {'sdtype': 'unknown', 'pii': True},
+                    'credit_card_number': {'sdtype': 'id'}
                 }
             }
         },
@@ -200,29 +216,45 @@ def test_detect_from_csvs(tmp_path):
     metadata.detect_from_csvs(folder_name=tmp_path)
 
     # Assert
+    metadata.update_column(
+        table_name='hotels',
+        column_name='city',
+        sdtype='categorical',
+    )
+    metadata.update_column(
+        table_name='hotels',
+        column_name='state',
+        sdtype='categorical',
+    )
+    metadata.update_column(
+        table_name='hotels',
+        column_name='classification',
+        sdtype='categorical',
+    )
+
     expected_metadata = {
         'tables': {
             'hotels': {
                 'columns': {
-                    'hotel_id': {'sdtype': 'categorical'},
+                    'hotel_id': {'sdtype': 'id'},
                     'city': {'sdtype': 'categorical'},
                     'state': {'sdtype': 'categorical'},
                     'rating': {'sdtype': 'numerical'},
                     'classification': {'sdtype': 'categorical'}
-                }
+                },
             },
             'guests': {
                 'columns': {
-                    'guest_email': {'sdtype': 'categorical'},
+                    'guest_email': {'sdtype': 'id'},
                     'hotel_id': {'sdtype': 'categorical'},
-                    'has_rewards': {'sdtype': 'boolean'},
+                    'has_rewards': {'sdtype': 'categorical'},
                     'room_type': {'sdtype': 'categorical'},
                     'amenities_fee': {'sdtype': 'numerical'},
-                    'checkin_date': {'sdtype': 'categorical'},
-                    'checkout_date': {'sdtype': 'categorical'},
+                    'checkin_date': {'sdtype': 'datetime', 'datetime_format': '%d %b %Y'},
+                    'checkout_date': {'sdtype': 'datetime', 'datetime_format': '%d %b %Y'},
                     'room_rate': {'sdtype': 'numerical'},
-                    'billing_address': {'sdtype': 'categorical'},
-                    'credit_card_number': {'sdtype': 'numerical'}
+                    'billing_address': {'sdtype': 'unknown', 'pii': True},
+                    'credit_card_number': {'sdtype': 'id'}
                 }
             }
         },
@@ -251,11 +283,26 @@ def test_detect_table_from_csv(tmp_path):
     metadata.detect_table_from_csv('hotels', tmp_path / 'hotels.csv')
 
     # Assert
+    metadata.update_column(
+        table_name='hotels',
+        column_name='city',
+        sdtype='categorical',
+    )
+    metadata.update_column(
+        table_name='hotels',
+        column_name='state',
+        sdtype='categorical',
+    )
+    metadata.update_column(
+        table_name='hotels',
+        column_name='classification',
+        sdtype='categorical',
+    )
     expected_metadata = {
         'tables': {
             'hotels': {
                 'columns': {
-                    'hotel_id': {'sdtype': 'categorical'},
+                    'hotel_id': {'sdtype': 'id'},
                     'city': {'sdtype': 'categorical'},
                     'state': {'sdtype': 'categorical'},
                     'rating': {'sdtype': 'numerical'},

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -605,6 +605,21 @@ def test_use_own_data_using_hma(tmp_path):
         regex_format='HID_[0-9]{3,4}'
     )
     metadata.update_column(
+        table_name='hotels',
+        column_name='city',
+        sdtype='categorical',
+    )
+    metadata.update_column(
+        table_name='hotels',
+        column_name='state',
+        sdtype='categorical',
+    )
+    metadata.update_column(
+        table_name='hotels',
+        column_name='classification',
+        sdtype='categorical',
+    )
+    metadata.update_column(
         table_name='guests',
         column_name='hotel_id',
         sdtype='id',

--- a/tests/integration/single_table/test_copulas.py
+++ b/tests/integration/single_table/test_copulas.py
@@ -369,8 +369,8 @@ def test_categorical_column_with_numbers():
     # Setup
     data = pd.DataFrame({
         'category_col': [
-            1, 2, 1, 2, 1, 2, np.nan, 1, 1, np.nan, 2, 2, None, 2,
-            1, 1, None, 1, 2, 2
+            1, 2, 1, 2, 1, 2, np.nan, 1, 1, np.nan, 2, 2, np.nan, 2,
+            1, 1, np.nan, 1, 2, 2
         ],
         'numerical_col': np.random.rand(20),
     })

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -2,7 +2,7 @@
 
 import json
 import re
-from datetime import datetime
+import warnings
 from unittest.mock import Mock, call, patch
 
 import numpy as np
@@ -785,6 +785,20 @@ class TestSingleTableMetadata:
         assert sdtype_all_unique == 'id'
         assert sdtype_categorical_large == 'categorical'
         assert sdtype_unknown == 'unknown'
+
+    def test__determine_sdtype_for_objects_silence_warning(self):
+        """Test that UserWarning are silenced for ``_determine_sdtype_for_objects``."""
+        # Setup
+        instance = SingleTableMetadata()
+        data = pd.Series(['warning1', 'warning2'])
+
+        # Run
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            instance._determine_sdtype_for_objects(data)
+
+        # Assert
+        assert len(w) == 0
 
     def test_detect_columns(self):
         """Test the ``_detect_columns`` method."""

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -945,7 +945,7 @@ class TestSingleTableMetadata:
         # Assert
         assert instance.columns == {
             'categorical': {'sdtype': 'categorical'},
-            'date': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+            'date': {'sdtype': 'datetime'},
             'int': {'sdtype': 'numerical'},
             'float': {'sdtype': 'numerical'},
             'bool': {'sdtype': 'categorical'}
@@ -1070,7 +1070,7 @@ class TestSingleTableMetadata:
         # Assert
         assert instance.columns == {
             'categorical': {'sdtype': 'categorical'},
-            'date': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+            'date': {'sdtype': 'datetime'},
             'int': {'sdtype': 'numerical'},
             'float': {'sdtype': 'numerical'},
             'bool': {'sdtype': 'categorical'}

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -756,9 +756,6 @@ class TestSingleTableMetadata:
 
         data_datetime = pd.Series(['2022-01-01', '2022-02-01', '2022-03-01'])
         data_categorical_small = pd.Series(['a', 'b', 'c', 'd', 'e'])
-        data_numerical = pd.Series(
-            ['1', '2', '2', '4', '5', '6', '7', '8', '9', '10', '11', '12']
-        )
         data_all_unique = pd.Series(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'])
         data_categorical_large = pd.Series(['a'] * 10 + ['b'] * 4)
         data_unknown = pd.Series(['a', 'b', 'c', 'c', 1, 2.2, np.nan, None, 'd', 'e', 'f'])
@@ -766,7 +763,6 @@ class TestSingleTableMetadata:
         # Run
         sdtype_datetime = instance._determine_sdtype_for_objects(data_datetime)
         sdtype_categorical_small = instance._determine_sdtype_for_objects(data_categorical_small)
-        sdtype_numerical_float = instance._determine_sdtype_for_objects(data_numerical)
         sdtype_all_unique = instance._determine_sdtype_for_objects(data_all_unique)
         sdtype_categorical_large = instance._determine_sdtype_for_objects(data_categorical_large)
         sdtype_unknown = instance._determine_sdtype_for_objects(data_unknown)
@@ -774,7 +770,6 @@ class TestSingleTableMetadata:
         # Assert
         assert sdtype_datetime == 'datetime'
         assert sdtype_categorical_small == 'categorical'
-        assert sdtype_numerical_float == 'numerical'
         assert sdtype_all_unique == 'id'
         assert sdtype_categorical_large == 'categorical'
         assert sdtype_unknown == 'unknown'

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -786,6 +786,20 @@ class TestSingleTableMetadata:
         assert sdtype_categorical_large == 'categorical'
         assert sdtype_unknown == 'unknown'
 
+    @patch.object(pd.Series, 'sample')
+    def test__determine_sdtype_for_objects_subsample_datetime(self, mock_sample):
+        """Test the ``_determine_sdtype_for_objects`` method with large a datetime column."""
+        # Setup
+        instance = SingleTableMetadata()
+
+        data_datetime = pd.Series(['2022-01-01'] * 15000)
+
+        # Run
+        instance._determine_sdtype_for_objects(data_datetime)
+
+        # Assert
+        mock_sample.assert_called_once_with(10000)
+
     def test__determine_sdtype_for_objects_silence_warning(self):
         """Test that UserWarning are silenced for ``_determine_sdtype_for_objects``."""
         # Setup

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -721,7 +721,16 @@ class TestSingleTableMetadata:
             'age', 'numerical', computer_representation='Float')
 
     def test__determine_sdtype_for_numbers(self):
-        """Test the ``determine_sdtype_for_numbers`` method."""
+        """Test the ``determine_sdtype_for_numbers`` method.
+
+        Setup:
+            - Instance of ``SingleTableMetadata``.
+            - A series of numbers with less than 5 rows. Should be detected as numerical sdtype
+            - A series of numbers with less than 10% unique values. Should be detected as
+              categorical sdtype
+            - A series of numbers with all unique values. Should be detected as id sdtype
+            - A series of integers. Should be detected as numerical sdtype
+            - A series of floats. Should be detected as numerical sdtype"""
         # Setup
         instance = SingleTableMetadata()
 

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -3,6 +3,7 @@
 import json
 import re
 import warnings
+from datetime import datetime
 from unittest.mock import Mock, call, patch
 
 import numpy as np

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -755,6 +755,7 @@ class TestSingleTableMetadata:
         instance = SingleTableMetadata()
 
         data_datetime = pd.Series(['2022-01-01', '2022-02-01', '2022-03-01'])
+        wrong_datetime = pd.Series(['2022-01-01', '01-02-2022', '2022-03-01', '2022-03-01'])
         data_categorical_small = pd.Series(['a', 'b', 'c', 'd', 'e'])
         data_all_unique = pd.Series(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'])
         data_categorical_large = pd.Series(['a'] * 10 + ['b'] * 4)
@@ -762,6 +763,7 @@ class TestSingleTableMetadata:
 
         # Run
         sdtype_datetime = instance._determine_sdtype_for_objects(data_datetime)
+        sdtype_wrong_datetime = instance._determine_sdtype_for_objects(wrong_datetime)
         sdtype_categorical_small = instance._determine_sdtype_for_objects(data_categorical_small)
         sdtype_all_unique = instance._determine_sdtype_for_objects(data_all_unique)
         sdtype_categorical_large = instance._determine_sdtype_for_objects(data_categorical_large)
@@ -769,6 +771,7 @@ class TestSingleTableMetadata:
 
         # Assert
         assert sdtype_datetime == 'datetime'
+        assert sdtype_wrong_datetime == 'categorical'
         assert sdtype_categorical_small == 'categorical'
         assert sdtype_all_unique == 'id'
         assert sdtype_categorical_large == 'categorical'


### PR DESCRIPTION
Resolve #1515
- Compared to the issue, I just added one condition for `Object` detection:
```
if len(data) <= 10:
    sdtype = 'categorical'
```
I did it because otherwise a lot of test we're failing due to columns detected as `id` rather than `categorical` now. I also feel that this follow a similar statement that we have for numbers which is:
`If there are <=5 rows, we can't properly detect this. Sdtype is numerical.
`
Let me know if this works @npatki 

- One other thing, I noticed there is a lot of `staticmethod` in `SingleTableMetadata`. Following the [google styleguide](https://google.github.io/styleguide/pyguide.html), do we want to move them outside of the class in this PR? @amontanez24, I did it first but then I realised it was confusing which changes are proper to this issue or just cleaning so I removed it. Let me know what we prefer.
