### PR TITLE
Pandas release causes `is_datetime_type` to fail

### DIFF
--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -1,6 +1,5 @@
 """Miscellaneous utility functions."""
 from collections.abc import Iterable
-from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -84,12 +83,7 @@ def is_datetime_type(value):
     if isinstance(value, Iterable) and not isinstance(value, str):
         value = get_first_non_nan_value(value)
 
-    return (
-        pd.api.types.is_datetime64_any_dtype(value)
-        or isinstance(value, pd.Timestamp)
-        or isinstance(value, datetime)
-        or bool(get_datetime_format([value]))
-    )
+    return bool(get_datetime_format([value]))
 
 
 def is_numerical_type(value):

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -41,8 +41,8 @@ def get_datetime_format(value):
 def is_datetime_type(value):
     """Determine if the input is a datetime type or not.
 
-    If a ``pandas.Series`` or ``list`` is passed, it will return ``True`` if all the values
-    are datetime. Otherwise, it will check if the value is a datetime.
+    If a ``pandas.Series`` or ``list`` is passed, it will return ``True`` if the first
+    thousand values are datetime. Otherwise, it will check if the value is a datetime.
 
     Note: it will return ``False`` if ``value`` is a string representing
     a date before the year 1677.
@@ -58,13 +58,14 @@ def is_datetime_type(value):
     if isinstance(value, str) or (not isinstance(value, Iterable)):
         value = cast_to_iterable(value)
 
-    value = pd.Series(value)
-    value = value[~value.isna()]
-    for item in value:
+    values = pd.Series(value)
+    values = values[~values.isna()]
+    values = values.head(1000)  # only check 1000 values so this method takes less than 1 second
+    for value in values:
         if not (
-            bool(get_datetime_format([item]))
-            or isinstance(item, pd.Timestamp)
-            or isinstance(item, datetime)
+            bool(get_datetime_format([value]))
+            or isinstance(value, pd.Timestamp)
+            or isinstance(value, datetime)
         ):
             return False
 

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -1,6 +1,5 @@
 """Miscellaneous utility functions."""
 from collections.abc import Iterable
-from datetime import datetime
 from pathlib import Path
 
 import pandas as pd

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -1,5 +1,6 @@
 """Miscellaneous utility functions."""
 from collections.abc import Iterable
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -71,6 +72,8 @@ def get_datetime_format(value):
 
 def is_datetime_type(value):
     """Determine if the input is a datetime type or not.
+
+    Note: dates before the year 1677 will not be detected as datetime.
 
     Args:
         value (pandas.DataFrame, int, str or datetime):

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -15,38 +15,6 @@ def cast_to_iterable(value):
     return [value]
 
 
-def get_first_non_nan_value(input_value):
-    """Return the first not ``nan`` value when possible.
-
-    Convert to ``pandas.Series`` if the ``input_value`` is not already. This helps to detect
-    easier the ``nan`` values. We filter the values that are ``nans`` since pandas does not
-    detect them properly in their ``_guess_datetime_format_for_array``. Also there is a bug in
-    ``pandas`` that does not support ``numpy.str_`` data type, that is why we use
-    ``pandas.Series`` and convert the data type to ``string`` and then to ``numpy.ndarray``.
-
-    Args:
-       input_value (pandas.Series, np.ndarray, list, or str):
-            Input to return the first non ``nan`` value.
-
-    Returns:
-        str or ``nan``:
-            Returns either the first valid value or ``nan``.
-    """
-    value = input_value
-    if not isinstance(value, pd.Series):
-        value = pd.Series(input_value)
-
-    value = value[~value.isna()]
-    value = value.astype(str).to_numpy()
-    if len(value):
-        return value[0]
-
-    if isinstance(input_value, Iterable) and not isinstance(input_value, str):
-        return input_value[0]
-
-    return input_value
-
-
 def get_datetime_format(value):
     """Get the ``strftime`` format for a given ``value``.
 

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -1705,7 +1705,7 @@ class TestSingleTableMetadata:
         # Setup
         data = pd.DataFrame({
             'date1': ['10', True, 'b', 'bla', None],
-            'date2': ['2021-10-10', '05-10-2021', pd.Timestamp(1), datetime(1800, 1, 1), '2020-1-33'],
+            'date2': ['2021-10-10', '05-10-2021', pd.Timestamp(1), datetime(1, 1, 1), '2020-1-33'],
             'bool1': ['a', 0, '10', True, 'b'],
             'bool2': ['True', False, np.nan, float('nan'), None],
             'num1': ['a', 0, '10', True, False],

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -1705,7 +1705,7 @@ class TestSingleTableMetadata:
         # Setup
         data = pd.DataFrame({
             'date1': ['10', True, 'b', 'bla', None],
-            'date2': ['2021-10-10', '05-10-2021', pd.Timestamp(1), datetime(1, 1, 1), '2020-1-33'],
+            'date2': ['2021-10-10', '05-10-2021', pd.Timestamp(1), datetime(1800, 1, 1), '2020-1-33'],
             'bool1': ['a', 0, '10', True, 'b'],
             'bool2': ['True', False, np.nan, float('nan'), None],
             'num1': ['a', 0, '10', True, False],

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -93,7 +93,7 @@ def test_is_datetime_type_with_mixed_array():
     data = [
         pd.to_datetime('2020-01-01'),
         '1890-03-05',
-        pd.Timestamp('01-01'),
+        pd.Timestamp('01-01-01'),
         datetime(2020, 1, 1),
         np.nan
     ]
@@ -155,7 +155,7 @@ def test_is_datetime_type_with_timestamp():
     - True
     """
     # Setup
-    data = pd.Timestamp('01-01')
+    data = pd.Timestamp('2020-01-10')
     is_datetime = is_datetime_type(data)
 
     # Assert

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -187,26 +187,6 @@ def test_is_datetime_type_with_invalid_str():
     assert is_datetime is False
 
 
-def test_is_datetime_type_with_string():
-    """Test the ``is_datetime_type`` function when a string is passed.
-
-    Expect to return False when a string variable is passed.
-
-    Input:
-    - string
-    Output:
-    - False
-    """
-    # Setup
-    data = 'test'
-
-    # Run
-    is_datetime = is_datetime_type(data)
-
-    # Assert
-    assert is_datetime is False
-
-
 def test_is_datetime_type_with_int_series():
     """Test the ``is_datetime_type`` function when an int series is passed.
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -93,7 +93,7 @@ def test_is_datetime_type_with_mixed_array():
     data = [
         pd.to_datetime('2020-01-01'),
         '1890-03-05',
-        pd.Timestamp('01-01 01:00:00'),
+        pd.Timestamp('01-01'),
         datetime(2020, 1, 1),
         np.nan
     ]
@@ -111,7 +111,7 @@ def test_is_datetime_type_with_invalid_strings_in_list():
     data = [
         pd.to_datetime('2020-01-01'),
         '1890-03-05',
-        pd.Timestamp('01-01 01:00:00'),
+        pd.Timestamp('01-01-01'),
         datetime(2020, 1, 1),
         'invalid',
         np.nan
@@ -155,7 +155,7 @@ def test_is_datetime_type_with_timestamp():
     - True
     """
     # Setup
-    data = pd.Timestamp('01-01 01:00:00')
+    data = pd.Timestamp('01-01')
     is_datetime = is_datetime_type(data)
 
     # Assert

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -87,6 +87,43 @@ def test_is_datetime_type_with_datetime_series():
     assert is_datetime
 
 
+def test_is_datetime_type_with_mixed_array():
+    """Test the ``is_datetime_type`` function with a list of mixed datetime types."""
+    # Setup
+    data = [
+        pd.to_datetime('2020-01-01'),
+        '1890-03-05',
+        pd.Timestamp('01-01 00:00:01'),
+        datetime(2020, 1, 1),
+        np.nan
+    ]
+
+    # Run
+    is_datetime = is_datetime_type(data)
+
+    # Assert
+    assert is_datetime
+
+
+def test_is_datetime_type_with_invalid_strings_in_list():
+    """Test the ``is_datetime_type`` function with a invalid datetime in a list."""
+    # Setup
+    data = [
+        pd.to_datetime('2020-01-01'),
+        '1890-03-05',
+        pd.Timestamp('01-01 00:00:01'),
+        datetime(2020, 1, 1),
+        'invalid',
+        np.nan
+    ]
+
+    # Run
+    is_datetime = is_datetime_type(data)
+
+    # Assert
+    assert is_datetime is False
+
+
 def test_is_datetime_type_with_datetime():
     """Test the ``is_datetime_type`` function when a datetime is passed.
 
@@ -118,7 +155,7 @@ def test_is_datetime_type_with_timestamp():
     - True
     """
     # Setup
-    data = pd.Timestamp('01-01-01 00:00:01')
+    data = pd.Timestamp('01-01 00:00:01')
     is_datetime = is_datetime_type(data)
 
     # Assert

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -107,6 +107,24 @@ def test_is_datetime_type_with_datetime():
     assert is_datetime
 
 
+def test_is_datetime_type_with_timestamp():
+    """Test the ``is_datetime_type`` function when a Timestamp is passed.
+
+    Expect to return True when a datetime variable is passed.
+
+    Input:
+    - datetime.Datetime
+    Output:
+    - True
+    """
+    # Setup
+    data = pd.Timestamp('01-01-01 00:00:01')
+    is_datetime = is_datetime_type(data)
+
+    # Assert
+    assert is_datetime
+
+
 def test_is_datetime_type_with_pandas_datetime():
     """Test the ``is_datetime_type`` function when a pandas.datetime is passed.
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,8 +5,7 @@ import numpy as np
 import pandas as pd
 
 from sdv.utils import (
-    convert_to_timedelta, create_unique_name, get_datetime_format, get_first_non_nan_value,
-    is_datetime_type)
+    convert_to_timedelta, create_unique_name, get_datetime_format, is_datetime_type)
 from tests.utils import SeriesMatcher
 
 
@@ -260,18 +259,6 @@ def test_is_datetime_type_with_int_series():
 
     # Assert
     assert is_datetime is False
-
-
-def test_get_first_non_nan_value():
-    """Test that ``get_first_non_nan_value`` returns the first valid value."""
-    # Setup
-    data = [np.nan, None, '2021-02-01']
-
-    # Run
-    result = get_first_non_nan_value(data)
-
-    # Assert
-    assert result == '2021-02-01'
 
 
 def test_create_unique_name():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -93,7 +93,7 @@ def test_is_datetime_type_with_mixed_array():
     data = [
         pd.to_datetime('2020-01-01'),
         '1890-03-05',
-        pd.Timestamp('01-01 00:00:01'),
+        pd.Timestamp('01-01 01:00:00'),
         datetime(2020, 1, 1),
         np.nan
     ]
@@ -111,7 +111,7 @@ def test_is_datetime_type_with_invalid_strings_in_list():
     data = [
         pd.to_datetime('2020-01-01'),
         '1890-03-05',
-        pd.Timestamp('01-01 00:00:01'),
+        pd.Timestamp('01-01 01:00:00'),
         datetime(2020, 1, 1),
         'invalid',
         np.nan
@@ -155,7 +155,7 @@ def test_is_datetime_type_with_timestamp():
     - True
     """
     # Setup
-    data = pd.Timestamp('01-01 00:00:01')
+    data = pd.Timestamp('01-01 01:00:00')
     is_datetime = is_datetime_type(data)
 
     # Assert


### PR DESCRIPTION
`pandas 2.1.0` new release makes the `is_datetime64_any_dtype` method fail in the presence of hyphens, which we use to test for datetime values (eg "2020-01-01"). This PR removes that method and improves the logic of `is_datetime_type` to fix this issue.