### PR TITLE
Fix _get_likelihoods not generating likelihood values

### DIFF
--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -318,7 +318,6 @@ class BaseMultiTableSynthesizer:
             synthesizer = self._table_synthesizers[table_name]
             self._assign_table_transformers(synthesizer, table_name, table_data)
             processed_data[table_name] = synthesizer._preprocess(table_data)
-            synthesizer._data_processor.reset_sampling()
 
         return processed_data
 

--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -318,6 +318,7 @@ class BaseMultiTableSynthesizer:
             synthesizer = self._table_synthesizers[table_name]
             self._assign_table_transformers(synthesizer, table_name, table_data)
             processed_data[table_name] = synthesizer._preprocess(table_data)
+            synthesizer._data_processor.reset_sampling()
 
         return processed_data
 

--- a/sdv/multi_table/hma.py
+++ b/sdv/multi_table/hma.py
@@ -511,6 +511,9 @@ class HMASynthesizer(BaseHierarchicalSampler, BaseMultiTableSynthesizer):
 
         data_processor = self._table_synthesizers[table_name]._data_processor
         transformed = data_processor.transform(table_rows)
+        if transformed.index.name:
+            table_rows = table_rows.set_index(transformed.index.name)
+
         table_rows = pd.concat(
             [transformed, table_rows.drop(columns=transformed.columns)],
             axis=1

--- a/sdv/multi_table/hma.py
+++ b/sdv/multi_table/hma.py
@@ -215,6 +215,23 @@ class HMASynthesizer(BaseHierarchicalSampler, BaseMultiTableSynthesizer):
 
         return columns_per_table
 
+    def preprocess(self, data):
+        """Transform the raw data to numerical space.
+
+        Args:
+            data (dict):
+                Dictionary mapping each table name to a ``pandas.DataFrame``.
+
+        Returns:
+            dict:
+                A dictionary with the preprocessed data.
+        """
+        processed_data = super().preprocess(data)
+        for _, synthesizer in self._table_synthesizers.items():
+            synthesizer.reset_sampling()
+
+        return processed_data
+
     def _get_extension(self, child_name, child_table, foreign_key, progress_bar_desc):
         """Generate the extension columns for this child table.
 

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -1181,32 +1181,29 @@ class TestHMASynthesizer:
     def test__get_likelihoods(self):
         """Test ``_get_likelihoods`` generates likelihoods for parents."""
         # Setup
-        data, metadata = download_demo('multi_table', 'fake_hotels')
+        data, metadata = download_demo('multi_table', 'got_families')
         hmasynthesizer = HMASynthesizer(metadata)
         hmasynthesizer.fit(data)
 
         sampled_data = {}
-        sampled_data['hotels'] = hmasynthesizer._sample_rows(
-            hmasynthesizer._table_synthesizers['hotels'],
-            len(data['hotels'])
+        sampled_data['characters'] = hmasynthesizer._sample_rows(
+            hmasynthesizer._table_synthesizers['characters'],
+            len(data['characters'])
         )
-        hmasynthesizer._sample_children('hotels', sampled_data)
+        hmasynthesizer._sample_children('characters', sampled_data)
 
         # Run
         likelihoods = hmasynthesizer._get_likelihoods(
-            sampled_data['guests'],
-            sampled_data['hotels'].set_index('hotel_id'),
-            'guests',
-            'hotel_id'
+            sampled_data['character_families'],
+            sampled_data['characters'].set_index('character_id'),
+            'character_families',
+            'character_id'
         )
 
         # Assert
-        not_nan_cols = ['HID_000', 'HID_001', 'HID_003', 'HID_004', 'HID_007', 'HID_009']
-        nan_cols = ['HID_002', 'HID_005', 'HID_006', 'HID_008']
-        assert set(likelihoods.columns) == {
-            'HID_000', 'HID_001', 'HID_002', 'HID_003', 'HID_004',
-            'HID_005', 'HID_006', 'HID_007', 'HID_008', 'HID_009'
-        }
-        assert len(likelihoods) == len(sampled_data['guests'])
+        not_nan_cols = [1, 3, 6]
+        nan_cols = [2, 4, 5, 7]
+        assert set(likelihoods.columns) == {1, 2, 3, 4, 5, 6, 7}
+        assert len(likelihoods) == len(sampled_data['character_families'])
         assert not any(likelihoods[not_nan_cols].isna().any())
         assert all(likelihoods[nan_cols].isna())

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -1207,6 +1207,6 @@ class TestHMASynthesizer:
             'HID_000', 'HID_001', 'HID_002', 'HID_003', 'HID_004',
             'HID_005', 'HID_006', 'HID_007', 'HID_008', 'HID_009'
         }
-        assert len(likelihoods) == 805
+        assert len(likelihoods) == len(sampled_data['guests'])
         assert not any(likelihoods[not_nan_cols].isna().any())
         assert all(likelihoods[nan_cols].isna())

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -1208,5 +1208,5 @@ class TestHMASynthesizer:
             'HID_005', 'HID_006', 'HID_007', 'HID_008', 'HID_009'
         }
         assert len(likelihoods) == 805
-        assert not any(likelihoods[not_nan_cols].isna())
+        assert not any(likelihoods[not_nan_cols].isna().any())
         assert all(likelihoods[nan_cols].isna())


### PR DESCRIPTION
Sampling after calling `reset_sampling` was different because both `fit` and `sample` have to call `transform` in `HMA`. Resetting sampling in the data processor after fitting re-aligns the randomness for sampling.