### PR TITLE
HMASynthesizer creates too much synthetic data (always creates a child for every parent row)

### DIFF
--- a/sdv/multi_table/hma.py
+++ b/sdv/multi_table/hma.py
@@ -1,7 +1,6 @@
 """Hierarchical Modeling Algorithms."""
 
 import logging
-import math
 from copy import deepcopy
 
 import numpy as np
@@ -432,7 +431,7 @@ class HMASynthesizer(BaseHierarchicalSampler, BaseMultiTableSynthesizer):
             num_rows = flat_parameters[num_rows_key]
             flat_parameters[num_rows_key] = min(
                 self._max_child_rows[num_rows_key],
-                math.ceil(num_rows)
+                round(num_rows)
             )
 
         return flat_parameters.rename(new_keys).to_dict()

--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -1,6 +1,5 @@
 """Hierarchical Samplers."""
 import logging
-import math
 
 import pandas as pd
 
@@ -67,7 +66,8 @@ class BaseHierarchicalSampler():
             pandas.DataFrame:
                 Sampled rows, shape (, num_rows)
         """
-        num_rows = num_rows or synthesizer._num_rows
+        if num_rows is None:
+            num_rows = synthesizer._num_rows
         return synthesizer._sample_batch(int(num_rows), keep_extra_columns=True)
 
     def _get_num_rows_from_parent(self, parent_row, child_name, foreign_key):
@@ -78,12 +78,12 @@ class BaseHierarchicalSampler():
             num_rows = parent_row[num_rows_key]
             num_rows = min(
                 self._max_child_rows[num_rows_key],
-                math.ceil(num_rows)
+                round(num_rows)
             )
 
         return num_rows
 
-    def _add_child_rows(self, child_name, parent_name, parent_row, sampled_data):
+    def _add_child_rows(self, child_name, parent_name, parent_row, sampled_data, num_rows=None):
         """Sample the child rows that reference the parent row.
 
         Args:
@@ -95,10 +95,14 @@ class BaseHierarchicalSampler():
                 The row from the parent table to sample for from the child table.
             sampled_data (dict):
                 A dictionary mapping table names to sampled data (pd.DataFrame).
+            num_rows (int):
+                Number of rows to sample. If None, infers number of child rows to sample
+                from the parent row. Defaults to None.
         """
         # A child table is created based on only one foreign key.
         foreign_key = self.metadata._get_foreign_keys(parent_name, child_name)[0]
-        num_rows = self._get_num_rows_from_parent(parent_row, child_name, foreign_key)
+        if num_rows is None:
+            num_rows = self._get_num_rows_from_parent(parent_row, child_name, foreign_key)
         child_synthesizer = self._recreate_child_synthesizer(child_name, parent_name, parent_row)
 
         sampled_rows = self._sample_rows(child_synthesizer, num_rows)
@@ -135,6 +139,15 @@ class BaseHierarchicalSampler():
                         parent_name=table_name,
                         parent_row=row,
                         sampled_data=sampled_data
+                    )
+
+                if child_name not in sampled_data:  # No child rows sampled, force row creation
+                    self._add_child_rows(
+                        child_name=child_name,
+                        parent_name=table_name,
+                        parent_row=sampled_data[table_name].sample().iloc[0],
+                        sampled_data=sampled_data,
+                        num_rows=1
                     )
                 self._sample_children(table_name=child_name, sampled_data=sampled_data)
 

--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -142,10 +142,18 @@ class BaseHierarchicalSampler():
                     )
 
                 if child_name not in sampled_data:  # No child rows sampled, force row creation
+                    foreign_key = self.metadata._get_foreign_keys(table_name, child_name)[0]
+                    num_rows_key = f'__{child_name}__{foreign_key}__num_rows'
+                    if num_rows_key in sampled_data[table_name].columns:
+                        max_num_child_index = sampled_data[table_name][num_rows_key].idxmax()
+                        parent_row = sampled_data[table_name].iloc[max_num_child_index]
+                    else:
+                        parent_row = sampled_data[table_name].sample().iloc[0]
+
                     self._add_child_rows(
                         child_name=child_name,
                         parent_name=table_name,
-                        parent_row=sampled_data[table_name].sample().iloc[0],
+                        parent_row=parent_row,
                         sampled_data=sampled_data,
                         num_rows=1
                     )

--- a/tests/unit/sampling/test_hierarchical_sampler.py
+++ b/tests/unit/sampling/test_hierarchical_sampler.py
@@ -277,7 +277,8 @@ class TestBaseHierarchicalSampler():
     def test__sample_children_no_rows_sampled(self):
         """Test sampling the children of a table where no rows created and no ``num_rows`` column.
 
-        ``_sample_table`` should
+        ``_sample_table`` should select the parent row with the highest ``num_rows``
+        value and force a child to be created from that row.
         """
         # Setup
         def sample_children(table_name, sampled_data):
@@ -349,7 +350,8 @@ class TestBaseHierarchicalSampler():
     def test__sample_children_no_rows_sampled_no_num_rows(self):
         """Test sampling the children of a table where no rows created.
 
-        ``_sample_table`` should
+        ``_sample_table`` should select randomly select a parent row and force
+        a child to be created from that row.
         """
         # Setup
         def sample_children(table_name, sampled_data):

--- a/tests/unit/sampling/test_hierarchical_sampler.py
+++ b/tests/unit/sampling/test_hierarchical_sampler.py
@@ -280,6 +280,7 @@ class TestBaseHierarchicalSampler():
         instance = Mock()
         instance.metadata._get_child_map.return_value = {'users': ['sessions', 'transactions']}
         instance.metadata._get_parent_map.return_value = {'users': []}
+        instance.metadata._get_foreign_keys.return_value = ['user_id']
         instance._table_sizes = {'users': 10, 'sessions': 5, 'transactions': 3}
         instance._table_synthesizers = {'users': Mock()}
         instance._sample_children = sample_children


### PR DESCRIPTION
CU-86ayp2nrr
Resolve #1673 

Round `num_rows` instead of using `math.ceil` to allow for zero child rows to be sampled. If no child rows are sampled, tries to find the parent row with the largest expected number of children (otherwise randomly selects a parent row) and forces 1 child row to be created for it.