### PR TITLE
Stop `output.pkl` from being generated while running tests

### DIFF
--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -1046,13 +1046,14 @@ class TestBaseMultiTableSynthesizer:
             }
 
     @patch('sdv.multi_table.base.cloudpickle')
-    def test_save(self, cloudpickle_mock):
+    def test_save(self, cloudpickle_mock, tmp_path):
         """Test that the synthesizer is saved correctly."""
         # Setup
         synthesizer = Mock()
 
         # Run
-        BaseMultiTableSynthesizer.save(synthesizer, 'output.pkl')
+        filepath = tmp_path / 'output.pkl'
+        BaseMultiTableSynthesizer.save(synthesizer, filepath)
 
         # Assert
         cloudpickle_mock.dump.assert_called_once_with(synthesizer, ANY)

--- a/tests/unit/sequential/test_par.py
+++ b/tests/unit/sequential/test_par.py
@@ -760,13 +760,14 @@ class TestPARSynthesizer:
             par.sample_sequential_columns(context_columns, 5)
 
     @patch('sdv.single_table.base.cloudpickle')
-    def test_save(self, cloudpickle_mock):
+    def test_save(self, cloudpickle_mock, tmp_path):
         """Test that the synthesizer is saved correctly."""
         # Setup
         synthesizer = Mock()
 
         # Run
-        PARSynthesizer.save(synthesizer, 'output.pkl')
+        filepath = tmp_path / 'output.pkl'
+        PARSynthesizer.save(synthesizer, filepath)
 
         # Assert
         cloudpickle_mock.dump.assert_called_once_with(synthesizer, ANY)

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -1550,13 +1550,14 @@ class TestBaseSingleTableSynthesizer:
         mock_handle_sampling_error.assert_called_once_with(False, 'temp_file', keyboard_error)
 
     @patch('sdv.single_table.base.cloudpickle')
-    def test_save(self, cloudpickle_mock):
+    def test_save(self, cloudpickle_mock, tmp_path):
         """Test that the synthesizer is saved correctly."""
         # Setup
         synthesizer = Mock()
 
         # Run
-        BaseSingleTableSynthesizer.save(synthesizer, 'output.pkl')
+        filepath = tmp_path / 'output.pkl'
+        BaseSingleTableSynthesizer.save(synthesizer, filepath)
 
         # Assert
         cloudpickle_mock.dump.assert_called_once_with(synthesizer, ANY)


### PR DESCRIPTION
When running `pytest`, some tests produce the `output.pkl` file. This PR makes sure the tests uses a temporary file, so no file is produced at the end of the run.