### PR TITLE
Auto detected metadata is invalid (sdtype `unknown` cannot be validated)

### DIFF
--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -32,7 +32,7 @@ class SingleTableMetadata:
         'categorical': frozenset(['order', 'order_by']),
         'boolean': frozenset([]),
         'id': frozenset(['regex_format']),
-        'unknown': frozenset([]),
+        'unknown': frozenset(['pii']),
     }
 
     _DTYPES_TO_SDTYPES = {


### PR DESCRIPTION
Resolve #1567