### PR TITLE
Add csv options to load_csvs

### DIFF
--- a/sdv/datasets/local.py
+++ b/sdv/datasets/local.py
@@ -6,13 +6,13 @@ from os import path, walk
 from sdv.utils import load_data_from_csv
 
 
-def load_csvs(folder_name, pandas_kwargs=None):
+def load_csvs(folder_name, read_csv_parameters=None):
     """Load csv files from specified folder.
 
     Args:
         folder_name (str):
             The full path of the folder with the data to be loaded.
-        pandas_kwargs (dict):
+        read_csv_parameters (dict):
             A python dictionary of with string and value accepted by ``pandas.read_csv``
             function. Defaults to ``None``.
     """
@@ -26,7 +26,7 @@ def load_csvs(folder_name, pandas_kwargs=None):
         base_name, ext = path.splitext(filename)
         if ext == '.csv':
             filepath = path.join(dirpath, filename)
-            csvs[base_name] = load_data_from_csv(filepath, pandas_kwargs)
+            csvs[base_name] = load_data_from_csv(filepath, read_csv_parameters)
         else:
             other_files.append(filename)
 

--- a/sdv/datasets/local.py
+++ b/sdv/datasets/local.py
@@ -6,12 +6,15 @@ from os import path, walk
 from sdv.utils import load_data_from_csv
 
 
-def load_csvs(folder_name):
+def load_csvs(folder_name, pandas_kwargs=None):
     """Load csv files from specified folder.
 
     Args:
         folder_name (str):
             The full path of the folder with the data to be loaded.
+        pandas_kwargs (dict):
+            A python dictionary of with string and value accepted by ``pandas.read_csv``
+            function. Defaults to ``None``.
     """
     if not path.exists(folder_name):
         raise ValueError(f"The folder '{folder_name}' cannot be found.")
@@ -23,7 +26,7 @@ def load_csvs(folder_name):
         base_name, ext = path.splitext(filename)
         if ext == '.csv':
             filepath = path.join(dirpath, filename)
-            csvs[base_name] = load_data_from_csv(filepath)
+            csvs[base_name] = load_data_from_csv(filepath, pandas_kwargs)
         else:
             other_files.append(filename)
 

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -471,7 +471,7 @@ class MultiTableMetadata:
 
         self._detect_relationships()
 
-    def detect_table_from_csv(self, table_name, filepath):
+    def detect_table_from_csv(self, table_name, filepath, pandas_kwargs=None):
         """Detect the metadata for a table from a csv file.
 
         Args:
@@ -479,10 +479,13 @@ class MultiTableMetadata:
                 Name of the table to detect.
             filepath (str):
                 String that represents the ``path`` to the ``csv`` file.
+            pandas_kwargs (dict):
+                A python dictionary of with string and value accepted by ``pandas.read_csv``
+                function. Defaults to ``None``.
         """
         self._validate_table_not_detected(table_name)
         table = SingleTableMetadata()
-        data = load_data_from_csv(filepath)
+        data = load_data_from_csv(filepath, pandas_kwargs)
         table._detect_columns(data)
         self.tables[table_name] = table
         self._log_detected_table(table)

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -471,7 +471,7 @@ class MultiTableMetadata:
 
         self._detect_relationships()
 
-    def detect_table_from_csv(self, table_name, filepath, pandas_kwargs=None):
+    def detect_table_from_csv(self, table_name, filepath, read_csv_parameters=None):
         """Detect the metadata for a table from a csv file.
 
         Args:
@@ -479,18 +479,18 @@ class MultiTableMetadata:
                 Name of the table to detect.
             filepath (str):
                 String that represents the ``path`` to the ``csv`` file.
-            pandas_kwargs (dict):
+            read_csv_parameters (dict):
                 A python dictionary of with string and value accepted by ``pandas.read_csv``
                 function. Defaults to ``None``.
         """
         self._validate_table_not_detected(table_name)
         table = SingleTableMetadata()
-        data = load_data_from_csv(filepath, pandas_kwargs)
+        data = load_data_from_csv(filepath, read_csv_parameters)
         table._detect_columns(data)
         self.tables[table_name] = table
         self._log_detected_table(table)
 
-    def detect_from_csvs(self, folder_name):
+    def detect_from_csvs(self, folder_name, read_csv_parameters=None):
         """Detect the metadata for all tables in a folder of csv files.
 
         Args:
@@ -510,7 +510,7 @@ class MultiTableMetadata:
 
         for csv_file in csv_files:
             table_name = csv_file.stem
-            self.detect_table_from_csv(table_name, str(csv_file))
+            self.detect_table_from_csv(table_name, str(csv_file), read_csv_parameters)
 
         self._detect_relationships()
 

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -374,7 +374,7 @@ class SingleTableMetadata:
         LOGGER.info('Detected metadata:')
         LOGGER.info(json.dumps(self.to_dict(), indent=4))
 
-    def detect_from_csv(self, filepath, pandas_kwargs=None):
+    def detect_from_csv(self, filepath, read_csv_parameters=None):
         """Detect the metadata from a ``csv`` file.
 
         This method automatically detects the ``sdtypes`` for a given ``csv`` file.
@@ -382,7 +382,7 @@ class SingleTableMetadata:
         Args:
             filepath (str):
                 String that represents the ``path`` to the ``csv`` file.
-            pandas_kwargs (dict):
+            read_csv_parameters (dict):
                 A python dictionary of with string and value accepted by ``pandas.read_csv``
                 function. Defaults to ``None``.
         """
@@ -392,7 +392,7 @@ class SingleTableMetadata:
                 'object to detect from other data sources.'
             )
 
-        data = load_data_from_csv(filepath, pandas_kwargs)
+        data = load_data_from_csv(filepath, read_csv_parameters)
         self.detect_from_dataframe(data)
 
     @staticmethod

--- a/sdv/utils.py
+++ b/sdv/utils.py
@@ -146,19 +146,19 @@ def convert_to_timedelta(column):
     return column
 
 
-def load_data_from_csv(filepath, pandas_kwargs=None):
+def load_data_from_csv(filepath, read_csv_parameters=None):
     """Load DataFrame from a filepath.
 
     Args:
         filepath (str):
             String that represents the ``path`` to the ``csv`` file.
-        pandas_kwargs (dict):
+        read_csv_parameters (dict):
             A python dictionary of with string and value accepted by ``pandas.read_csv``
             function. Defaults to ``None``.
     """
     filepath = Path(filepath)
-    pandas_kwargs = pandas_kwargs or {}
-    data = pd.read_csv(filepath, **pandas_kwargs)
+    read_csv_parameters = read_csv_parameters or {}
+    data = pd.read_csv(filepath, **read_csv_parameters)
     return data
 
 

--- a/tests/unit/datasets/test_local.py
+++ b/tests/unit/datasets/test_local.py
@@ -30,7 +30,7 @@ def test_load_csvs(load_mock, warnings_mock, tmp_path):
     users_mock = Mock()
     orders_mock = Mock()
 
-    load_mock.side_effect = lambda file: orders_mock if 'orders.csv' in file else users_mock
+    load_mock.side_effect = lambda file, args: orders_mock if 'orders.csv' in file else users_mock
 
     # Run
     orders_path = tmp_path / 'orders.csv'
@@ -48,8 +48,8 @@ def test_load_csvs(load_mock, warnings_mock, tmp_path):
         'orders': orders_mock,
         'users': users_mock
     }
-    assert call(op.join(tmp_path, 'orders.csv')) in load_mock.mock_calls
-    assert call(op.join(tmp_path, 'users.csv')) in load_mock.mock_calls
+    assert call(op.join(tmp_path, 'orders.csv'), None) in load_mock.mock_calls
+    assert call(op.join(tmp_path, 'users.csv'), None) in load_mock.mock_calls
     warnings_mock.warn.assert_called_once_with(
         f"Ignoring incompatible files ['fake.json'] in folder '{tmp_path}'.")
 

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -2031,7 +2031,7 @@ class TestMultiTableMetadata:
         metadata.detect_table_from_csv('table', 'path.csv')
 
         # Assert
-        load_csv_mock.assert_called_once_with('path.csv')
+        load_csv_mock.assert_called_once_with('path.csv', None)
         single_table_mock.return_value._detect_columns.assert_called_once_with(fake_data)
         assert metadata.tables == {'table': single_table_mock.return_value}
 

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -2101,8 +2101,8 @@ class TestMultiTableMetadata:
 
         # Assert
         expected_calls = [
-            call('table1', str(filepath1)),
-            call('table2', str(filepath2))
+            call('table1', str(filepath1), None),
+            call('table2', str(filepath2), None)
         ]
 
         instance.detect_table_from_csv.assert_has_calls(expected_calls, any_order=True)

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -1125,7 +1125,7 @@ class TestSingleTableMetadata:
         # Run
         filepath = tmp_path / 'mydata.csv'
         data.to_csv(filepath, index=False)
-        instance.detect_from_csv(filepath, pandas_kwargs={'parse_dates': ['date']})
+        instance.detect_from_csv(filepath, read_csv_parameters={'parse_dates': ['date']})
 
         # Assert
         assert instance.columns == {


### PR DESCRIPTION
Clickup task: 
CU-86ayj7br6

resolves #1644 

Allow local read csv function to accept pandas csv options as a dictionary, so the user can process the csv in their preferred manner