### PR TITLE
Fixing Bandit command

### DIFF
--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -19,7 +19,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install bandit==1.7.7
     - name: Save code analysis
-      run: bandit -r . -x ./tests -f txt -o static_code_analysis.txt
+      run: bandit -r . -x ./tests -f txt -o static_code_analysis.txt --exit-zero
     - name: Create pull request
       id: cpr
       uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -19,7 +19,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install bandit==1.7.7
     - name: Save code analysis
-      run: python -m bandit -r . -x ./tests -f txt -o static_code_analysis.txt
+      run: bandit -r . -x ./tests -f txt -o static_code_analysis.txt
     - name: Create pull request
       id: cpr
       uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
fixes #1881 
The workflow was failing because Bandit exits with error code 1 if any issues are found which killed the Github workflow. There is a flag to cause it to exit with 0 that is now enabled