### PR TITLE
missing_value_replacement now defaults to random with RDT 1.7.1

### DIFF
--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -1144,7 +1144,7 @@ class TestDataProcessor:
 
         datetime_transformer = config['transformers']['date']
         assert isinstance(datetime_transformer, UnixTimestampEncoder)
-        assert datetime_transformer.missing_value_replacement == 'mean'
+        assert datetime_transformer.missing_value_replacement == 'random'
         assert datetime_transformer.missing_value_generation == 'random'
         assert datetime_transformer.datetime_format == '%Y-%m-%d'
         assert dp._primary_key == 'id'


### PR DESCRIPTION
With the change to RDT:
https://github.com/sdv-dev/RDT/pull/715

Value replacement will default to random which causes a test to fail with RDT: 1.7.1