### PR TITLE
HMASynthesizer throws an error when sampling multi table models with three levels of depths

### DIFF
--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -117,8 +117,9 @@ class BaseHierarchicalSampler():
     def _sample_children(self, table_name, sampled_data):
         """Recursively sample the children of a table.
 
-        This method will loop through the children of a table and sample rows for that child for 
-        every primary key value in the parent.
+        This method will loop through the children of a table and sample rows for that child for
+        every primary key value in the parent. If the child has already been sampled by another
+        parent, this method will skip it.
 
         Args:
             table_name (string):
@@ -202,8 +203,8 @@ class BaseHierarchicalSampler():
             parent_name = relationship['parent_table_name']
             child_name = relationship['child_table_name']
             # When more than one relationship exists between two tables, only the first one
-            # is used to recreate the child tables, so that's the only one that needs to be
-            # added back.
+            # is used to recreate the child tables, so the rest of the foreign key columns
+            # need to be added.
             if (parent_name, child_name) not in added_relationships:
                 self._add_foreign_key_columns(
                     sampled_data[child_name],

--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -114,22 +114,18 @@ class BaseHierarchicalSampler():
                 sampled_data[child_name] = pd.concat(
                     [previous, sampled_rows]).reset_index(drop=True)
 
-    def _sample_table(self, table_name, sampled_data):
-        """Recursively sample every table.
+    def _sample_children(self, table_name, sampled_data):
+        """Recursively sample the children of a table.
 
-        Sample top level tables first, then their children, and so on.
+        This method will loop through the children of a table and sample rows for that child for 
+        every primary key value in the parent.
 
         Args:
             table_name (string):
-                Name of the table to sample.
+                Name of the table to sample children for.
             sampled_data (dict):
                 A dictionary mapping table names to sampled tables (pd.DataFrame).
         """
-        for parent_name in self.metadata._get_parent_map()[table_name]:
-            if parent_name not in sampled_data:
-                self._sample_table(table_name=parent_name, sampled_data=sampled_data)
-                return  # Optimization to avoid iterating through the same nodes multiple times
-
         for child_name in self.metadata._get_child_map()[table_name]:
             if child_name not in sampled_data:  # Sample based on only 1 parent
                 for _, row in sampled_data[table_name].iterrows():
@@ -139,7 +135,7 @@ class BaseHierarchicalSampler():
                         parent_row=row,
                         sampled_data=sampled_data
                     )
-                self._sample_table(table_name=child_name, sampled_data=sampled_data)
+                self._sample_children(table_name=child_name, sampled_data=sampled_data)
 
     def _finalize(self, sampled_data):
         """Remove extra columns from sampled tables and apply finishing touches.
@@ -198,8 +194,8 @@ class BaseHierarchicalSampler():
             sampled_data[table] = self._sample_rows(synthesizer, num_rows)
 
         # Sample rest of the graph
-        starting_table = root_parents.pop()  # Start at any root table
-        self._sample_table(table_name=starting_table, sampled_data=sampled_data)
+        for root_table in root_parents:
+            self._sample_children(table_name=root_table, sampled_data=sampled_data)
 
         added_relationships = set()
         for relationship in self.metadata.relationships:

--- a/tests/unit/sampling/test_hierarchical_sampler.py
+++ b/tests/unit/sampling/test_hierarchical_sampler.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import numpy as np
 import pandas as pd
@@ -177,16 +177,13 @@ class TestBaseHierarchicalSampler():
         })
         pd.testing.assert_frame_equal(sampled_data['sessions'], expected_result)
 
-    def test__sample_table(self):
-        """Test sampling a table.
-
-        The ``_sample_table`` method will call sample children and return the sampled data
-        dictionary.
+    def test__sample_children(self):
+        """Test sampling the children of a table.
 
         ``_sample_table`` does not sample the root parents of a graph, only the children.
         """
         # Setup
-        def sample_children(table_name, sampled_data, table_rows):
+        def sample_children(table_name, sampled_data):
             sampled_data['sessions'] = pd.DataFrame({
                 'user_id': [1, 1, 3],
                 'session_id': ['a', 'b', 'c'],
@@ -204,14 +201,10 @@ class TestBaseHierarchicalSampler():
         instance._table_sizes = {'users': 10, 'sessions': 5, 'transactions': 3}
         instance._table_synthesizers = {'users': Mock()}
         instance._sample_children.side_effect = sample_children
-        instance._sample_rows.return_value = pd.DataFrame({
-            'user_id': [1, 2, 3],
-            'name': ['John', 'Doe', 'Johanna']
-        })
 
         # Run
         result = {'users': pd.DataFrame()}
-        BaseHierarchicalSampler._sample_table(
+        BaseHierarchicalSampler._sample_children(
             self=instance,
             table_name='users',
             sampled_data=result
@@ -309,26 +302,34 @@ class TestBaseHierarchicalSampler():
             pd.testing.assert_frame_equal(result_frame, expected_frame)
 
     def test__sample(self):
-        """Test that the ``_sample_table`` is called for root tables."""
-        # Setup
-        expected_sample = {
-            'users': pd.DataFrame({
-                'user_id': [1, 2, 3],
-                'name': ['John', 'Doe', 'Johanna']
-            }),
-            'sessions': pd.DataFrame({
-                'user_id': [1, 1, 3],
-                'session_id': ['a', 'b', 'c'],
-                'os': ['windows', 'linux', 'mac'],
-                'country': ['us', 'us', 'es']
-            }),
-            'transactions': pd.DataFrame(dtype='Int64')
-        }
+        """Test that the whole dataset is sampled.
 
-        def _sample_table(table_name, sampled_data):
-            sampled_data['users'] = expected_sample['users']
-            sampled_data['sessions'] = expected_sample['sessions']
-            sampled_data['transactions'] = expected_sample['transactions']
+        Sampling has the following steps:
+        1. The root tables should be sampled first.
+        2. Then the lineage for each root is sampled by calling ``_sample_children``.
+        3. Any missing parent-child relationships are added using ``_add_foreign_key_columns``.
+        4. All extra columns are dropped by calling ``_finalize``.
+        """
+        # Setup
+        users = pd.DataFrame({
+            'id': [1, 2, 3],
+            'name': ['John', 'Doe', 'Johanna']
+        })
+        sessions = pd.DataFrame({
+            'user_id': [1, 1, 3],
+            'session_id': ['a', 'b', 'c'],
+            'os': ['windows', 'linux', 'mac'],
+            'country': ['us', 'us', 'es']
+        })
+        transactions = pd.DataFrame({
+            'user_id': [1, 2, 3],
+            'transaction_id': [1, 2, 3],
+            'transaction_amount': [100, 1000, 200]
+        })
+
+        def _sample_children_dummy(table_name, sampled_data):
+            sampled_data['sessions'] = sessions
+            sampled_data['transactions'] = transactions
 
         instance = Mock()
         instance._table_sizes = {
@@ -341,32 +342,67 @@ class TestBaseHierarchicalSampler():
                 'parent_table_name': 'users',
                 'parent_primary_key': 'id',
                 'child_table_name': 'sessions',
-                'child_foreign_key': 'id'
+                'child_foreign_key': 'user_id'
+            },
+            {
+                'parent_table_name': 'users',
+                'parent_primary_key': 'id',
+                'child_table_name': 'transactions',
+                'child_foreign_key': 'user_id'
             }
         ]
         users_synthesizer = Mock()
         instance._table_synthesizers = defaultdict(Mock, {'users': users_synthesizer})
         instance.metadata._get_parent_map.return_value = {
             'sessions': ['users'],
-            'transactions': ['sessions']
+            'transactions': ['users']
         }
         instance.metadata.tables = {
             'users': Mock(),
             'sessions': Mock(),
             'transactions': Mock(),
         }
-        instance._sample_table.side_effect = _sample_table
+        instance._sample_rows.return_value = users
+        instance._sample_children.side_effect = _sample_children_dummy
 
         # Run
         result = BaseHierarchicalSampler._sample(instance)
 
         # Assert
+        expected_sample = {
+            'users': DataFrameMatcher(pd.DataFrame({
+                'id': [1, 2, 3],
+                'name': ['John', 'Doe', 'Johanna']
+            })),
+            'sessions': DataFrameMatcher(pd.DataFrame({
+                'user_id': [1, 1, 3],
+                'session_id': ['a', 'b', 'c'],
+                'os': ['windows', 'linux', 'mac'],
+                'country': ['us', 'us', 'es']
+            })),
+            'transactions': DataFrameMatcher(pd.DataFrame({
+                'user_id': [1, 2, 3],
+                'transaction_id': [1, 2, 3],
+                'transaction_amount': [100, 1000, 200]
+            }))
+        }
         assert result == instance._finalize.return_value
-        instance._sample_table.assert_called_once_with(table_name='users',
-                                                       sampled_data=expected_sample)
-        instance._add_foreign_key_columns.assert_called_once_with(
-            DataFrameMatcher(expected_sample['sessions']),
-            DataFrameMatcher(expected_sample['users']),
-            'sessions',
-            'users')
+        instance._sample_children.assert_called_once_with(
+            table_name='users',
+            sampled_data=expected_sample
+        )
+        instance._add_foreign_key_columns.assert_has_calls([
+            call(
+                expected_sample['sessions'],
+                expected_sample['users'],
+                'sessions',
+                'users'
+            ),
+            call(
+                expected_sample['transactions'],
+                expected_sample['users'],
+                'transactions',
+                'users'
+            )
+        ])
         instance._finalize.assert_called_once_with(expected_sample)


### PR DESCRIPTION
resolves #1600

The main issue stems from the fact that root tables and child tables are sampled differently. A root table can be sampled all at once, while child tables are sampled in parts, based on the row being used from the parent. 

The current algorithm was trying to sample any parents of a table before sampling the table. See the following lines
https://github.com/sdv-dev/SDV/blob/3333b7a3e3c20691a825f794570d0e0243cc9fcb/sdv/sampling/hierarchical_sampler.py#L128-L131
The problem is that there are only two possibilities for the other parent:
1. It is also a root table in which case it would get skipped because all root tables are sampled [here](https://github.com/sdv-dev/SDV/blob/3333b7a3e3c20691a825f794570d0e0243cc9fcb/sdv/sampling/hierarchical_sampler.py#L194)
2. It isn't a root, in which case it can't be sampled unless `_sample_table` is called on its parent. This is because all tables that aren't roots get sampled by their parent. See these lines
https://github.com/sdv-dev/SDV/blob/3333b7a3e3c20691a825f794570d0e0243cc9fcb/sdv/sampling/hierarchical_sampler.py#L133-L141

This means that tables that were a second parent of a child, but not roots, never got sampled themselves. To fix this, I just looped over all the root tables and recursively sample their children.