### PR TITLE
Show warning when loading a synthesizer on a previously-saved SDV version

### DIFF
--- a/sdv/_utils.py
+++ b/sdv/_utils.py
@@ -316,32 +316,31 @@ def check_sdv_versions_and_warn(synthesizer):
     public_missmatch = current_public_version != synthesizer._fitted_sdv_version
     enterprise_missmatch = current_enterprise_version != synthesizer._fitted_sdv_enterprise_version
     if synthesizer._fitted and (public_missmatch or enterprise_missmatch):
+        static_message = (
+            'The latest bug fixes and features may not be available for this synthesizer. '
+            'To see these enhancements, create and train a new synthesizer on this version.'
+        )
         if public_missmatch and enterprise_missmatch:
             message = (
                 'You are currently on SDV version '
                 f'{current_public_version} and SDV Enterprise version '
                 f'{current_enterprise_version} but this synthesizer was created on '
                 f'SDV version {synthesizer._fitted_sdv_version} and SDV Enterprise version '
-                f'{synthesizer._fitted_sdv_enterprise_version}. The latest bug fixes and features '
-                'may not be available for this synthesizer. To see these enhancements, '
-                'create and train a new synthesizer on this version.'
+                f'{synthesizer._fitted_sdv_enterprise_version}.'
             )
 
         elif public_missmatch:
             message = (
                 'You are currently on SDV version '
                 f'{current_public_version} but this synthesizer was created on '
-                f'version {synthesizer._fitted_sdv_version}. The latest bug fixes and features '
-                'may not be available for this synthesizer. To see these enhancements, '
-                'create and train a new synthesizer on this version.'
+                f'version {synthesizer._fitted_sdv_version}.'
             )
         elif enterprise_missmatch:
             message = (
                 'You are currently on SDV Enterprise version '
                 f'{current_enterprise_version} but this synthesizer was created on '
-                f'version {synthesizer._fitted_sdv_enterprise_version}. The latest bug fixes and '
-                'features may not be available for this synthesizer. To see these '
-                'enhancements, create and train a new synthesizer on this version.'
+                f'version {synthesizer._fitted_sdv_enterprise_version}.'
             )
 
+        message = f'{message} {static_message}'
         warnings.warn(message, SDVVersionWarning)

--- a/sdv/_utils.py
+++ b/sdv/_utils.py
@@ -313,34 +313,38 @@ def check_sdv_versions_and_warn(synthesizer):
     """
     current_public_version = getattr(version, 'public', None)
     current_enterprise_version = getattr(version, 'enterprise', None)
-    public_missmatch = current_public_version != synthesizer._fitted_sdv_version
-    enterprise_missmatch = current_enterprise_version != synthesizer._fitted_sdv_enterprise_version
-    if synthesizer._fitted and (public_missmatch or enterprise_missmatch):
-        static_message = (
-            'The latest bug fixes and features may not be available for this synthesizer. '
-            'To see these enhancements, create and train a new synthesizer on this version.'
-        )
-        if public_missmatch and enterprise_missmatch:
-            message = (
-                'You are currently on SDV version '
-                f'{current_public_version} and SDV Enterprise version '
-                f'{current_enterprise_version} but this synthesizer was created on '
-                f'SDV version {synthesizer._fitted_sdv_version} and SDV Enterprise version '
-                f'{synthesizer._fitted_sdv_enterprise_version}.'
-            )
+    if synthesizer._fitted:
+        fitted_public_version = getattr(synthesizer, '_fitted_sdv_version', None)
+        fitted_enterprise_version = getattr(synthesizer, '_fitted_sdv_enterprise_version', None)
+        public_missmatch = current_public_version != fitted_public_version
+        enterprise_missmatch = current_enterprise_version != fitted_enterprise_version
 
-        elif public_missmatch:
-            message = (
-                'You are currently on SDV version '
-                f'{current_public_version} but this synthesizer was created on '
-                f'version {synthesizer._fitted_sdv_version}.'
+        if (public_missmatch or enterprise_missmatch):
+            static_message = (
+                'The latest bug fixes and features may not be available for this synthesizer. '
+                'To see these enhancements, create and train a new synthesizer on this version.'
             )
-        elif enterprise_missmatch:
-            message = (
-                'You are currently on SDV Enterprise version '
-                f'{current_enterprise_version} but this synthesizer was created on '
-                f'version {synthesizer._fitted_sdv_enterprise_version}.'
-            )
+            if public_missmatch and enterprise_missmatch:
+                message = (
+                    'You are currently on SDV version '
+                    f'{current_public_version} and SDV Enterprise version '
+                    f'{current_enterprise_version} but this synthesizer was created on '
+                    f'SDV version {synthesizer._fitted_sdv_version} and SDV Enterprise version '
+                    f'{synthesizer._fitted_sdv_enterprise_version}.'
+                )
 
-        message = f'{message} {static_message}'
-        warnings.warn(message, SDVVersionWarning)
+            elif public_missmatch:
+                message = (
+                    'You are currently on SDV version '
+                    f'{current_public_version} but this synthesizer was created on '
+                    f'version {synthesizer._fitted_sdv_version}.'
+                )
+            elif enterprise_missmatch:
+                message = (
+                    'You are currently on SDV Enterprise version '
+                    f'{current_enterprise_version} but this synthesizer was created on '
+                    f'version {synthesizer._fitted_sdv_enterprise_version}.'
+                )
+
+            message = f'{message} {static_message}'
+            warnings.warn(message, SDVVersionWarning)

--- a/sdv/_utils.py
+++ b/sdv/_utils.py
@@ -1,4 +1,5 @@
 """Miscellaneous utility functions."""
+import warnings
 from collections import defaultdict
 from collections.abc import Iterable
 from copy import deepcopy
@@ -8,7 +9,8 @@ from pathlib import Path
 import pandas as pd
 from pandas.core.tools.datetimes import _guess_datetime_format_for_array
 
-from sdv.errors import SynthesizerInputError
+from sdv import version
+from sdv.errors import SDVVersionWarning, SynthesizerInputError
 
 
 def _cast_to_iterable(value):
@@ -295,3 +297,51 @@ def _validate_foreign_keys_not_null(metadata, data):
             err_msg += f"Table '{table_name}', column(s) {invalid_columns}\n"
 
         raise SynthesizerInputError(err_msg)
+
+
+def check_sdv_versions_and_warn(synthesizer):
+    """Check if the current SDV and SDV Enterprise versions mismatch.
+
+    Args:
+        synthesizer (BaseSingleTableSynthesizer or BaseMultiTableSynthesizer):
+            An SDV model instance to check versions against.
+
+    Raises:
+        SDVVersionWarning:
+            If the current SDV or SDV Enterprise version does not match the version used to fit
+            the synthesizer.
+    """
+    current_public_version = getattr(version, 'public', None)
+    current_enterprise_version = getattr(version, 'enterprise', None)
+    public_missmatch = current_public_version != synthesizer._fitted_sdv_version
+    enterprise_missmatch = current_enterprise_version != synthesizer._fitted_sdv_enterprise_version
+    if public_missmatch or enterprise_missmatch:
+        if public_missmatch and enterprise_missmatch:
+            message = (
+                'You are currently on SDV version '
+                f'{current_public_version} and SDV Enterprise version '
+                f'{current_enterprise_version} but this synthesizer was created on '
+                f'SDV version {synthesizer._fitted_sdv_version} and SDV Enterprise version '
+                f'{synthesizer._fitted_sdv_enterprise_version}. The latest bug fixes and features '
+                'may not be available for this synthesizer. To see these enhancements, '
+                'create and train a new synthesizer on this version.'
+            )
+
+        elif public_missmatch:
+            message = (
+                'You are currently on SDV version '
+                f'{current_public_version} but this synthesizer was created on '
+                f'version {synthesizer._fitted_sdv_version}. The latest bug fixes and features '
+                'may not be available for this synthesizer. To see these enhancements, '
+                'create and train a new synthesizer on this version.'
+            )
+        elif enterprise_missmatch:
+            message = (
+                'You are currently on SDV Enterprise version '
+                f'{current_enterprise_version} but this synthesizer was created on '
+                f'version {synthesizer._fitted_sdv_enterprise_version}. The latest bug fixes and '
+                'features may not be available for this synthesizer. To see these '
+                'enhancements, create and train a new synthesizer on this version.'
+            )
+
+        warnings.warn(message, SDVVersionWarning)

--- a/sdv/_utils.py
+++ b/sdv/_utils.py
@@ -315,7 +315,7 @@ def check_sdv_versions_and_warn(synthesizer):
     current_enterprise_version = getattr(version, 'enterprise', None)
     public_missmatch = current_public_version != synthesizer._fitted_sdv_version
     enterprise_missmatch = current_enterprise_version != synthesizer._fitted_sdv_enterprise_version
-    if public_missmatch or enterprise_missmatch:
+    if synthesizer._fitted and (public_missmatch or enterprise_missmatch):
         if public_missmatch and enterprise_missmatch:
             message = (
                 'You are currently on SDV version '

--- a/sdv/errors.py
+++ b/sdv/errors.py
@@ -62,3 +62,14 @@ class InvalidDataTypeError(Exception):
 
 class VisualizationUnavailableError(Exception):
     """Exception to indicate that a visualization is unavailable."""
+
+
+class SDVVersionWarning(UserWarning):
+    """Warning to be raised if there is a version mismatch.
+
+    Warning to be raised  if there is a version mismatch between the loaded
+    synthesizer and the current version of the SDV software.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.__class__.__name__ = 'SDV Version Warning'

--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -11,7 +11,7 @@ import numpy as np
 import pkg_resources
 from tqdm import tqdm
 
-from sdv._utils import _validate_foreign_keys_not_null
+from sdv._utils import _validate_foreign_keys_not_null, check_sdv_versions_and_warn
 from sdv.errors import InvalidDataError, SynthesizerInputError
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
 
@@ -576,12 +576,18 @@ class BaseMultiTableSynthesizer:
 
     @classmethod
     def load(cls, filepath):
-        """Load the multi-table synthesizer from a given path.
+        """Load a multi-table synthesizer from a given path.
 
         Args:
             filepath (str):
-                Path from which to load the instance.
+                A string describing the filepath of your saved synthesizer.
+
+        Returns:
+            MultiTableSynthesizer:
+                The loaded synthesizer.
         """
         with open(filepath, 'rb') as f:
             synthesizer = cloudpickle.load(f)
-            return synthesizer
+
+        check_sdv_versions_and_warn(synthesizer)
+        return synthesizer

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -1244,9 +1244,10 @@ class TestBaseMultiTableSynthesizer:
         # Assert
         cloudpickle_mock.dump.assert_called_once_with(synthesizer, ANY)
 
+    @patch('sdv.multi_table.base.check_sdv_versions_and_warn')
     @patch('sdv.multi_table.base.cloudpickle')
     @patch('builtins.open', new_callable=mock_open)
-    def test_load(self, mock_file, cloudpickle_mock):
+    def test_load(self, mock_file, cloudpickle_mock, mock_check_sdv_versions_and_warn):
         """Test that the ``load`` method loads a stored synthesizer."""
         # Setup
         synthesizer_mock = Mock()
@@ -1257,5 +1258,6 @@ class TestBaseMultiTableSynthesizer:
 
         # Assert
         mock_file.assert_called_once_with('synth.pkl', 'rb')
+        mock_check_sdv_versions_and_warn.assert_called_once_with(loaded_instance)
         cloudpickle_mock.load.assert_called_once_with(mock_file.return_value)
         assert loaded_instance == synthesizer_mock

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -1176,30 +1176,23 @@ class TestBaseMultiTableSynthesizer:
             'custom'
         )
 
-    def _pkg_mock(self, lib):
-        if lib == 'sdv':
-            class Distribution:
-                version = '1.0.0'
-
-            return Distribution
-
-    @patch('pkg_resources.get_distribution')
-    def test_get_info(self, pkg_mock):
+    @patch('sdv.multi_table.base.version')
+    def test_get_info(self, mock_version):
         """Test the correct dictionary is returned.
 
         Check the return dictionary is valid both before and after fitting the synthesizer.
 
         Mocks:
-            * Mock ``pkg_resources`` so we don't have to rewrite this test for every new release.
             * Unfortunately, ``datetime`` can't be mocked directly. This link explains how to
             do it: https://docs.python.org/3/library/unittest.mock-examples.html#partial-mocking
         """
         # Setup
         data = {'tab': pd.DataFrame({'col': [1, 2, 3]})}
-        pkg_mock.side_effect = self._pkg_mock
         metadata = MultiTableMetadata()
         metadata.add_table('tab')
         metadata.add_column('tab', 'col', sdtype='numerical')
+        mock_version.public = '1.0.0'
+        mock_version.enterprise = None
 
         with patch('sdv.multi_table.base.datetime.datetime') as mock_date:
             mock_date.today.return_value = datetime(2023, 1, 23)
@@ -1229,6 +1222,55 @@ class TestBaseMultiTableSynthesizer:
                 'is_fit': True,
                 'last_fit_date': '2023-01-23',
                 'fitted_sdv_version': '1.0.0'
+            }
+
+    @patch('sdv.multi_table.base.version')
+    def test_get_info_with_enterprise(self, mock_version):
+        """Test the correct dictionary is returned.
+
+        Check the return dictionary is valid both before and after fitting the synthesizer.
+
+        Mocks:
+            * Unfortunately, ``datetime`` can't be mocked directly. This link explains how to
+            do it: https://docs.python.org/3/library/unittest.mock-examples.html#partial-mocking
+        """
+        # Setup
+        data = {'tab': pd.DataFrame({'col': [1, 2, 3]})}
+        metadata = MultiTableMetadata()
+        metadata.add_table('tab')
+        metadata.add_column('tab', 'col', sdtype='numerical')
+        mock_version.public = '1.0.0'
+        mock_version.enterprise = '1.1.0'
+
+        with patch('sdv.multi_table.base.datetime.datetime') as mock_date:
+            mock_date.today.return_value = datetime(2023, 1, 23)
+            mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
+            synthesizer = HMASynthesizer(metadata)
+
+            # Run
+            info = synthesizer.get_info()
+
+            # Assert
+            assert info == {
+                'class_name': 'HMASynthesizer',
+                'creation_date': '2023-01-23',
+                'is_fit': False,
+                'last_fit_date': None,
+                'fitted_sdv_version': None
+            }
+
+            # Run
+            synthesizer.fit(data)
+            info = synthesizer.get_info()
+
+            # Assert
+            assert info == {
+                'class_name': 'HMASynthesizer',
+                'creation_date': '2023-01-23',
+                'is_fit': True,
+                'last_fit_date': '2023-01-23',
+                'fitted_sdv_version': '1.0.0',
+                'fitted_sdv_enterprise_version': '1.1.0'
             }
 
     @patch('sdv.multi_table.base.cloudpickle')

--- a/tests/unit/test__utils.py
+++ b/tests/unit/test__utils.py
@@ -477,30 +477,26 @@ def test_check_sdv_versions_and_warn_no_missmatch(mock_warnings):
     mock_warnings.warn.assert_not_called()
 
 
-@patch('sdv._utils.warnings')
-def test_check_sdv_versions_and_warn_public_missmatch(mock_warnings):
+def test_check_sdv_versions_and_warn_public_missmatch():
     """Test that warnings is raised when public version is missmatched."""
     # Setup
     synthesizer = Mock()
     synthesizer._fitted_sdv_version = '1.0.0'
     synthesizer._fitted_sdv_enterprise_version = version.enterprise
 
-    # Run
-    check_sdv_versions_and_warn(synthesizer)
-
-    # Assert
+    # Run and Assert
     message = (
         f'You are currently on SDV version {version.public} but this synthesizer was created on '
         'version 1.0.0. The latest bug fixes and features may not be available for this '
         'synthesizer. To see these enhancements, create and train a new synthesizer on this '
         'version.'
     )
-    mock_warnings.warn.assert_called_once_with(message, SDVVersionWarning)
+    with pytest.warns(SDVVersionWarning, match=message):
+        check_sdv_versions_and_warn(synthesizer)
 
 
 @patch('sdv._utils.version')
-@patch('sdv._utils.warnings')
-def test_check_sdv_versions_and_warn_enterprise_missmatch(mock_warnings, mock_version):
+def test_check_sdv_versions_and_warn_enterprise_missmatch(mock_version):
     """Test that warnings is raised when enterprise version is missmatched."""
     # Setup
     synthesizer = Mock()
@@ -510,22 +506,19 @@ def test_check_sdv_versions_and_warn_enterprise_missmatch(mock_warnings, mock_ve
     mock_version.enterprise = '1.3.0'
     mock_version.public = version.public
 
-    # Run
-    check_sdv_versions_and_warn(synthesizer)
-
-    # Assert
+    # Run and Assert
     message = (
         'You are currently on SDV Enterprise version 1.3.0 but this synthesizer was created on '
         'version 1.2.0. The latest bug fixes and features may not be available for this '
         'synthesizer. To see these enhancements, create and train a new synthesizer on this '
         'version.'
     )
-    mock_warnings.warn.assert_called_once_with(message, SDVVersionWarning)
+    with pytest.warns(SDVVersionWarning, match=message):
+        check_sdv_versions_and_warn(synthesizer)
 
 
 @patch('sdv._utils.version')
-@patch('sdv._utils.warnings')
-def test_check_sdv_versions_and_warn_public_and_enterprise_missmatch(mock_warnings, mock_version):
+def test_check_sdv_versions_and_warn_public_and_enterprise_missmatch(mock_version):
     """Test that warnings is raised when both public and enterprise version missmatch."""
     # Setup
     synthesizer = Mock()
@@ -535,14 +528,12 @@ def test_check_sdv_versions_and_warn_public_and_enterprise_missmatch(mock_warnin
     mock_version.public = '1.3.0'
     mock_version.enterprise = '1.3.3'
 
-    # Run
-    check_sdv_versions_and_warn(synthesizer)
-
-    # Assert
+    # Run and Assert
     message = (
         'You are currently on SDV version 1.3.0 and SDV Enterprise version 1.3.3 but this '
         'synthesizer was created on SDV version 1.0.0 and SDV Enterprise version 1.2.0. '
         'The latest bug fixes and features may not be available for this synthesizer. '
         'To see these enhancements, create and train a new synthesizer on this version.'
     )
-    mock_warnings.warn.assert_called_once_with(message, SDVVersionWarning)
+    with pytest.warns(SDVVersionWarning, match=message):
+        check_sdv_versions_and_warn(synthesizer)


### PR DESCRIPTION
Resolves #1836 
CU-86azkp7mu

Added a new attribute to the `synthesizers`  called `_fitted_sdv_enterprise_version` which will only be added to `get_info` if it is not `None`.