### PR TITLE
Improve debug messages when a constraint falls back to reject sampling approach

### DIFF
--- a/sdv/constraints/errors.py
+++ b/sdv/constraints/errors.py
@@ -1,5 +1,11 @@
 """Constraint Exceptions."""
 
+import logging
+
+from sdv.errors import log_exc_stacktrace
+
+LOGGER = logging.getLogger(__name__)
+
 
 class MissingConstraintColumnError(Exception):
     """Error used when constraint is provided a table with missing columns."""
@@ -13,6 +19,8 @@ class AggregateConstraintsError(Exception):
 
     def __init__(self, errors):
         self.errors = errors
+        for error in self.errors:
+            log_exc_stacktrace(LOGGER, error)
 
     def __str__(self):
         return '\n' + '\n\n'.join(map(str, self.errors))

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -435,6 +435,7 @@ class Inequality(Constraint):
             table_data (pandas.DataFrame):
                 The Table data.
         """
+        raise ValueError('Inequality stubbed exception')
         self._validate_columns_exist(table_data)
         self._is_datetime = self._get_is_datetime(table_data)
         self._dtype = table_data[self._high_column_name].dtypes

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -184,8 +184,8 @@ def create_custom_constraint_class(is_valid_fn, transform_fn=None, reverse_trans
             except InvalidFunctionError as e:
                 raise e
 
-            except Exception:
-                raise FunctionError
+            except Exception as e:
+                raise FunctionError(str(e))
 
         def reverse_transform(self, data):
             """Reverse transform the table data.
@@ -435,7 +435,6 @@ class Inequality(Constraint):
             table_data (pandas.DataFrame):
                 The Table data.
         """
-        raise ValueError('Inequality stubbed exception')
         self._validate_columns_exist(table_data)
         self._is_datetime = self._get_is_datetime(table_data)
         self._dtype = table_data[self._high_column_name].dtypes

--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -327,8 +327,10 @@ class DataProcessor:
                     # Error came from custom constraint. We don't want to crash but we do
                     # want to log it.
                     LOGGER.info(
-                        'Error transforming %s:\n%s\nUsing the reject sampling approach instead.',
+                        'Unable to transform %s with columns %s due to an error in transform: \n'
+                        '%s\nUsing the reject sampling approach instead.',
                         constraint.__class__.__name__,
+                        constraint.column_names,
                         str(error)
                     )
                     log_exception(LOGGER)

--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -18,8 +18,8 @@ from sdv.constraints.errors import (
 from sdv.data_processing.datetime_formatter import DatetimeFormatter
 from sdv.data_processing.errors import InvalidConstraintsError, NotFittedError
 from sdv.data_processing.numerical_formatter import NumericalFormatter
-from sdv.data_processing.utils import load_module_from_path, log_exception
-from sdv.errors import SynthesizerInputError
+from sdv.data_processing.utils import load_module_from_path
+from sdv.errors import SynthesizerInputError, log_exc_stacktrace
 from sdv.metadata.anonymization import get_anonymized_transformer
 from sdv.metadata.single_table import SingleTableMetadata
 
@@ -297,7 +297,6 @@ class DataProcessor:
             try:
                 constraint.fit(data)
             except Exception as e:
-                log_exception(LOGGER)
                 errors.append(e)
 
         if errors:
@@ -322,7 +321,7 @@ class DataProcessor:
                         constraint.__class__.__name__,
                         error.missing_columns
                     )
-                    log_exception(LOGGER)
+                    log_exc_stacktrace(LOGGER, error)
                 else:
                     # Error came from custom constraint. We don't want to crash but we do
                     # want to log it.
@@ -333,14 +332,13 @@ class DataProcessor:
                         constraint.column_names,
                         str(error)
                     )
-                    log_exception(LOGGER)
+                    log_exc_stacktrace(LOGGER, error)
                 if is_condition:
                     indices_to_drop = data.columns.isin(constraint.constraint_columns)
                     columns_to_drop = data.columns.where(indices_to_drop).dropna()
                     data = data.drop(columns_to_drop, axis=1)
 
             except Exception as error:
-                log_exception(LOGGER)
                 errors.append(error)
 
         if errors:

--- a/sdv/data_processing/utils.py
+++ b/sdv/data_processing/utils.py
@@ -1,6 +1,8 @@
 """Utility functions for data processing."""
 
 import importlib
+import sys
+import traceback
 
 
 def load_module_from_path(path):
@@ -23,3 +25,15 @@ def load_module_from_path(path):
     spec.loader.exec_module(module)
 
     return module
+
+
+def log_exception(logger):
+    """Log the traceback of a caught exception.
+
+    Args:
+        logger (logging.Logger):
+            A logger object to use for the logging.
+    """
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    message = ''.join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+    logger.debug(message)

--- a/sdv/data_processing/utils.py
+++ b/sdv/data_processing/utils.py
@@ -1,8 +1,6 @@
 """Utility functions for data processing."""
 
 import importlib
-import sys
-import traceback
 
 
 def load_module_from_path(path):
@@ -25,15 +23,3 @@ def load_module_from_path(path):
     spec.loader.exec_module(module)
 
     return module
-
-
-def log_exception(logger):
-    """Log the traceback of a caught exception.
-
-    Args:
-        logger (logging.Logger):
-            A logger object to use for the logging.
-    """
-    exc_type, exc_value, exc_traceback = sys.exc_info()
-    message = ''.join(traceback.format_exception(exc_type, exc_value, exc_traceback))
-    logger.debug(message)

--- a/sdv/errors.py
+++ b/sdv/errors.py
@@ -1,5 +1,23 @@
 """SDV Exceptions."""
 
+import logging
+import traceback
+
+LOGGER = logging.getLogger(__name__)
+
+
+def log_exc_stacktrace(logger, error):
+    """Log the stack trace of an exception.
+
+    Args:
+        logger (logging.Logger):
+            A logger object to use for the logging.
+        error (Exception):
+            The error to log.
+    """
+    message = ''.join(traceback.format_exception(type(error), error, error.__traceback__))
+    logger.debug(message)
+
 
 class NotFittedError(Exception):
     """Error to raise when sample is called and the model is not fitted."""

--- a/tests/integration/single_table/test_constraints.py
+++ b/tests/integration/single_table/test_constraints.py
@@ -923,6 +923,7 @@ def test_custom_and_overlapping_constraint_errors(caplog, demo_data, demo_metada
 
 def test_aggregate_constraint_errors(demo_data, demo_metadata):
     """Test that if there are multiple constraint errors, they are raised together."""
+    # Setup
     class BadConstraint(Constraint):
         def __init__(self, column_name):
             self.column_name = column_name

--- a/tests/integration/single_table/test_constraints.py
+++ b/tests/integration/single_table/test_constraints.py
@@ -854,6 +854,7 @@ def test_timezone_aware_constraints():
     # Assert
     assert all(samples['col1'] < samples['col2'])
 
+
 def test_custom_and_overlapping_constraint_errors(caplog, demo_data, demo_metadata):
     """Test a synthesizer when constraints overlap or custom constraints raise an error.
 

--- a/tests/unit/constraints/test_errors.py
+++ b/tests/unit/constraints/test_errors.py
@@ -1,0 +1,16 @@
+import logging
+
+from sdv.constraints.errors import AggregateConstraintsError
+
+
+def test_aggregate_constraints_error_logs_errors(caplog):
+    """Test that an ``AggregateConstraintsError`` logs the stack trace for all its errors."""
+    # Run
+    with caplog.at_level(logging.DEBUG, logger='sdv.constraints.errors'):
+        error = AggregateConstraintsError(errors=[ValueError('error 1'), ValueError('error 2')])
+        message = str(error)
+
+    # Assert
+    log_messages = [record[2] for record in caplog.record_tuples]
+    assert log_messages == ['ValueError: error 1\n', 'ValueError: error 2\n']
+    assert message == '\nerror 1\n\nerror 2'

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -336,8 +336,8 @@ class TestBaseSingleTableSynthesizer:
         """Test that ``_validate_constraints`` calls ``fit`` and returns any errors."""
         # Setup
         instance = Mock()
-        msg = 'Invalid data for constraint.'
-        instance._data_processor._fit_constraints.side_effect = AggregateConstraintsError([msg])
+        error = ValueError('Invalid data for constraint.')
+        instance._data_processor._fit_constraints.side_effect = AggregateConstraintsError([error])
         data = object()
 
         # Run

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,0 +1,22 @@
+from unittest.mock import Mock, patch
+
+from sdv.errors import log_exc_stacktrace
+
+
+@patch('sdv.errors.traceback')
+def test_log_exception(traceback_mock):
+    """Test that the sys.excinfo is logged in a debug statement."""
+    # Setup
+    error = Mock(spec=Exception)
+    logger = Mock()
+    traceback_mock.format_exception.return_value = [
+        'error line 1\n',
+        'error line 2\n',
+        'error line 3\n'
+    ]
+
+    # Run
+    log_exc_stacktrace(logger, error)
+
+    # Assert
+    logger.debug.assert_called_once_with('error line 1\nerror line 2\nerror line 3\n')


### PR DESCRIPTION
resolves #1478 
CU-85ztc8c9a

This PR addresses the issue above but also introduces a function to log the stack trace of an exception at the `DEBUG` level. There are a few places where we catch errors, accumulate them and then raise them altogether with a large error message later. The problem with this is that we lose the stack trace of those errors. To help remedy this, I call the function in the following places:
1. The initialization of a `AggregateConstraintsError`. This way whenever one is made, we know the log will be accessible.
2. When overlapping constraints cause a `MissingConstraintColumnError`.
3. When a custom constraint raises an unexpected error. This is because in that situation, we don't crash and fall back to reject sampling.