### PR TITLE
Create chart for generator-discriminator loss

### DIFF
--- a/sdv/single_table/ctgan.py
+++ b/sdv/single_table/ctgan.py
@@ -1,8 +1,8 @@
 """Wrapper around CTGAN model."""
 import numpy as np
 import pandas as pd
-from ctgan import CTGAN, TVAE
 import plotly.express as px
+from ctgan import CTGAN, TVAE
 from sdmetrics import visualization
 
 from sdv.errors import InvalidDataTypeError, NotFittedError
@@ -78,12 +78,11 @@ class LossValuesMixin:
                 'Generator Loss': visualization.PlotConfig.DATACEBO_BLUE,
                 'Discriminator Loss': visualization.PlotConfig.DATACEBO_GREEN
             },
-
         )
         fig.update_layout(
             template='plotly_white',
             legend_title_text='',
-            legend_orientation="v",
+            legend_orientation='v',
             plot_bgcolor=visualization.PlotConfig.BACKGROUND_COLOR,
             font={'size': visualization.PlotConfig.FONT_SIZE}
         )

--- a/sdv/single_table/ctgan.py
+++ b/sdv/single_table/ctgan.py
@@ -54,6 +54,10 @@ class LossValuesMixin:
     def get_loss_values_plot(self, title='CTGAN loss function'):
         """Create a loss values plot from the model.
 
+        Args:
+            title (pd.DataFrame):
+                Title string for the graph created.
+
         Raises:
             - ``NotFittedError`` if synthesizer has not been fitted.
 

--- a/sdv/single_table/ctgan.py
+++ b/sdv/single_table/ctgan.py
@@ -75,7 +75,7 @@ class LossValuesMixin:
             loss_df, x='Epoch',
             y=['Generator Loss', 'Discriminator Loss'],
             color_discrete_map={
-                'Generator Loss': visualization.PlotConfig.DATACEBO_DARK,
+                'Generator Loss': visualization.PlotConfig.DATACEBO_BLUE,
                 'Discriminator Loss': visualization.PlotConfig.DATACEBO_GREEN
             },
 


### PR DESCRIPTION
resolves #1828 

Creates API to generate generator-discriminator loss chart for CTGAN

Example below with epochs = 200
<img width="1499" alt="Screenshot 2024-03-25 at 11 59 33 AM" src="https://github.com/sdv-dev/SDV/assets/10409759/c808d71f-d95b-4d19-a9e1-25d2c32cec8c">

