### PR TITLE
Add print estimate warning when the estimate cols for hma are large

### DIFF
--- a/sdv/multi_table/hma.py
+++ b/sdv/multi_table/hma.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 
 import numpy as np
 import pandas as pd
-from tabulate import tabulate
 from tqdm import tqdm
 
 from sdv.errors import SynthesizerInputError
@@ -163,9 +162,9 @@ class HMASynthesizer(BaseHierarchicalSampler, BaseMultiTableSynthesizer):
                 'schema is not recommended. To model this data, HMA will '
                 f'generate a large number of columns. ({total_est_cols} columns)\n\n')
             self._print(
-                tabulate(
+                pd.DataFrame(
                     print_table,
-                    headers=[
+                    columns=[
                         'Table Name',
                         '# Columns in Metadata',
                         'Est # Columns'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ install_requires = [
     'deepecho>=0.4.2,<0.5',
     'rdt>=1.7.0,<2',
     'sdmetrics>=0.11.0,<0.12',
-    'tabulate>=0.8.8',
 ]
 
 pomegranate_requires = [

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     'deepecho>=0.4.2,<0.5',
     'rdt>=1.7.0,<2',
     'sdmetrics>=0.11.0,<0.12',
-    'tabulate>=0.8',
+    'tabulate>=0.8.8',
 ]
 
 pomegranate_requires = [

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
     'deepecho>=0.4.2,<0.5',
     'rdt>=1.7.0,<2',
     'sdmetrics>=0.11.0,<0.12',
+    'tabulate>=0.8',
 ]
 
 pomegranate_requires = [

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -735,6 +735,7 @@ class TestHMASynthesizer:
             r'contact us at info@sdv.dev for enterprise solutions.'
         ]
 
+        # Run
         HMASynthesizer(metadata)
 
         captured = capsys.readouterr()
@@ -748,6 +749,7 @@ class TestHMASynthesizer:
             dataset_name='trains_v1'
         )
 
+        # Run
         HMASynthesizer(small_metadata)
 
         captured = capsys.readouterr()

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -721,6 +721,42 @@ class TestHMASynthesizer:
             match = re.search(pattern, captured.out + captured.err)
             assert match is not None
 
+    def test_warning_message_too_many_cols(self, capsys):
+        """Test that a warning appears if there are more than 1000 expected columns"""
+        # Setup
+        (_, metadata) = download_demo(
+            modality='multi_table',
+            dataset_name='NBA_v1'
+        )
+
+        key_phrases = [
+            r'PerformanceAlert:',
+            r'large number of columns.',
+            r'contact us at info@sdv.dev for enterprise solutions.'
+        ]
+
+        HMASynthesizer(metadata)
+
+        captured = capsys.readouterr()
+
+        # Assert
+        for pattern in key_phrases:
+            match = re.search(pattern, captured.out + captured.err)
+            assert match is not None
+        (_, small_metadata) = download_demo(
+            modality='multi_table',
+            dataset_name='trains_v1'
+        )
+
+        HMASynthesizer(small_metadata)
+
+        captured = capsys.readouterr()
+
+        # Assert that small amount of columns don't trigger the message
+        for pattern in key_phrases:
+            match = re.search(pattern, captured.out + captured.err)
+            assert match is None
+
     def test_hma_three_linear_nodes(self):
         """Test it works on a simple 'grandparent-parent-child' dataset."""
         # Setup

--- a/tests/unit/multi_table/test_hma.py
+++ b/tests/unit/multi_table/test_hma.py
@@ -85,9 +85,9 @@ class TestHMASynthesizer:
 
         pd.testing.assert_frame_equal(result, expected)
 
-    def test_warning_message_too_many_cols(self, capsys):
+    def test__print_estimate_warning(self, capsys):
         """Test that a warning appears if there are more than 1000 expected columns"""
-
+        # Setup
         metadata = get_multi_table_metadata()
 
         key_phrases = [
@@ -96,6 +96,7 @@ class TestHMASynthesizer:
             r'contact us at info@sdv.dev for enterprise solutions.'
         ]
 
+        # Run
         with patch.object(HMASynthesizer,
                           '_estimate_num_columns',
                           return_value={'nesreca': 2000}):
@@ -108,11 +109,11 @@ class TestHMASynthesizer:
             match = re.search(pattern, captured.out + captured.err)
             assert match is not None
 
-        small_metadata = get_multi_table_metadata()
+        # Run
         with patch.object(HMASynthesizer,
                           '_estimate_num_columns',
                           return_value={'nesreca': 10}):
-            HMASynthesizer(small_metadata)
+            HMASynthesizer(metadata)
 
         captured = capsys.readouterr()
 

--- a/tests/unit/multi_table/test_hma.py
+++ b/tests/unit/multi_table/test_hma.py
@@ -110,7 +110,7 @@ class TestHMASynthesizer:
             assert match is not None
         (_, small_metadata) = download_demo(
             modality='multi_table',
-            dataset_name='fake_hotels'
+            dataset_name='trains_v1'
         )
 
         HMASynthesizer(small_metadata)


### PR DESCRIPTION
CU-86ayjengm

resolves #1646 

Print a notice in a tabular format explaining the HMASynthesizer will be slow.

Visual Output:
<img width="1192" alt="Screenshot 2023-10-25 at 6 20 39 PM" src="https://github.com/sdv-dev/SDV/assets/10409759/af17c7da-369e-4638-925d-d95fede99cdd">
