### PR TITLE
Raise a `VersionError` when re-fitting a synthesizer that was created on a previous SDV version

### DIFF
--- a/sdv/_utils.py
+++ b/sdv/_utils.py
@@ -299,8 +299,12 @@ def _compare_versions(current_version, synthesizer_version, compare_operator=ope
 
     Returns:
         bool:
-            True if the synthesizer version is greater than the current version, False otherwise.
+            Depending on the ``operator`` function it will return ``True`` or ``False`` if
+            ``current_version`` is bigger or lower than ``synthesizer_version``.
     """
+    if None in (current_version, synthesizer_version):
+        return False
+
     current_version = current_version.split('.')
     synthesizer_version = synthesizer_version.split('.')
     for current_v, synth_v in zip(current_version, synthesizer_version):
@@ -346,21 +350,17 @@ def check_synthesizer_version(synthesizer, is_fit_method=False, compare_operator
     fit_public_version = getattr(synthesizer, '_fitted_sdv_version', None)
     fit_enterprise_version = getattr(synthesizer, '_fitted_sdv_enterprise_version', None)
 
-    is_public_lower = False
-    if None not in (current_public_version, fit_public_version):
-        is_public_lower = _compare_versions(
-            current_public_version,
-            fit_public_version,
-            compare_operator
-        )
+    is_public_lower = _compare_versions(
+        current_public_version,
+        fit_public_version,
+        compare_operator
+    )
 
-    is_enterprise_lower = False
-    if None not in (current_enterprise_version, fit_enterprise_version):
-        is_enterprise_lower = _compare_versions(
-            current_enterprise_version,
-            fit_enterprise_version,
-            compare_operator
-        )
+    is_enterprise_lower = _compare_versions(
+        current_enterprise_version,
+        fit_enterprise_version,
+        compare_operator
+    )
 
     if is_public_lower and is_enterprise_lower:
         raise VersionError(

--- a/sdv/_utils.py
+++ b/sdv/_utils.py
@@ -346,6 +346,7 @@ def check_synthesizer_version(synthesizer, is_fit_method=False,
             fit_public_version,
             check_synthesizer_is_greater
         )
+
     is_enterprise_lower = False
     if None not in (current_enterprise_version, fit_enterprise_version):
         is_enterprise_lower = _check_is_lower_version(

--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -2,6 +2,7 @@
 import contextlib
 import datetime
 import inspect
+import operator
 import warnings
 from collections import defaultdict
 from copy import deepcopy
@@ -368,7 +369,7 @@ class BaseMultiTableSynthesizer:
             processed_data (dict):
                 Dictionary mapping each table name to a preprocessed ``pandas.DataFrame``.
         """
-        check_synthesizer_version(self, is_fit_method=True, check_synthesizer_is_greater=True)
+        check_synthesizer_version(self, is_fit_method=True, compare_operator=operator.lt)
         augmented_data = self._augment_tables(processed_data)
         self._model_tables(augmented_data)
         self._fitted = True
@@ -384,7 +385,7 @@ class BaseMultiTableSynthesizer:
                 Dictionary mapping each table name to a ``pandas.DataFrame`` in the raw format
                 (before any transformations).
         """
-        check_synthesizer_version(self, is_fit_method=True, check_synthesizer_is_greater=True)
+        check_synthesizer_version(self, is_fit_method=True, compare_operator=operator.lt)
         _validate_foreign_keys_not_null(self.metadata, data)
         self._check_metadata_updated()
         self._fitted = False

--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -368,6 +368,7 @@ class BaseMultiTableSynthesizer:
             processed_data (dict):
                 Dictionary mapping each table name to a preprocessed ``pandas.DataFrame``.
         """
+        check_synthesizer_version(self, is_fit_method=True, check_synthesizer_is_greater=True)
         augmented_data = self._augment_tables(processed_data)
         self._model_tables(augmented_data)
         self._fitted = True
@@ -383,6 +384,7 @@ class BaseMultiTableSynthesizer:
                 Dictionary mapping each table name to a ``pandas.DataFrame`` in the raw format
                 (before any transformations).
         """
+        check_synthesizer_version(self, is_fit_method=True, check_synthesizer_is_greater=True)
         _validate_foreign_keys_not_null(self.metadata, data)
         self._check_metadata_updated()
         self._fitted = False

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -5,6 +5,7 @@ import functools
 import inspect
 import logging
 import math
+import operator
 import os
 import uuid
 import warnings
@@ -386,7 +387,7 @@ class BaseSynthesizer:
             processed_data (pandas.DataFrame):
                 The transformed data used to fit the model to.
         """
-        check_synthesizer_version(self, is_fit_method=True, check_synthesizer_is_greater=True)
+        check_synthesizer_version(self, is_fit_method=True, compare_operator=operator.lt)
         if not processed_data.empty:
             self._fit(processed_data)
 
@@ -402,7 +403,7 @@ class BaseSynthesizer:
             data (pandas.DataFrame):
                 The raw data (before any transformations) to fit the model to.
         """
-        check_synthesizer_version(self, is_fit_method=True, check_synthesizer_is_greater=True)
+        check_synthesizer_version(self, is_fit_method=True, compare_operator=operator.lt)
         self._check_metadata_updated()
         self._fitted = False
         self._data_processor.reset_sampling()

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -386,6 +386,7 @@ class BaseSynthesizer:
             processed_data (pandas.DataFrame):
                 The transformed data used to fit the model to.
         """
+        check_synthesizer_version(self, is_fit_method=True, check_synthesizer_is_greater=True)
         if not processed_data.empty:
             self._fit(processed_data)
 
@@ -401,6 +402,7 @@ class BaseSynthesizer:
             data (pandas.DataFrame):
                 The raw data (before any transformations) to fit the model to.
         """
+        check_synthesizer_version(self, is_fit_method=True, check_synthesizer_is_greater=True)
         self._check_metadata_updated()
         self._fitted = False
         self._data_processor.reset_sampling()

--- a/tests/integration/single_table/test_base.py
+++ b/tests/integration/single_table/test_base.py
@@ -675,6 +675,7 @@ def test_metadata_updated_warning(method, kwargs):
 
     The warning should be raised during synthesizer initialization.
     """
+    # Setup
     metadata = SingleTableMetadata().load_from_dict({
         'columns': {
             'col 1': {'sdtype': 'id'},
@@ -696,3 +697,26 @@ def test_metadata_updated_warning(method, kwargs):
 
     # Assert
     assert metadata._updated is False
+
+
+def test_fit_raises_version_error():
+    """Test that a ``VersionError`` is being raised if the current version is newer."""
+    # Setup
+    data = pd.DataFrame({
+        'col 1': [1, 2, 3],
+        'col 2': [4, 5, 6],
+        'col 3': ['a', 'b', 'c'],
+    })
+    metadata = SingleTableMetadata()
+    metadata.detect_from_dataframe(data)
+    instance = BaseSingleTableSynthesizer(metadata)
+    instance._fitted_sdv_version = '1.0.0'
+
+    # Run and Assert
+    expected_message = (
+        f'You are currently on SDV version {version.public} but this synthesizer was created on '
+        'version 1.0.0. Fitting this synthesizer again is not supported. Please create a new '
+        'synthesizer.'
+    )
+    with pytest.raises(VersionError, match=expected_message):
+        instance.fit(data)

--- a/tests/unit/sequential/test_par.py
+++ b/tests/unit/sequential/test_par.py
@@ -942,7 +942,10 @@ class TestPARSynthesizer:
     def test_load(self, mock_file, cloudpickle_mock):
         """Test that the ``load`` method loads a stored synthesizer."""
         # Setup
-        synthesizer_mock = Mock(_fitted=False)
+        synthesizer_mock = Mock(
+            _fitted_sdv_version=None,
+            _fitted_sdv_enterprise_version=None,
+        )
         cloudpickle_mock.load.return_value = synthesizer_mock
 
         # Run

--- a/tests/unit/test__utils.py
+++ b/tests/unit/test__utils.py
@@ -1,3 +1,4 @@
+import operator
 import re
 from datetime import datetime
 from unittest.mock import Mock, patch
@@ -8,7 +9,7 @@ import pytest
 
 from sdv import version
 from sdv._utils import (
-    _check_is_lower_version, _convert_to_timedelta, _create_unique_name, _get_datetime_format,
+    _compare_versions, _convert_to_timedelta, _create_unique_name, _get_datetime_format,
     _get_root_tables, _is_datetime_type, _validate_foreign_keys_not_null,
     check_sdv_versions_and_warn, check_synthesizer_version)
 from sdv.errors import SDVVersionWarning, SynthesizerInputError, VersionError
@@ -409,40 +410,40 @@ def test_check_sdv_versions_and_warn_public_and_enterprise_missmatch(mock_versio
         check_sdv_versions_and_warn(synthesizer)
 
 
-def test__check_is_lower_version():
-    """Test that _check_is_lower_version returns True if synthesizer version is greater."""
+def test__compare_versions():
+    """Test that _compare_versions returns True if synthesizer version is greater."""
     # Setup
-    synthesizer_version = '1.2.3'
     current_version = '1.2.1'
+    synthesizer_version = '1.2.3'
 
     # Run
-    result = _check_is_lower_version(current_version, synthesizer_version)
+    result = _compare_versions(current_version, synthesizer_version)
 
     # Assert
     assert result is True
 
 
-def test__check_is_lower_version_equal():
-    """Test that _check_is_lower_version returns False if synthesizer version is equal."""
+def test__compare_versions_equal():
+    """Test that _compare_versions returns False if synthesizer version is equal."""
     # Setup
     synthesizer_version = '1.2.3'
     current_version = '1.2.3'
 
     # Run
-    result = _check_is_lower_version(current_version, synthesizer_version)
+    result = _compare_versions(current_version, synthesizer_version)
 
     # Assert
     assert result is False
 
 
-def test__check_is_lower_version_lower():
-    """Test that _check_is_lower_version returns False if synthesizer version is lower."""
+def test__compare_versions_lower():
+    """Test that _compare_versions returns False if synthesizer version is lower."""
     # Setup
     synthesizer_version = '1.0.3'
     current_version = '1.2.1'
 
     # Run
-    result = _check_is_lower_version(current_version, synthesizer_version)
+    result = _compare_versions(current_version, synthesizer_version)
 
     # Assert
     assert result is False
@@ -570,7 +571,7 @@ def test_check_synthesizer_version_check_synthesizer_is_greater(mock_version):
         check_synthesizer_version(
             synthesizer,
             is_fit_method=True,
-            check_synthesizer_is_greater=True
+            compare_operator=operator.lt
         )
 
 
@@ -587,7 +588,7 @@ def test_check_synthesizer_version_check_synthesizer_is_greater_equal(mock_versi
     mock_version.enterprise = '1.3.0'
 
     # Run and Assert
-    check_synthesizer_version(synthesizer, is_fit_method=True, check_synthesizer_is_greater=True)
+    check_synthesizer_version(synthesizer, is_fit_method=True, compare_operator=operator.lt)
 
 
 @patch('sdv._utils.version')
@@ -613,11 +614,7 @@ def test_check_synthesizer_version_check_synthesizer_is_greater_public_missmatch
         'Please create a new synthesizer.'
     )
     with pytest.raises(VersionError, match=message):
-        check_synthesizer_version(
-            synthesizer,
-            is_fit_method=True,
-            check_synthesizer_is_greater=True
-        )
+        check_synthesizer_version(synthesizer, is_fit_method=True, compare_operator=operator.lt)
 
 
 @patch('sdv._utils.version')
@@ -643,8 +640,4 @@ def test_check_synthesizer_version_check_synthesizer_is_greater_both_missmatch(m
         'Fitting this synthesizer again is not supported. Please create a new synthesizer.'
     )
     with pytest.raises(VersionError, match=message):
-        check_synthesizer_version(
-            synthesizer,
-            is_fit_method=True,
-            check_synthesizer_is_greater=True
-        )
+        check_synthesizer_version(synthesizer, is_fit_method=True, compare_operator=operator.lt)

--- a/tests/unit/test__utils.py
+++ b/tests/unit/test__utils.py
@@ -542,3 +542,109 @@ def test__get_root_tables():
 
     # Assert
     assert result == {'parent'}
+
+
+@patch('sdv._utils.version')
+def test_check_synthesizer_version_check_synthesizer_is_greater(mock_version):
+    """Test that ``VersionError`` is raised when checking if synthesizer is greater.
+
+    Ensure that this test will raise a ``VersionError`` when the synthesizer version is lower
+    than the current package version.
+    """
+    # Setup
+    synthesizer = Mock(
+        _fitted_sdv_version='1.3.0',
+        _fitted_sdv_enterprise_version='1.3.0'
+    )
+
+    mock_version.public = '1.3.0'
+    mock_version.enterprise = '1.4.0'
+
+    # Run and Assert
+    message = (
+        'You are currently on SDV Enterprise version 1.4.0 but this synthesizer was created on '
+        'version 1.3.0. Fitting this synthesizer again is not supported. '
+        'Please create a new synthesizer.'
+    )
+    with pytest.raises(VersionError, match=message):
+        check_synthesizer_version(
+            synthesizer,
+            is_fit_method=True,
+            check_synthesizer_is_greater=True
+        )
+
+
+@patch('sdv._utils.version')
+def test_check_synthesizer_version_check_synthesizer_is_greater_equal(mock_version):
+    """Test that no ``VersionError`` is raised when versions match."""
+    # Setup
+    synthesizer = Mock(
+        _fitted_sdv_version='1.3.0',
+        _fitted_sdv_enterprise_version='1.3.0'
+    )
+
+    mock_version.public = '1.3.0'
+    mock_version.enterprise = '1.3.0'
+
+    # Run and Assert
+    check_synthesizer_version(synthesizer, is_fit_method=True, check_synthesizer_is_greater=True)
+
+
+@patch('sdv._utils.version')
+def test_check_synthesizer_version_check_synthesizer_is_greater_public_missmatch(mock_version):
+    """Test that ``VersionError`` is raised when checking if synthesizer is greater.
+
+    Ensure that this test will raise a ``VersionError`` when the synthesizer version is lower
+    than the current package version.
+    """
+    # Setup
+    synthesizer = Mock(
+        _fitted_sdv_version='1.3.0',
+        _fitted_sdv_enterprise_version='1.4.0'
+    )
+
+    mock_version.public = '1.5.0'
+    mock_version.enterprise = '1.4.0'
+
+    # Run and Assert
+    message = (
+        'You are currently on SDV version 1.5.0 but this synthesizer was created on '
+        'version 1.3.0. Fitting this synthesizer again is not supported. '
+        'Please create a new synthesizer.'
+    )
+    with pytest.raises(VersionError, match=message):
+        check_synthesizer_version(
+            synthesizer,
+            is_fit_method=True,
+            check_synthesizer_is_greater=True
+        )
+
+
+@patch('sdv._utils.version')
+def test_check_synthesizer_version_check_synthesizer_is_greater_both_missmatch(mock_version):
+    """Test that ``VersionError`` is raised when public and enterprise are greater.
+
+    Ensure that this test will raise a ``VersionError`` when the synthesizer version is lower
+    than the current package version.
+    """
+    # Setup
+    synthesizer = Mock(
+        _fitted_sdv_version='1.3.0',
+        _fitted_sdv_enterprise_version='1.3.2'
+    )
+
+    mock_version.public = '1.5.0'
+    mock_version.enterprise = '1.4.0'
+
+    # Run and Assert
+    message = (
+        'You are currently on SDV version 1.5.0 and SDV Enterprise version 1.4.0 but this '
+        'synthesizer was created on SDV version 1.3.0 and SDV Enterprise version 1.3.2. '
+        'Fitting this synthesizer again is not supported. Please create a new synthesizer.'
+    )
+    with pytest.raises(VersionError, match=message):
+        check_synthesizer_version(
+            synthesizer,
+            is_fit_method=True,
+            check_synthesizer_is_greater=True
+        )


### PR DESCRIPTION
Resolves #1838 
CU-86azkp7m4