### PR TITLE
Identifying PII Sdtypes in Metadata

### DIFF
--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -300,7 +300,7 @@ class SingleTableMetadata:
         cleaned_name = re.sub(r'[^a-zA-Z0-9]', '', column_name).lower()
         return next((
             sdtype for reference, sdtype in self._REFERENCE_TO_SDTYPE.items()
-            if cleaned_name == reference or reference in cleaned_name
+            if reference in cleaned_name
         ), None)
 
     def _determine_sdtype_for_numbers(self, data):
@@ -400,9 +400,7 @@ class SingleTableMetadata:
 
             column_dict = {'sdtype': sdtype}
 
-            if sdtype in self._REFERENCE_TO_SDTYPE.values():
-                column_dict['pii'] = True
-            elif sdtype == 'unknown':
+            if sdtype in self._REFERENCE_TO_SDTYPE.values() or sdtype == 'unknown':
                 column_dict['pii'] = True
             elif sdtype == 'datetime' and dtype == 'O':
                 datetime_format = get_datetime_format(column_data.iloc[:100])

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -52,6 +52,46 @@ class SingleTableMetadata:
         'sequence_index',
         'METADATA_SPEC_VERSION'
     ])
+
+    _REFERENCE_TO_SDTYPE = {
+        'phonenumber': 'phone_number',
+        'email': 'email',
+        'ssn': 'ssn',
+        'firstname': 'first_name',
+        'lastname': 'last_name',
+        'countrycode': 'country_code',
+        'administativeunit': 'administrative_unit',
+        'state': 'administrative_unit',
+        'province': 'administrative_unit',
+        'stateabbr': 'state_abbr',
+        'city': 'city',
+        'postalcode': 'postcode',
+        'zipcode': 'postcode',
+        'postcode': 'postcode',
+        'streetaddress': 'street_address',
+        'line1': 'street_address',
+        'secondaryaddress': 'secondary_address',
+        'line2': 'secondary_address',
+        'latitude': 'latitude',
+        'longitude': 'longitude',
+        'ipv4': 'ipv4_address',
+        'ipv4address': 'ipv4_address',
+        'ipv6': 'ipv6_address',
+        'ipv6address': 'ipv6_address',
+        'ipaddress': 'ipv6_address',
+        'macaddress': 'mac_address',
+        'useragent': 'user_agent_string',
+        'useragentstring': 'user_agent_string',
+        'iban': 'iban',
+        'swift': 'swift11',
+        'swift11': 'swift11',
+        'swift8': 'swift8',
+        'creditcardnumber': 'credit_card_number',
+        'vin': 'vin',
+        'licenseplate': 'license_plate',
+        'license': 'license_plate',
+    }
+
     METADATA_SPEC_VERSION = 'SINGLE_TABLE_V1'
     _DEFAULT_SDTYPES = list(_SDTYPE_KWARGS) + list(SDTYPE_ANONYMIZERS)
 
@@ -250,6 +290,19 @@ class SingleTableMetadata:
 
         return deepcopy(metadata)
 
+    def _detect_pii_column(self, column_name):
+        """Detect PII columns.
+
+        Args:
+            column_name (str):
+                The column name to be analyzed.
+        """
+        cleaned_name = re.sub(r'[^a-zA-Z0-9]', '', column_name).lower()
+        return next((
+            sdtype for reference, sdtype in self._REFERENCE_TO_SDTYPE.items()
+            if cleaned_name == reference or reference in cleaned_name
+        ), None)
+
     def _determine_sdtype_for_numbers(self, data):
         """Determine the sdtype for a numerical column.
 
@@ -322,31 +375,34 @@ class SingleTableMetadata:
             clean_data = column_data.dropna()
             dtype = clean_data.infer_objects().dtype.kind
 
-            sdtype = None
-            if dtype in self._DTYPES_TO_SDTYPES:
-                sdtype = self._DTYPES_TO_SDTYPES[dtype]
-            elif dtype in ['i', 'f']:
-                sdtype = self._determine_sdtype_for_numbers(column_data)
-
-            elif dtype == 'O':
-                sdtype = self._determine_sdtype_for_objects(column_data)
-
+            sdtype = self._detect_pii_column(field)
             if sdtype is None:
-                raise InvalidMetadataError(
-                    f"Unsupported data type for column '{field}' (kind: {dtype})."
-                    "The valid data types are: 'object', 'int', 'float', 'datetime', 'bool'."
-                )
+                if dtype in self._DTYPES_TO_SDTYPES:
+                    sdtype = self._DTYPES_TO_SDTYPES[dtype]
+                elif dtype in ['i', 'f']:
+                    sdtype = self._determine_sdtype_for_numbers(column_data)
 
-            # Set the first ID column we detect to be the primary key
-            if sdtype == 'id':
-                if self.primary_key is None:
-                    self.primary_key = field
-                else:
-                    sdtype = 'unknown'
+                elif dtype == 'O':
+                    sdtype = self._determine_sdtype_for_objects(column_data)
+
+                if sdtype is None:
+                    raise InvalidMetadataError(
+                        f"Unsupported data type for column '{field}' (kind: {dtype})."
+                        "The valid data types are: 'object', 'int', 'float', 'datetime', 'bool'."
+                    )
+
+                # Set the first ID column we detect to be the primary key
+                if sdtype == 'id':
+                    if self.primary_key is None:
+                        self.primary_key = field
+                    else:
+                        sdtype = 'unknown'
 
             column_dict = {'sdtype': sdtype}
 
-            if sdtype == 'unknown':
+            if sdtype in self._REFERENCE_TO_SDTYPE.values():
+                column_dict['pii'] = True
+            elif sdtype == 'unknown':
                 column_dict['pii'] = True
             elif sdtype == 'datetime' and dtype == 'O':
                 datetime_format = get_datetime_format(column_data.iloc[:100])

--- a/tests/integration/metadata/test_multi_table.py
+++ b/tests/integration/metadata/test_multi_table.py
@@ -151,16 +151,6 @@ def test_detect_from_dataframes():
     # Assert
     metadata.update_column(
         table_name='hotels',
-        column_name='city',
-        sdtype='categorical',
-    )
-    metadata.update_column(
-        table_name='hotels',
-        column_name='state',
-        sdtype='categorical',
-    )
-    metadata.update_column(
-        table_name='hotels',
         column_name='classification',
         sdtype='categorical',
     )
@@ -170,8 +160,8 @@ def test_detect_from_dataframes():
             'hotels': {
                 'columns': {
                     'hotel_id': {'sdtype': 'id'},
-                    'city': {'sdtype': 'categorical'},
-                    'state': {'sdtype': 'categorical'},
+                    'city': {'sdtype': 'city', 'pii': True},
+                    'state': {'sdtype': 'administrative_unit', 'pii': True},
                     'rating': {'sdtype': 'numerical'},
                     'classification': {'sdtype': 'categorical'}
                 },
@@ -179,7 +169,7 @@ def test_detect_from_dataframes():
             },
             'guests': {
                 'columns': {
-                    'guest_email': {'sdtype': 'id'},
+                    'guest_email': {'sdtype': 'email', 'pii': True},
                     'hotel_id': {'sdtype': 'id'},
                     'has_rewards': {'sdtype': 'categorical'},
                     'room_type': {'sdtype': 'categorical'},
@@ -188,9 +178,8 @@ def test_detect_from_dataframes():
                     'checkout_date': {'sdtype': 'datetime', 'datetime_format': '%d %b %Y'},
                     'room_rate': {'sdtype': 'numerical'},
                     'billing_address': {'sdtype': 'unknown', 'pii': True},
-                    'credit_card_number': {'sdtype': 'unknown', 'pii': True}
+                    'credit_card_number': {'sdtype': 'credit_card_number', 'pii': True}
                 },
-                'primary_key': 'guest_email'
             }
         },
         'relationships': [
@@ -226,16 +215,6 @@ def test_detect_from_csvs(tmp_path):
     # Assert
     metadata.update_column(
         table_name='hotels',
-        column_name='city',
-        sdtype='categorical',
-    )
-    metadata.update_column(
-        table_name='hotels',
-        column_name='state',
-        sdtype='categorical',
-    )
-    metadata.update_column(
-        table_name='hotels',
         column_name='classification',
         sdtype='categorical',
     )
@@ -245,8 +224,8 @@ def test_detect_from_csvs(tmp_path):
             'hotels': {
                 'columns': {
                     'hotel_id': {'sdtype': 'id'},
-                    'city': {'sdtype': 'categorical'},
-                    'state': {'sdtype': 'categorical'},
+                    'city': {'sdtype': 'city', 'pii': True},
+                    'state': {'sdtype': 'administrative_unit', 'pii': True},
                     'rating': {'sdtype': 'numerical'},
                     'classification': {'sdtype': 'categorical'}
                 },
@@ -254,7 +233,7 @@ def test_detect_from_csvs(tmp_path):
             },
             'guests': {
                 'columns': {
-                    'guest_email': {'sdtype': 'id'},
+                    'guest_email': {'sdtype': 'email', 'pii': True},
                     'hotel_id': {'sdtype': 'id'},
                     'has_rewards': {'sdtype': 'categorical'},
                     'room_type': {'sdtype': 'categorical'},
@@ -263,9 +242,8 @@ def test_detect_from_csvs(tmp_path):
                     'checkout_date': {'sdtype': 'datetime', 'datetime_format': '%d %b %Y'},
                     'room_rate': {'sdtype': 'numerical'},
                     'billing_address': {'sdtype': 'unknown', 'pii': True},
-                    'credit_card_number': {'sdtype': 'unknown', 'pii': True}
+                    'credit_card_number': {'sdtype': 'credit_card_number', 'pii': True}
                 },
-                'primary_key': 'guest_email'
             }
         },
         'relationships': [

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -721,6 +721,20 @@ class TestSingleTableMetadata:
         mock__validate_column.assert_called_once_with(
             'age', 'numerical', computer_representation='Float')
 
+    def test__detect_pii_columns(self):
+        """Test the ``_detect_pii_column`` method."""
+        # Setup
+        metadata = SingleTableMetadata()
+
+        # Run and Assert
+        assert metadata._detect_pii_column('user_first_name') == 'first_name'
+        assert metadata._detect_pii_column('User_Last_Name') == 'last_name'
+        assert metadata._detect_pii_column('country^code') == 'country_code'
+        assert metadata._detect_pii_column('city') == 'city'
+        assert metadata._detect_pii_column('address') is None
+        assert metadata._detect_pii_column('first_name_last_name') == 'first_name'
+        assert metadata._detect_pii_column('license') == 'license_plate'
+
     def test__determine_sdtype_for_numbers(self):
         """Test the ``determine_sdtype_for_numbers`` method.
 
@@ -860,6 +874,10 @@ class TestSingleTableMetadata:
             'categorical': ['a', 'b', 'a', 'a', 'b', 'b', 'a', 'b', 'a', 'b', 'a'],
             'bool': [True, False, True, False, True, False, True, False, True, False, True],
             'unknown': ['a', 'b', 'c', 'c', 1, 2.2, np.nan, None, 'd', 'e', 'f'],
+            'first_name': [
+                'John', 'Jane', 'John', 'Jane', 'John', 'Jane', 'John', 'Jane', 'John',
+                'Jane', 'John'
+            ],
         })
 
         expected_datetime_format = '%Y-%m-%d'
@@ -880,6 +898,8 @@ class TestSingleTableMetadata:
         assert instance.columns['unknown']['sdtype'] == 'unknown'
         assert instance.columns['unknown']['pii'] is True
         assert instance.columns['bool']['sdtype'] == 'categorical'
+        assert instance.columns['first_name']['sdtype'] == 'first_name'
+        assert instance.columns['first_name']['pii'] is True
 
         assert instance.primary_key == 'id'
 


### PR DESCRIPTION
CU-86ayr5vuu
Resolve #1683

For info, if there are 2 references in the column name, like `first_name_and_last_name`
it will be the first sdtype in order in `REFERENCE_TO_SDTYPE` that will be assigned. In this case, it will be `first_name`