### PR TITLE
Fix `BaseIndependentSampler` crashing with ID columns being new `dtype`

### DIFF
--- a/sdv/sampling/independent_sampler.py
+++ b/sdv/sampling/independent_sampler.py
@@ -102,18 +102,17 @@ class BaseIndependentSampler():
             dtypes_to_sdtype = synthesizer._data_processor._DTYPE_TO_SDTYPE
 
             for name, dtype in dtypes.items():
-
                 try:
                     table_rows[name] = table_rows[name].dropna().astype(dtype)
-
                 except ValueError as e:
                     column_metadata = metadata.columns.get(name)
                     sdtype = column_metadata.get('sdtype')
                     if sdtype not in dtypes_to_sdtype.values():
                         LOGGER.info(
-                            f"The real data in '{name}' was stored as '{dtype}' but the "
-                            'synthetic data could not be cast back to this type. If this is a '
-                            'problem, please check your input data and metadata settings.'
+                            f"The real data in '{table_name}' and column '{name}' was stored as "
+                            f"'{dtype}' but the synthetic data could not be cast back to "
+                            'this type. If this is a problem, please check your input data '
+                            'and metadata settings.'
                         )
 
                     else:

--- a/sdv/sampling/independent_sampler.py
+++ b/sdv/sampling/independent_sampler.py
@@ -95,10 +95,29 @@ class BaseIndependentSampler():
         """
         final_data = {}
         for table_name, table_rows in sampled_data.items():
+
             synthesizer = self._table_synthesizers.get(table_name)
+            metadata = synthesizer.get_metadata()
             dtypes = synthesizer._data_processor._dtypes
+            dtypes_to_sdtype = synthesizer._data_processor._DTYPE_TO_SDTYPE
+
             for name, dtype in dtypes.items():
-                table_rows[name] = table_rows[name].dropna().astype(dtype)
+
+                try:
+                    table_rows[name] = table_rows[name].dropna().astype(dtype)
+
+                except ValueError as e:
+                    column_metadata = metadata.columns.get(name)
+                    sdtype = column_metadata.get('sdtype')
+                    if sdtype not in dtypes_to_sdtype.values():
+                        LOGGER.info(
+                            f"The real data in '{name}' was stored as '{dtype}' but the "
+                            'synthetic data could not be cast back to this type. If this is a '
+                            'problem, please check your input data and metadata settings.'
+                        )
+
+                    else:
+                        raise ValueError(e)
 
             final_data[table_name] = table_rows[list(dtypes.keys())]
 

--- a/tests/unit/sampling/test_independent_sampler.py
+++ b/tests/unit/sampling/test_independent_sampler.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, call
+from unittest.mock import Mock, call, patch
 
 import numpy as np
 import pandas as pd
@@ -196,7 +196,8 @@ class TestBaseIndependentSampler():
         for result_frame, expected_frame in zip(result.values(), expected_result.values()):
             pd.testing.assert_frame_equal(result_frame, expected_frame)
 
-    def test__finalize_id_being_string(self):
+    @patch('sdv.sampling.independent_sampler.LOGGER')
+    def test__finalize_id_being_string(self, mock_logger):
         """Test that finalize function when an id column is string but dtype is int."""
         # Setup
         instance = Mock()
@@ -293,6 +294,21 @@ class TestBaseIndependentSampler():
         }
         for result_frame, expected_frame in zip(result.values(), expected_result.values()):
             pd.testing.assert_frame_equal(result_frame, expected_frame)
+
+        message_users = (
+            "The real data in 'users' and column 'user_id' was stored as "
+            "'<class 'numpy.int64'>' but the synthetic data "
+            'could not be cast back to this type. If this is a problem, please check your input '
+            'data and metadata settings.'
+        )
+
+        message_sessions = (
+            "The real data in 'sessions' and column 'user_id' was stored as "
+            "'<class 'numpy.int64'>' but the synthetic data "
+            'could not be cast back to this type. If this is a problem, please check your input '
+            'data and metadata settings.'
+        )
+        assert mock_logger.info.call_args_list == [call(message_users), call(message_sessions)]
 
     def test__sample(self):
         """Test that the ``_sample_table`` is called for root tables."""


### PR DESCRIPTION
CU-86ayvkf8c
Resolves #1712 