### PR TITLE
Improve quality of `sequence_index`

### DIFF
--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -4,12 +4,14 @@ import inspect
 import logging
 import uuid
 import warnings
+from datetime import datetime
 
 import numpy as np
 import pandas as pd
 import tqdm
 from deepecho import PARModel
 from deepecho.sequences import assemble_sequences
+from rdt.transformers import FloatFormatter
 
 from sdv.errors import SamplingError, SynthesizerInputError
 from sdv.metadata.single_table import SingleTableMetadata
@@ -75,6 +77,9 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
 
         for column in context_columns:
             context_columns_dict[column] = self.metadata.columns[column]
+        
+        for column, column_metadata in self._extra_context_columns.items():
+            context_columns_dict[column] = column_metadata
 
         context_metadata_dict = {'columns': context_columns_dict}
         return SingleTableMetadata.load_from_dict(context_metadata_dict)
@@ -99,6 +104,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
 
         self._sequence_index = self.metadata.sequence_index
         self.context_columns = context_columns or []
+        self._extra_context_columns = {}
+        self.extended_columns = {}
         self.segment_size = segment_size
         self._model_kwargs = {
             'epochs': epochs,
@@ -164,12 +171,30 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             pandas.DataFrame:
                 The preprocessed data.
         """
+        self._extra_context_columns = {}
         sequence_key_transformers = {sequence_key: None for sequence_key in self._sequence_key}
         if not self._data_processor._prepared_for_fitting:
             self.auto_assign_transformers(data)
 
         self.update_transformers(sequence_key_transformers)
-        return super()._preprocess(data)
+
+        preprocessed = super()._preprocess(data)
+        if self._sequence_index:
+            sequence_index = preprocessed[self._sequence_key + [self._sequence_index]]
+            sequence_index_context = sequence_index.groupby(self._sequence_key).agg('first')
+            sequence_index_context.rename(columns={self._sequence_index: f'{self._sequence_index}.context'}, inplace=True)
+            sequence_index_sequence = sequence_index.groupby(self._sequence_key).apply(
+                lambda x: x.diff().bfill()
+            ).droplevel(1).reset_index()
+
+            preprocessed[self._sequence_index] = sequence_index_sequence[self._sequence_index]
+            preprocessed = preprocessed.merge(sequence_index_context, left_on='Symbol', right_index=True)
+
+            self.extended_columns[self._sequence_index] = FloatFormatter(enforce_min_max_values=True)
+            self.extended_columns[self._sequence_index].fit(sequence_index_sequence, self._sequence_index)
+            self._extra_context_columns[f'{self._sequence_index}.context'] = {'sdtype': 'numerical'}
+        
+        return preprocessed
 
     def update_transformers(self, column_name_to_transformer):
         """Update any of the transformers assigned to each of the column names.
@@ -190,26 +215,26 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
 
     def _fit_context_model(self, transformed):
         LOGGER.debug(f'Fitting context synthesizer {self._context_synthesizer.__class__.__name__}')
-        if self.context_columns:
-            context = transformed[self._sequence_key + self.context_columns]
+        if self.context_columns or self._extra_context_columns:
+            context_cols = (
+                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
+            )
+            context = transformed[context_cols]
         else:
             context = transformed[self._sequence_key].copy()
             # Add constant column to allow modeling
             constant_column = str(uuid.uuid4())
             context[constant_column] = 0
-            self._context_synthesizer.metadata.add_column(constant_column, sdtype='numerical')
+            self._extra_context_columns[constant_column] = {'sdtype': 'numerical'}
 
+        context_metadata = self._get_context_metadata()
+        self._context_synthesizer = GaussianCopulaSynthesizer(
+            context_metadata,
+            enforce_min_max_values=self._context_synthesizer.enforce_min_max_values,
+            enforce_rounding=self._context_synthesizer.enforce_rounding
+        )
         context = context.groupby(self._sequence_key).first().reset_index()
         self._context_synthesizer.fit(context)
-
-    def _transform_sequence_index(self, sequences):
-        sequence_index_idx = self._data_columns.index(self._sequence_index)
-        for sequence in sequences:
-            data = sequence['data']
-            sequence_index = data[sequence_index_idx]
-            diffs = np.diff(sequence_index).tolist()
-            data[sequence_index_idx] = diffs[0:1] + diffs
-            data.append(sequence_index[0:1] * len(sequence_index))
 
     def _fit_sequence_columns(self, timeseries_data):
         self._model = PARModel(**self._model_kwargs)
@@ -218,13 +243,15 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         self._data_columns = [
             column
             for column in timeseries_data.columns
-            if column not in self._sequence_key + self.context_columns
+            if column not in (
+                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
+            )
         ]
 
         sequences = assemble_sequences(
             timeseries_data,
             self._sequence_key,
-            self.context_columns,
+            self.context_columns + list(self._extra_context_columns.keys()),
             self.segment_size,
             self._sequence_index,
             drop_sequence_index=False
@@ -243,12 +270,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
 
             if field in self._data_columns:
                 data_types.append(data_type)
-            elif field in self.context_columns:
+            elif field in self.context_columns or field in self._extra_context_columns.keys():
                 context_types.append(data_type)
-
-        if self._sequence_index:
-            self._transform_sequence_index(sequences)
-            data_types.append('continuous')
 
         # Validate and fit
         self._model.fit_sequences(sequences, context_types, data_types)
@@ -287,7 +310,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         if self._sequence_key:
             context = context.set_index(self._sequence_key)
             # reorder context columns
-            context = context[self.context_columns]
+            context_columns = self.context_columns + list(self._extra_context_columns.keys())
+            context = context[context_columns]
 
         should_disable = not self._model_kwargs['verbose']
         iterator = tqdm.tqdm(context.iterrows(), disable=should_disable, total=len(context))
@@ -299,7 +323,12 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             if self._sequence_index:
                 sequence_index_idx = self._data_columns.index(self._sequence_index)
                 diffs = sequence[sequence_index_idx]
-                start = sequence.pop(-1)
+                float_formatter = self.extended_columns[self._sequence_index]
+                diffs = float_formatter.reverse_transform(
+                    pd.DataFrame({self._sequence_index: diffs})
+                )[self._sequence_index].to_numpy()
+                start_index = context_columns.index(f'{self._sequence_index}.context')
+                start = context_values[start_index]
                 sequence[sequence_index_idx] = np.cumsum(diffs) - diffs[0] + start
 
             # Reformat as a DataFrame
@@ -308,7 +337,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
                 columns=self._data_columns
             )
             sequence_df[self._sequence_key] = sequence_key_values
-            for column, value in zip(self.context_columns, context_values):
+            context_columns = self.context_columns + list(self._extra_context_columns.keys())
+            for column, value in zip(context_columns, context_values):
                 sequence_df[column] = value
 
             output.append(sequence_df)

--- a/tests/integration/sequential/test_par.py
+++ b/tests/integration/sequential/test_par.py
@@ -59,9 +59,9 @@ def test_column_after_date_simple():
     # Setup
     date = datetime.datetime.strptime('2020-01-01', '%Y-%m-%d')
     data = pd.DataFrame({
-        'col': [1, 1],
-        'date': [date, date],
-        'col2': ['hello', 'world'],
+        'col': [1, 1, 1, 1],
+        'date': [date, date, date, date],
+        'col2': ['hello', 'world', 'beep', 'boop'],
     })
     metadata = SingleTableMetadata()
     metadata.detect_from_dataframe(data)

--- a/tests/integration/sequential/test_par.py
+++ b/tests/integration/sequential/test_par.py
@@ -59,9 +59,9 @@ def test_column_after_date_simple():
     # Setup
     date = datetime.datetime.strptime('2020-01-01', '%Y-%m-%d')
     data = pd.DataFrame({
-        'col': [1, 1, 1, 1],
-        'date': [date, date, date, date],
-        'col2': ['hello', 'world', 'beep', 'boop'],
+        'col': [1, 1],
+        'date': [date, date],
+        'col2': ['hello', 'world'],
     })
     metadata = SingleTableMetadata()
     metadata.detect_from_dataframe(data)

--- a/tests/integration/sequential/test_par.py
+++ b/tests/integration/sequential/test_par.py
@@ -51,7 +51,8 @@ def test_par():
     assert (sampled.notna().sum(axis=1) != 0).all()
     loss_values = model.get_loss_values()
     assert len(loss_values) == 1
-    assert list(loss_values.columns) == ['Epoch', 'Loss']
+    assert all(sampled.groupby('store_id')['date'].is_monotonic_increasing)
+    assert all(sampled.groupby('store_id')['date'].agg(lambda x: x.is_unique))
 
 
 def test_column_after_date_simple():

--- a/tests/unit/sequential/test_par.py
+++ b/tests/unit/sequential/test_par.py
@@ -9,10 +9,10 @@ from rdt.transformers import FloatFormatter, UnixTimestampEncoder
 from sdv.data_processing.data_processor import DataProcessor
 from sdv.errors import InvalidDataError, NotFittedError, SamplingError, SynthesizerInputError
 from sdv.metadata.single_table import SingleTableMetadata
+from sdv.sampling import Condition
 from sdv.sequential.par import PARSynthesizer
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
 from tests.utils import DataFrameMatcher
-from sdv.sampling import Condition
 
 
 class TestPARSynthesizer:
@@ -313,12 +313,12 @@ class TestPARSynthesizer:
         par = PARSynthesizer(metadata, context_columns=['gender'])
         initial_synthesizer = Mock()
         context_metadata = SingleTableMetadata.load_from_dict({
-            "columns": {
-                "gender": {
-                    "sdtype": "categorical"
+            'columns': {
+                'gender': {
+                    'sdtype': 'categorical'
                 },
-                "name": {
-                    "sdtype": "id"
+                'name': {
+                    'sdtype': 'id'
                 }
             }
         })
@@ -434,7 +434,10 @@ class TestPARSynthesizer:
         )
         sequences = [
             {'context': np.array(['F'], dtype=object), 'data': [[1, 1], [55, 60], [1, 1]]},
-            {'context': np.array(['M'], dtype=object), 'data': [[2, 2, 3], [65, 65, 70], [3, 3, 3]]},
+            {
+                'context': np.array(['M'], dtype=object),
+                'data': [[2, 2, 3], [65, 65, 70], [3, 3, 3]]
+            },
         ]
         assemble_sequences_mock.return_value = sequences
 
@@ -664,7 +667,8 @@ class TestPARSynthesizer:
         model_mock = Mock()
         par._model = model_mock
         mock_transformer = Mock()
-        mock_transformer.reverse_transform.return_value = pd.DataFrame({'time': [1000, 2000, 2000]})
+        mock_transformer.reverse_transform.return_value = pd.DataFrame(
+            {'time': [1000, 2000, 2000]})
         par.extended_columns = {'time': mock_transformer}
         par._data_columns = ['time', 'measurement']
         par._output_columns = ['time', 'gender', 'name', 'measurement']
@@ -673,7 +677,8 @@ class TestPARSynthesizer:
             [1000, 2000, 2000],
             [55, 60, 65]
         ]
-        context_columns = pd.DataFrame({'name': ['John'], 'gender': ['M'], 'time.context': [18000]})
+        context_columns = pd.DataFrame(
+            {'name': ['John'], 'gender': ['M'], 'time.context': [18000]})
         tqdm_mock.tqdm.return_value = context_columns.set_index('name').iterrows()
 
         # Run


### PR DESCRIPTION
CU-86az5xcqz
Resolve #1760

The sequence index is now split into a diff column which goes through the sequential model and a context column which is added to the context model. Additionally, `FloatFormatter` is used on the diff column to force sampled columns to be within the given min/max range.

Also, `sample_sequential_columns` had to be adjusted to use conditional sampling to get missing extra context columns before getting sequential samples.