### PR TITLE
Constraint outputs are being overwritten in DataProcessor.reverse_transform

### DIFF
--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -753,12 +753,7 @@ class DataProcessor:
             if column in sampled_columns
         ]
         for column_name in sampled_columns:
-            if column_name in missing_columns:
-                column_data = anonymized_data[column_name]
-            elif column_name in self._keys:
-                column_data = generated_keys[column_name]
-            else:
-                column_data = reversed_data[column_name]
+            column_data = reversed_data[column_name]
 
             dtype = self._dtypes[column_name]
             if is_integer_dtype(dtype) and is_float_dtype(column_data.dtype):

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -1895,7 +1895,13 @@ class TestDataProcessor:
             [np.float64, np.bool_, np.object_, np.object_, np.object_],
             index=['a', 'b', 'c', 'd', 'key']
         )
-        constraint_mock.reverse_transform.return_value = data
+        constraint_mock.reverse_transform.return_value = pd.DataFrame({
+            'a': [1, 4, 3],
+            'b': [True, True, False],
+            'c': ['d', 'e', 'f'],
+            'd': ['a@gmail.com', 'b@gmail.com', 'c@gmail.com'],
+            'key': ['sdv_0', 'sdv_1', 'sdv_2']
+        })
 
         # Run
         reverse_transformed = dp.reverse_transform(data)
@@ -1923,7 +1929,7 @@ class TestDataProcessor:
             call(num_rows=3, column_names=['key'])
         )
         expected_output = pd.DataFrame({
-            'a': [1., 2., 3.],
+            'a': [1., 4., 3.],
             'b': [True, True, False],
             'c': ['d', 'e', 'f'],
             'key': ['sdv_0', 'sdv_1', 'sdv_2'],


### PR DESCRIPTION
resolve #1551

This PR fixes a bug where the output from a constraint's reverse transform were being overwritten by the outputs of `self.generate_keys` and `self._hyper_transformer.create_anonymized_columns`. All keys and anonymized columns should still be able to go through the constraint reverse transformations and those changes should make it to the output.