### PR TITLE
Allow IDGenerator be used for Primary and Alternate Keys

### DIFF
--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pandas as pd
 import rdt
 from pandas.api.types import is_float_dtype, is_integer_dtype
-from rdt.transformers import AnonymizedFaker, IDGenerator, RegexGenerator, get_default_transformers
+from rdt.transformers import AnonymizedFaker, IDGenerator, get_default_transformers
 from rdt.transformers.pii.anonymization import get_anonymized_transformer
 
 from sdv.constraints import Constraint
@@ -644,8 +644,7 @@ class DataProcessor:
             )
 
         for column, transformer in column_name_to_transformer.items():
-            if column in self._keys and not type(transformer) \
-                    in (AnonymizedFaker, RegexGenerator, IDGenerator):
+            if column in self._keys and not transformer.is_generator():
                 raise SynthesizerInputError(
                     f"Invalid transformer '{transformer.__class__.__name__}' for a primary "
                     f"or alternate key '{column}'. Please use 'AnonymizedFaker', "

--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -644,11 +644,12 @@ class DataProcessor:
             )
 
         for column, transformer in column_name_to_transformer.items():
-            if column in self._keys and not type(transformer) in (AnonymizedFaker, RegexGenerator):
+            if column in self._keys and not type(transformer) \
+                    in (AnonymizedFaker, RegexGenerator, IDGenerator):
                 raise SynthesizerInputError(
                     f"Invalid transformer '{transformer.__class__.__name__}' for a primary "
-                    f"or alternate key '{column}'. Please use 'AnonymizedFaker' or "
-                    "'RegexGenerator' instead."
+                    f"or alternate key '{column}'. Please use 'AnonymizedFaker', "
+                    "'IDGenerator', or 'RegexGenerator' instead."
                 )
 
         with warnings.catch_warnings():

--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -647,8 +647,7 @@ class DataProcessor:
             if column in self._keys and not transformer.is_generator():
                 raise SynthesizerInputError(
                     f"Invalid transformer '{transformer.__class__.__name__}' for a primary "
-                    f"or alternate key '{column}'. Please use 'AnonymizedFaker', "
-                    "'IDGenerator', or 'RegexGenerator' instead."
+                    f"or alternate key '{column}'. Please use a generator transformer instead."
                 )
 
         with warnings.catch_warnings():

--- a/tests/integration/data_processing/test_data_processor.py
+++ b/tests/integration/data_processing/test_data_processor.py
@@ -6,8 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from rdt.transformers import (
-    AnonymizedFaker, BinaryEncoder, FloatFormatter,
-    IDGenerator, RegexGenerator, UniformEncoder,
+    AnonymizedFaker, BinaryEncoder, FloatFormatter, IDGenerator, RegexGenerator, UniformEncoder,
     UnixTimestampEncoder)
 
 from sdv._utils import _get_datetime_format

--- a/tests/integration/single_table/test_copulas.py
+++ b/tests/integration/single_table/test_copulas.py
@@ -4,7 +4,8 @@ import numpy as np
 import pandas as pd
 import pytest
 from rdt.transformers import (
-    AnonymizedFaker, CustomLabelEncoder, FloatFormatter, LabelEncoder, PseudoAnonymizedFaker)
+    AnonymizedFaker, CustomLabelEncoder, FloatFormatter, LabelEncoder, PseudoAnonymizedFaker
+)
 
 from sdv.datasets.demo import download_demo
 from sdv.errors import ConstraintsNotMetError

--- a/tests/integration/single_table/test_copulas.py
+++ b/tests/integration/single_table/test_copulas.py
@@ -297,7 +297,9 @@ def test_custom_processing_anonymization():
     assert any(anonymized_sample['billing_address'].value_counts() > 1)
 
 
-def test_update_transformers_id_generator():
+def test_update_transformers_with_id_generator():
+    """Test using the ID Generator for a primary key"""
+    # Setup
     min_value_id = 5
     sample_num = 20
     data = pd.DataFrame({
@@ -314,13 +316,15 @@ def test_update_transformers_id_generator():
     custom_id = IDGenerator(starting_value=min_value_id)
     gc.auto_assign_transformers(data)
 
+    # Run
     gc.update_transformers({'user_id': custom_id})
-    transformers = gc.get_transformers()
-    assert transformers['user_id'] == custom_id
-    assert type(transformers['user_cat']).__name__ == 'UniformEncoder'
-
     gc.fit(data)
     samples = gc.sample(sample_num)
+    transformers = gc.get_transformers()
+
+    # Assert
+    assert transformers['user_id'] == custom_id
+    assert type(transformers['user_cat']).__name__ == 'UniformEncoder'
     assert len(samples) == sample_num
     assert samples['user_id'].min() == min_value_id
 

--- a/tests/integration/single_table/test_copulas.py
+++ b/tests/integration/single_table/test_copulas.py
@@ -4,8 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from rdt.transformers import (
-    AnonymizedFaker, CustomLabelEncoder, FloatFormatter, LabelEncoder, PseudoAnonymizedFaker
-)
+    AnonymizedFaker, CustomLabelEncoder, FloatFormatter, LabelEncoder, PseudoAnonymizedFaker)
 
 from sdv.datasets.demo import download_demo
 from sdv.errors import ConstraintsNotMetError

--- a/tests/integration/single_table/test_copulas.py
+++ b/tests/integration/single_table/test_copulas.py
@@ -4,7 +4,8 @@ import numpy as np
 import pandas as pd
 import pytest
 from rdt.transformers import (
-    AnonymizedFaker, CustomLabelEncoder, FloatFormatter, LabelEncoder, PseudoAnonymizedFaker)
+    AnonymizedFaker, CustomLabelEncoder, FloatFormatter, IDGenerator, LabelEncoder,
+    PseudoAnonymizedFaker)
 
 from sdv.datasets.demo import download_demo
 from sdv.errors import ConstraintsNotMetError
@@ -294,6 +295,34 @@ def test_custom_processing_anonymization():
     assert anonymized_transformers['billing_address'] == billing_address_transformer
     assert [UUID(uuid) for uuid in anonymized_sample['guest_email']]
     assert any(anonymized_sample['billing_address'].value_counts() > 1)
+
+
+def test_update_transformers_id_generator():
+    min_value_id = 5
+    sample_num = 20
+    data = pd.DataFrame({
+        'user_id': list(range(4)),
+        'user_cat': ['a', 'b', 'c', 'd']
+    })
+
+    stm = SingleTableMetadata()
+    stm.detect_from_dataframe(data)
+    stm.update_column('user_id', sdtype='id')
+    stm.set_primary_key('user_id')
+
+    gc = GaussianCopulaSynthesizer(stm)
+    custom_id = IDGenerator(starting_value=min_value_id)
+    gc.auto_assign_transformers(data)
+
+    gc.update_transformers({'user_id': custom_id})
+    transformers = gc.get_transformers()
+    assert transformers['user_id'] == custom_id
+    assert type(transformers['user_cat']).__name__ == 'UniformEncoder'
+
+    gc.fit(data)
+    samples = gc.sample(sample_num)
+    assert len(samples) == sample_num
+    assert samples['user_id'].min() == min_value_id
 
 
 def test_validate_with_failing_constraint():

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -1600,7 +1600,7 @@ class TestDataProcessor:
         # Run and Assert
         error_msg = re.escape(
             "Invalid transformer 'FloatFormatter' for a primary or alternate key 'pk_column'. "
-            "Please use 'AnonymizedFaker', 'IDGenerator', or 'RegexGenerator' instead."
+            'Please use a generator transformer instead.'
         )
         with pytest.raises(SynthesizerInputError, match=error_msg):
             dp.update_transformers({'pk_column': FloatFormatter()})

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -1588,7 +1588,10 @@ class TestDataProcessor:
             dp.update_transformers({'col1': GaussianNormalizer()})
 
     def test_update_transformers_for_key(self):
-        """Test when ``transformer`` is not ``AnonymizedFaker`` or ``RegexGenerator`` for keys."""
+        """
+        Test when ``transformer`` is not ``AnonymizedFaker``, ``IDGenerator,
+        or ``RegexGenerator`` for keys.
+        """
         # Setup
         dp = DataProcessor(SingleTableMetadata())
         dp._keys = ['pk_column', 'b']
@@ -1597,7 +1600,7 @@ class TestDataProcessor:
         # Run and Assert
         error_msg = re.escape(
             "Invalid transformer 'FloatFormatter' for a primary or alternate key 'pk_column'. "
-            "Please use 'AnonymizedFaker' or 'RegexGenerator' instead."
+            "Please use 'AnonymizedFaker', 'IDGenerator', or 'RegexGenerator' instead."
         )
         with pytest.raises(SynthesizerInputError, match=error_msg):
             dp.update_transformers({'pk_column': FloatFormatter()})


### PR DESCRIPTION
resolves #1862 
CU_86aztbydu

Allow IDGenerator transformer to be used for primary and alternate keys