### PR TITLE
Add `_estimate_num_columns` method to ctgan

### DIFF
--- a/sdv/single_table/ctgan.py
+++ b/sdv/single_table/ctgan.py
@@ -1,5 +1,5 @@
 """Wrapper around CTGAN model."""
-
+import numpy as np
 from ctgan import CTGAN, TVAE
 
 from sdv.single_table.base import BaseSingleTableSynthesizer
@@ -131,7 +131,7 @@ class CTGANSynthesizer(BaseSingleTableSynthesizer):
 
             elif sdtypes[column] in {'categorical', 'boolean'}:
                 if transformers[column] is None:
-                    num_categories = data[column].nunique(dropna=False)
+                    num_categories = data[column].fillna(np.nan).nunique(dropna=False)
                     num_generated_columns[column] = num_categories
                 else:
                     num_generated_columns[column] = 11

--- a/sdv/single_table/ctgan.py
+++ b/sdv/single_table/ctgan.py
@@ -133,9 +133,6 @@ class CTGANSynthesizer(BaseSingleTableSynthesizer):
                 else:
                     num_generated_columns[column] = 11
 
-            else:
-                num_generated_columns[column] = 0
-
         return num_generated_columns
 
     def _fit(self, processed_data):

--- a/sdv/single_table/ctgan.py
+++ b/sdv/single_table/ctgan.py
@@ -111,6 +111,9 @@ class CTGANSynthesizer(BaseSingleTableSynthesizer):
     def _estimate_num_columns(self, data):
         """Estimate the number of columns that the data will generate.
 
+        Estimates that continuous columns generate 11 columns and categorical ones
+        create n where n is the number of unique categories.
+
         Args:
             data (pandas.DataFrame):
                 Data to estimate the number of columns from.
@@ -128,7 +131,7 @@ class CTGANSynthesizer(BaseSingleTableSynthesizer):
 
             elif sdtypes[column] in {'categorical', 'boolean'}:
                 if transformers[column] is None:
-                    num_categories = data[column].nunique()
+                    num_categories = data[column].nunique(dropna=False)
                     num_generated_columns[column] = num_categories
                 else:
                     num_generated_columns[column] = 11

--- a/sdv/single_table/ctgan.py
+++ b/sdv/single_table/ctgan.py
@@ -108,6 +108,36 @@ class CTGANSynthesizer(BaseSingleTableSynthesizer):
             'cuda': cuda
         }
 
+    def _estimate_num_columns(self, data):
+        """Estimate the number of columns that the data will generate.
+
+        Args:
+            data (pandas.DataFrame):
+                Data to estimate the number of columns from.
+
+        Returns:
+            int:
+                Number of estimate columns.
+        """
+        sdtypes = self._data_processor.get_sdtypes()
+        transformers = self.get_transformers()
+        num_generated_columns = {}
+        for column in data.columns:
+            if sdtypes[column] in {'numerical', 'datetime'}:
+                num_generated_columns[column] = 11
+
+            elif sdtypes[column] in {'categorical', 'boolean'}:
+                if transformers[column] is None:
+                    num_categories = data[column].nunique()
+                    num_generated_columns[column] = num_categories
+                else:
+                    num_generated_columns[column] = 11
+
+            else:
+                num_generated_columns[column] = 0
+
+        return num_generated_columns
+
     def _fit(self, processed_data):
         """Fit the model to the table.
 

--- a/tests/integration/single_table/test_ctgan.py
+++ b/tests/integration/single_table/test_ctgan.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 from rdt.transformers import FloatFormatter, LabelEncoder
 
@@ -14,6 +15,7 @@ def test__estimate_num_columns():
     metadata.add_column('numerical', sdtype='numerical')
     metadata.add_column('categorical', sdtype='categorical')
     metadata.add_column('categorical2', sdtype='categorical')
+    metadata.add_column('categorical3', sdtype='categorical')
     metadata.add_column('datetime', sdtype='datetime')
     metadata.add_column('boolean', sdtype='boolean')
     data = pd.DataFrame({
@@ -21,6 +23,7 @@ def test__estimate_num_columns():
         'datetime': ['2020-01-01', '2020-01-02', '2020-01-03'],
         'categorical': ['a', 'b', 'b'],
         'categorical2': ['a', 'b', 'b'],
+        'categorical3': ['a', np.nan, np.nan],
         'boolean': [True, False, True],
     })
     instance = CTGANSynthesizer(metadata)
@@ -36,6 +39,7 @@ def test__estimate_num_columns():
         'datetime': 11,
         'categorical': 2,
         'categorical2': 11,
+        'categorical3': 2,
         'boolean': 2,
     }
 

--- a/tests/integration/single_table/test_ctgan.py
+++ b/tests/integration/single_table/test_ctgan.py
@@ -1,10 +1,46 @@
 import pandas as pd
-from rdt.transformers import FloatFormatter
+from rdt.transformers import FloatFormatter, LabelEncoder
 
 from sdv.datasets.demo import download_demo
 from sdv.evaluation.single_table import evaluate_quality, get_column_pair_plot, get_column_plot
 from sdv.metadata import SingleTableMetadata
 from sdv.single_table import CTGANSynthesizer
+
+
+def test__estimate_num_columns():
+    """Test the number of columns is estimated correctly."""
+    # Setup
+    metadata = SingleTableMetadata()
+    metadata.add_column('numerical', sdtype='numerical')
+    metadata.add_column('categorical', sdtype='categorical')
+    metadata.add_column('categorical2', sdtype='categorical')
+    metadata.add_column('datetime', sdtype='datetime')
+    metadata.add_column('boolean', sdtype='boolean')
+    metadata.add_column('id', sdtype='id')
+    data = pd.DataFrame({
+        'numerical': [.1, .2, .3],
+        'datetime': ['2020-01-01', '2020-01-02', '2020-01-03'],
+        'categorical': ['a', 'b', 'b'],
+        'categorical2': ['a', 'b', 'b'],
+        'boolean': [True, False, True],
+        'id': [1, 2, 3],
+    })
+    instance = CTGANSynthesizer(metadata)
+
+    # Run
+    instance.auto_assign_transformers(data)
+    instance.update_transformers({'categorical2': LabelEncoder()})
+    result = instance._estimate_num_columns(data)
+
+    # Assert
+    assert result == {
+        'numerical': 11,
+        'datetime': 11,
+        'categorical': 2,
+        'categorical2': 11,
+        'boolean': 2,
+        'id': 0,
+    }
 
 
 def test_synthesize_table_ctgan(tmp_path):

--- a/tests/integration/single_table/test_ctgan.py
+++ b/tests/integration/single_table/test_ctgan.py
@@ -23,7 +23,7 @@ def test__estimate_num_columns():
         'datetime': ['2020-01-01', '2020-01-02', '2020-01-03'],
         'categorical': ['a', 'b', 'b'],
         'categorical2': ['a', 'b', 'b'],
-        'categorical3': ['a', np.nan, np.nan],
+        'categorical3': [float('nan'), np.nan, None],
         'boolean': [True, False, True],
     })
     instance = CTGANSynthesizer(metadata)
@@ -39,7 +39,7 @@ def test__estimate_num_columns():
         'datetime': 11,
         'categorical': 2,
         'categorical2': 11,
-        'categorical3': 2,
+        'categorical3': 1,
         'boolean': 2,
     }
 

--- a/tests/integration/single_table/test_ctgan.py
+++ b/tests/integration/single_table/test_ctgan.py
@@ -16,14 +16,12 @@ def test__estimate_num_columns():
     metadata.add_column('categorical2', sdtype='categorical')
     metadata.add_column('datetime', sdtype='datetime')
     metadata.add_column('boolean', sdtype='boolean')
-    metadata.add_column('id', sdtype='id')
     data = pd.DataFrame({
         'numerical': [.1, .2, .3],
         'datetime': ['2020-01-01', '2020-01-02', '2020-01-03'],
         'categorical': ['a', 'b', 'b'],
         'categorical2': ['a', 'b', 'b'],
         'boolean': [True, False, True],
-        'id': [1, 2, 3],
     })
     instance = CTGANSynthesizer(metadata)
 
@@ -39,7 +37,6 @@ def test__estimate_num_columns():
         'categorical': 2,
         'categorical2': 11,
         'boolean': 2,
-        'id': 0,
     }
 
 


### PR DESCRIPTION
CU-86ayfuk2q
Resolve #1657.

Note: this doesn't implement the error message described in the issue - "if transformers haven't been determined yet, throw an error" - because `get_transformers` does that internally.