### PR TITLE
Fix lint issues by running linter

### DIFF
--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -8,9 +8,9 @@ import logging
 import pandas as pd
 from copulas.multivariate.gaussian import GaussianMultivariate
 from copulas.univariate import GaussianUnivariate
+
 from rdt import HyperTransformer
 from rdt.transformers import BinaryEncoder, FloatFormatter, OneHotEncoder, UnixTimestampEncoder
-
 from sdv.constraints.errors import (
     AggregateConstraintsError, ConstraintMetadataError, MissingConstraintColumnError)
 from sdv.errors import ConstraintsNotMetError

--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -7,10 +7,10 @@ from copy import deepcopy
 from pathlib import Path
 
 import pandas as pd
-import rdt
 from pandas.api.types import is_float_dtype, is_integer_dtype
-from rdt.transformers import AnonymizedFaker, IDGenerator, RegexGenerator, get_default_transformers
 
+import rdt
+from rdt.transformers import AnonymizedFaker, IDGenerator, RegexGenerator, get_default_transformers
 from sdv.constraints import Constraint
 from sdv.constraints.base import get_subclasses
 from sdv.constraints.errors import (

--- a/sdv/lite/single_table.py
+++ b/sdv/lite/single_table.py
@@ -4,8 +4,8 @@ import logging
 import sys
 
 import cloudpickle
-import rdt.transformers
 
+import rdt.transformers
 from sdv.single_table import GaussianCopulaSynthesizer
 
 LOGGER = logging.getLogger(__name__)

--- a/sdv/metadata/anonymization.py
+++ b/sdv/metadata/anonymization.py
@@ -6,6 +6,7 @@ from functools import lru_cache
 
 from faker import Faker
 from faker.config import AVAILABLE_LOCALES
+
 from rdt.transformers import AnonymizedFaker
 
 SDTYPE_ANONYMIZERS = {

--- a/sdv/single_table/copulagan.py
+++ b/sdv/single_table/copulagan.py
@@ -3,7 +3,6 @@ import logging
 from copy import deepcopy
 
 import rdt
-
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
 from sdv.single_table.ctgan import CTGANSynthesizer
 from sdv.single_table.utils import (

--- a/sdv/single_table/copulas.py
+++ b/sdv/single_table/copulas.py
@@ -9,8 +9,8 @@ import numpy as np
 import pandas as pd
 import scipy
 from copulas import multivariate
-from rdt.transformers import OneHotEncoder
 
+from rdt.transformers import OneHotEncoder
 from sdv.errors import NonParametricError
 from sdv.single_table.base import BaseSingleTableSynthesizer
 from sdv.single_table.utils import (

--- a/tests/integration/data_processing/test_data_processor.py
+++ b/tests/integration/data_processing/test_data_processor.py
@@ -3,10 +3,10 @@ import itertools
 
 import numpy as np
 import pandas as pd
+
 from rdt.transformers import (
     AnonymizedFaker, BinaryEncoder, FloatFormatter, RegexGenerator, UniformEncoder,
     UnixTimestampEncoder)
-
 from sdv.data_processing import DataProcessor
 from sdv.data_processing.datetime_formatter import DatetimeFormatter
 from sdv.data_processing.numerical_formatter import NumericalFormatter

--- a/tests/integration/single_table/test_base.py
+++ b/tests/integration/single_table/test_base.py
@@ -3,8 +3,8 @@ import datetime
 import pandas as pd
 import pkg_resources
 import pytest
-from rdt.transformers import AnonymizedFaker, FloatFormatter, RegexGenerator, UniformEncoder
 
+from rdt.transformers import AnonymizedFaker, FloatFormatter, RegexGenerator, UniformEncoder
 from sdv.metadata import SingleTableMetadata
 from sdv.sampling import Condition
 from sdv.single_table import (

--- a/tests/integration/single_table/test_copulas.py
+++ b/tests/integration/single_table/test_copulas.py
@@ -3,9 +3,9 @@ from uuid import UUID
 import numpy as np
 import pandas as pd
 import pytest
+
 from rdt.transformers import (
     AnonymizedFaker, CustomLabelEncoder, FloatFormatter, LabelEncoder, PseudoAnonymizedFaker)
-
 from sdv.datasets.demo import download_demo
 from sdv.errors import InvalidDataError
 from sdv.evaluation.single_table import evaluate_quality, get_column_pair_plot, get_column_plot

--- a/tests/integration/single_table/test_ctgan.py
+++ b/tests/integration/single_table/test_ctgan.py
@@ -1,6 +1,6 @@
 import pandas as pd
-from rdt.transformers import FloatFormatter
 
+from rdt.transformers import FloatFormatter
 from sdv.datasets.demo import download_demo
 from sdv.evaluation.single_table import evaluate_quality, get_column_pair_plot, get_column_plot
 from sdv.metadata import SingleTableMetadata

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -5,12 +5,12 @@ from unittest.mock import Mock, call, patch
 import numpy as np
 import pandas as pd
 import pytest
+
 from rdt.errors import ConfigNotSetError
 from rdt.errors import NotFittedError as RDTNotFittedError
 from rdt.transformers import (
     AnonymizedFaker, FloatFormatter, GaussianNormalizer, IDGenerator, UniformEncoder,
     UnixTimestampEncoder)
-
 from sdv.constraints.errors import MissingConstraintColumnError
 from sdv.constraints.tabular import Positive, ScalarRange
 from sdv.data_processing.data_processor import DataProcessor

--- a/tests/unit/sequential/test_par.py
+++ b/tests/unit/sequential/test_par.py
@@ -4,8 +4,8 @@ from unittest.mock import ANY, Mock, mock_open, patch
 import numpy as np
 import pandas as pd
 import pytest
-from rdt.transformers import FloatFormatter, UnixTimestampEncoder
 
+from rdt.transformers import FloatFormatter, UnixTimestampEncoder
 from sdv.data_processing.data_processor import DataProcessor
 from sdv.errors import InvalidDataError, SamplingError, SynthesizerInputError
 from sdv.metadata.single_table import SingleTableMetadata

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -5,9 +5,9 @@ from unittest.mock import ANY, MagicMock, Mock, call, mock_open, patch
 import pandas as pd
 import pytest
 from copulas.multivariate import GaussianMultivariate
+
 from rdt.transformers import (
     BinaryEncoder, FloatFormatter, GaussianNormalizer, OneHotEncoder, RegexGenerator)
-
 from sdv.constraints.errors import AggregateConstraintsError
 from sdv.errors import ConstraintsNotMetError, InvalidDataError, SynthesizerInputError
 from sdv.metadata.single_table import SingleTableMetadata

--- a/tests/unit/single_table/test_copulagan.py
+++ b/tests/unit/single_table/test_copulagan.py
@@ -5,8 +5,8 @@ import numpy as np
 import pandas as pd
 import pytest
 from copulas.univariate import BetaUnivariate, GammaUnivariate, UniformUnivariate
-from rdt.transformers import GaussianNormalizer
 
+from rdt.transformers import GaussianNormalizer
 from sdv.errors import SynthesizerInputError
 from sdv.metadata.single_table import SingleTableMetadata
 from sdv.single_table.copulagan import CopulaGANSynthesizer


### PR DESCRIPTION
Running the linter runs into this warning:
`imports are incorrectly sorted`

Fixing this by running `make fix-lint`. All these changes were generated by  using autoflake, autopep8, and isort
