### PR TITLE
Add verbosity to `drop_unknown_references`

### DIFF
--- a/sdv/utils/poc.py
+++ b/sdv/utils/poc.py
@@ -1,10 +1,14 @@
 """Utility functions."""
+import sys
+
+import pandas as pd
+
 from sdv._utils import (
     _get_relationship_for_child, _get_rows_to_drop, _validate_foreign_keys_not_null)
 from sdv.errors import InvalidDataError, SynthesizerInputError
 
 
-def drop_unknown_references(metadata, data, drop_missing_values=True):
+def drop_unknown_references(metadata, data, drop_missing_values=True, verbose=True):
     """Drop rows with unknown foreign keys.
 
     Args:
@@ -17,16 +21,24 @@ def drop_unknown_references(metadata, data, drop_missing_values=True):
             Boolean describing whether or not to also drop foreign keys with missing values
             If True, drop rows with missing values in the foreign keys.
             Defaults to True.
+        verbose (bool):
+            If True, print information about the rows that are dropped.
+            Defaults to True.
 
     Returns:
         dict:
             Dictionary with the dataframes ensuring referential integrity.
     """
+    success_message = 'Success! All foreign keys have referential integrity.'
     metadata.validate()
     try:
         metadata.validate_data(data)
         if drop_missing_values:
             _validate_foreign_keys_not_null(metadata, data)
+
+        if verbose:
+            message = [success_message, 'No rows were dropped.']
+            sys.stdout.write('\n'.join(message))
 
         return data
     except (InvalidDataError, SynthesizerInputError):
@@ -46,5 +58,19 @@ def drop_unknown_references(metadata, data, drop_missing_values=True):
                     f"All references in table '{table}' are unknown and must be dropped."
                     'Try providing different data for this table.'
                 ])
+
+        if verbose:
+            table_names = sorted(metadata.tables)
+            summary_table = pd.DataFrame({
+                'Table Name': table_names,
+                '# Rows (Original)': [len(data[table]) for table in table_names],
+                '# Invalid Rows': [
+                    len(data[table]) - len(result[table]) for table in table_names
+                ],
+                '# Rows (New)': [len(result[table]) for table in table_names]
+            })
+            message = [success_message, 'Summary of the number of rows dropped:']
+            message.append(summary_table.to_string(index=False))
+            sys.stdout.write('\n'.join(message))
 
         return result

--- a/tests/unit/utils/test_poc.py
+++ b/tests/unit/utils/test_poc.py
@@ -66,14 +66,16 @@ def test_drop_unknown_references(mock_get_rows_to_drop, mock_stdout_write):
     result = drop_unknown_references(metadata, data)
 
     # Assert
-    mock_stdout_write.assert_called_once_with(
-        'Success! All foreign keys have referential integrity.\n'
-        'Summary of the number of rows dropped:\n'
-        'Table Name  # Rows (Original)  # Invalid Rows  # Rows (New)\n'
-        '     child                  5               1             4\n'
-        'grandchild                  5               3             2\n'
-        '    parent                  5               0             5'
+    expected_pattern = re.compile(
+        r'Success! All foreign keys have referential integrity\.\s*'
+        r'Summary of the number of rows dropped:\s*'
+        r'Table Name\s*#\s*Rows \(Original\)\s*#\s*Invalid Rows\s*#\s*Rows \(New\)\s*'
+        r'child\s*5\s*1\s*4\s*'
+        r'grandchild\s*5\s*3\s*2\s*'
+        r'parent\s*5\s*0\s*5'
     )
+    output = mock_stdout_write.call_args[0][0]
+    assert expected_pattern.match(output)
     metadata.validate.assert_called_once()
     metadata.validate_data.assert_called_once_with(data)
     mock_get_rows_to_drop.assert_called_once()


### PR DESCRIPTION
CU-86aznj0ht
Resolve #1845

@npatki I slightly changed the message printed compared to the issue let me know if it works:

- Data with referential integrity:
<img width="440" alt="Screenshot 2024-03-18 at 14 43 30" src="https://github.com/sdv-dev/SDV/assets/116157184/19221042-a062-4ca1-a710-da9ec300c976">

- Data without referential integrity:
<img width="462" alt="Screenshot 2024-03-18 at 14 44 03" src="https://github.com/sdv-dev/SDV/assets/116157184/f8b64b12-e9c5-48ca-b7c8-ed9ace6fcb89">
