### PR TITLE
Make SDV compatible with SDMetrics 0.13.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'ctgan>=0.8,<0.9',
     'deepecho>=0.5,<0.6',
     'rdt>=1.9.0,<2',
-    "sdmetrics @ git+https://github.com/sdv-dev/sdmetrics.git@main",
+    'sdmetrics>=0.13.0.dev0,<0.14',
 ]
 
 pomegranate_requires = [

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'ctgan>=0.8,<0.9',
     'deepecho>=0.5,<0.6',
     'rdt>=1.9.0,<2',
-    'sdmetrics>=0.12.1,<0.13',
+    "sdmetrics @ git+https://github.com/sdv-dev/sdmetrics.git@main",
 ]
 
 pomegranate_requires = [

--- a/tests/integration/evaluation/test_multi_table.py
+++ b/tests/integration/evaluation/test_multi_table.py
@@ -48,7 +48,11 @@ def test_evaluation():
     assert score == 0.9566297110928815
 
     report = run_diagnostic(data, samples, metadata)
-    assert report._overall_score == 1
-    assert report._properties['Data Validity']._compute_average() == 1
-    assert report._properties['Data Structure']._compute_average() == 1
-    assert report._properties['Relationship Validity']._compute_average() == 1
+    assert report.get_score() == 1
+    pd.testing.assert_frame_equal(
+        report.get_properties(),
+        pd.DataFrame({
+            'Property': ['Data Validity', 'Data Structure', 'Relationship Validity'],
+            'Score': [1., 1., 1.],
+        })
+    )

--- a/tests/integration/evaluation/test_multi_table.py
+++ b/tests/integration/evaluation/test_multi_table.py
@@ -47,12 +47,8 @@ def test_evaluation():
     score = evaluate_quality(data, samples, metadata).get_score()
     assert score == 0.9566297110928815
 
-    diagnostic = run_diagnostic(data, samples, metadata).get_results()
-    assert diagnostic == {
-        'DANGER': ['More than 50% of the synthetic rows are copies of the real data'],
-        'SUCCESS': [
-            'The synthetic data covers over 90% of the numerical ranges present in the real data',
-            'The synthetic data follows over 90% of the min/max boundaries set by the real data'
-        ],
-        'WARNING': []
-    }
+    report = run_diagnostic(data, samples, metadata)
+    assert report._overall_score == 1
+    assert report._properties['Data Validity']._compute_average() == 1
+    assert report._properties['Data Structure']._compute_average() == 1
+    assert report._properties['Relationship Validity']._compute_average() == 1

--- a/tests/integration/evaluation/test_single_table.py
+++ b/tests/integration/evaluation/test_single_table.py
@@ -21,15 +21,10 @@ def test_evaluation():
     score = evaluate_quality(data, samples, metadata).get_score()
     assert score == 0.8666666666666667
 
-    diagnostic = run_diagnostic(data, samples, metadata).get_results()
-    assert diagnostic == {
-        'DANGER': ['More than 50% of the synthetic rows are copies of the real data'],
-        'SUCCESS': [
-            'The synthetic data covers over 90% of the numerical ranges present in the real data',
-            'The synthetic data follows over 90% of the min/max boundaries set by the real data'
-        ],
-        'WARNING': []
-    }
+    report = run_diagnostic(data, samples, metadata)
+    assert report._overall_score == 1
+    assert report._properties['Data Validity']._compute_average() == 1
+    assert report._properties['Data Structure']._compute_average() == 1
 
 
 def test_column_pair_plot_sample_size_parameter():

--- a/tests/integration/evaluation/test_single_table.py
+++ b/tests/integration/evaluation/test_single_table.py
@@ -22,9 +22,14 @@ def test_evaluation():
     assert score == 0.8666666666666667
 
     report = run_diagnostic(data, samples, metadata)
-    assert report._overall_score == 1
-    assert report._properties['Data Validity']._compute_average() == 1
-    assert report._properties['Data Structure']._compute_average() == 1
+    assert report.get_score() == 1
+    pd.testing.assert_frame_equal(
+        report.get_properties(),
+        pd.DataFrame({
+            'Property': ['Data Validity', 'Data Structure'],
+            'Score': [1., 1.],
+        })
+    )
 
 
 def test_column_pair_plot_sample_size_parameter():


### PR DESCRIPTION
CU-86ayrh3mn, resolve #1687

Note: the minimum version tests fail because I'm using SDMetrics' master version. It will fixed when the new SDMetrics is released, since then I can set `sdmetrics >= 0.13.0` in setup.py