### PR TITLE
Create unique id for each synthesizer

### DIFF
--- a/sdv/_utils.py
+++ b/sdv/_utils.py
@@ -1,5 +1,6 @@
 """Miscellaneous utility functions."""
 import operator
+import uuid
 import warnings
 from collections import defaultdict
 from collections.abc import Iterable
@@ -388,3 +389,23 @@ def _get_root_tables(relationships):
     parent_tables = {rel['parent_table_name'] for rel in relationships}
     child_tables = {rel['child_table_name'] for rel in relationships}
     return parent_tables - child_tables
+
+
+def generate_synthesizer_id(synthesizer):
+    """Generate a unique identifier for the synthesizer instance.
+
+    This method creates a unique identifier by combining the class name, the public SDV version
+    and the last part of a UUID4 composed by 12 random characters.
+
+    Args:
+        synthesizer (BaseSynthesizer or BaseMultiTableSynthesizer):
+            An SDV model instance to check versions against.
+
+    Returns:
+        ID:
+            A unique identifier for this synthesizer.
+    """
+    class_name = synthesizer.__class__.__name__
+    synth_version = version.public
+    unique_id = str(uuid.uuid4()).split('-')[-1]
+    return f'{class_name}_{synth_version}_{unique_id}'

--- a/sdv/_utils.py
+++ b/sdv/_utils.py
@@ -395,7 +395,7 @@ def generate_synthesizer_id(synthesizer):
     """Generate a unique identifier for the synthesizer instance.
 
     This method creates a unique identifier by combining the class name, the public SDV version
-    and the last part of a UUID4 composed by 12 random characters.
+    and the last part of a UUID4 composed by 36 random characters.
 
     Args:
         synthesizer (BaseSynthesizer or BaseMultiTableSynthesizer):
@@ -407,5 +407,5 @@ def generate_synthesizer_id(synthesizer):
     """
     class_name = synthesizer.__class__.__name__
     synth_version = version.public
-    unique_id = str(uuid.uuid4()).split('-')[-1]
+    unique_id = ''.join(str(uuid.uuid4()).split('-'))
     return f'{class_name}_{synth_version}_{unique_id}'

--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -13,7 +13,8 @@ from tqdm import tqdm
 
 from sdv import version
 from sdv._utils import (
-    _validate_foreign_keys_not_null, check_sdv_versions_and_warn, check_synthesizer_version)
+    _validate_foreign_keys_not_null, check_sdv_versions_and_warn, check_synthesizer_version,
+    generate_synthesizer_id)
 from sdv.errors import ConstraintsNotMetError, InvalidDataError, SynthesizerInputError
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
 
@@ -111,6 +112,7 @@ class BaseMultiTableSynthesizer:
         self._fitted_date = None
         self._fitted_sdv_version = None
         self._fitted_sdv_enterprise_version = None
+        self._synthesizer_id = generate_synthesizer_id(self)
 
     def _get_root_parents(self):
         """Get the set of root parents in the graph."""
@@ -604,4 +606,7 @@ class BaseMultiTableSynthesizer:
 
         check_synthesizer_version(synthesizer)
         check_sdv_versions_and_warn(synthesizer)
+        if getattr(synthesizer, '_synthesizer_id', None) is None:
+            synthesizer._synthesizer_id = generate_synthesizer_id(synthesizer)
+
         return synthesizer

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -19,7 +19,8 @@ import tqdm
 from copulas.multivariate import GaussianMultivariate
 
 from sdv import version
-from sdv._utils import _groupby_list, check_sdv_versions_and_warn, check_synthesizer_version
+from sdv._utils import (
+    _groupby_list, check_sdv_versions_and_warn, check_synthesizer_version, generate_synthesizer_id)
 from sdv.constraints.errors import AggregateConstraintsError
 from sdv.data_processing.data_processor import DataProcessor
 from sdv.errors import ConstraintsNotMetError, InvalidDataError, SynthesizerInputError
@@ -105,6 +106,7 @@ class BaseSynthesizer:
         self._fitted_date = None
         self._fitted_sdv_version = None
         self._fitted_sdv_enterprise_version = None
+        self._synthesizer_id = generate_synthesizer_id(self)
 
     def set_address_columns(self, column_names, anonymization_level='full'):
         """Set the address multi-column transformer."""
@@ -438,6 +440,9 @@ class BaseSynthesizer:
 
         check_synthesizer_version(synthesizer)
         check_sdv_versions_and_warn(synthesizer)
+        if getattr(synthesizer, '_synthesizer_id', None) is None:
+            synthesizer._synthesizer_id = generate_synthesizer_id(synthesizer)
+
         return synthesizer
 
 

--- a/tests/integration/single_table/test_base.py
+++ b/tests/integration/single_table/test_base.py
@@ -538,12 +538,39 @@ def test_save_and_load(tmp_path):
 
     # Assert
     assert isinstance(loaded_instance, BaseSingleTableSynthesizer)
-    assert instance.metadata.columns == {}
-    assert instance.metadata.primary_key is None
-    assert instance.metadata.alternate_keys == []
-    assert instance.metadata.sequence_key is None
-    assert instance.metadata.sequence_index is None
-    assert instance.metadata._version == 'SINGLE_TABLE_V1'
+    assert loaded_instance.metadata.columns == {}
+    assert loaded_instance.metadata.primary_key is None
+    assert loaded_instance.metadata.alternate_keys == []
+    assert loaded_instance.metadata.sequence_key is None
+    assert loaded_instance.metadata.sequence_index is None
+    assert loaded_instance.metadata._version == 'SINGLE_TABLE_V1'
+    assert instance._synthesizer_id == loaded_instance._synthesizer_id
+
+
+def test_save_and_load_no_id(tmp_path):
+    """Test that synthesizers can be saved and loaded properly."""
+    # Setup
+    metadata = SingleTableMetadata()
+    instance = BaseSingleTableSynthesizer(metadata)
+    synthesizer_path = tmp_path / 'synthesizer.pkl'
+    delattr(instance, '_synthesizer_id')
+
+    instance.save(synthesizer_path)
+
+    # Run
+    loaded_instance = BaseSingleTableSynthesizer.load(synthesizer_path)
+
+    # Assert
+    assert isinstance(loaded_instance, BaseSingleTableSynthesizer)
+    assert loaded_instance.metadata.columns == {}
+    assert loaded_instance.metadata.primary_key is None
+    assert loaded_instance.metadata.alternate_keys == []
+    assert loaded_instance.metadata.sequence_key is None
+    assert loaded_instance.metadata.sequence_index is None
+    assert loaded_instance.metadata._version == 'SINGLE_TABLE_V1'
+    assert hasattr(instance, '_synthesizer_id') is False
+    assert hasattr(loaded_instance, '_synthesizer_id') is True
+    assert isinstance(loaded_instance._synthesizer_id, str) is True
 
 
 def test_save_and_load_with_downgraded_version(tmp_path):

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -109,7 +109,8 @@ class TestBaseMultiTableSynthesizer:
         calls the ``self._initialize_models`` which creates the initial instances of those.
         """
         # Setup
-        mock_generate_synthesizer_id.return_value = 'BaseMultiTableSynthesizer_1.0.0_123456789abc'
+        synthesizer_id = 'BaseSingleTableSynthesizer_1.0.0_92aff11e9a5649d1a280990d1231a5f5'
+        mock_generate_synthesizer_id.return_value = synthesizer_id
         metadata = get_multi_table_metadata()
         metadata.validate = Mock()
 
@@ -125,7 +126,7 @@ class TestBaseMultiTableSynthesizer:
         instance.metadata.validate.assert_called_once_with()
         mock_check_metadata_updated.assert_called_once()
         mock_generate_synthesizer_id.assert_called_once_with(instance)
-        assert instance._synthesizer_id == 'BaseMultiTableSynthesizer_1.0.0_123456789abc'
+        assert instance._synthesizer_id == synthesizer_id
 
     def test__init__column_relationship_warning(self):
         """Test that a warning is raised only once when the metadata has column relationships."""
@@ -1408,7 +1409,8 @@ class TestBaseMultiTableSynthesizer:
                   mock_generate_synthesizer_id):
         """Test that the ``load`` method loads a stored synthesizer."""
         # Setup
-        mock_generate_synthesizer_id.return_value = 'BaseMultiTableSynthesizer_1.0.0_123456789abc'
+        synthesizer_id = 'BaseSingleTableSynthesizer_1.0.0_92aff11e9a5649d1a280990d1231a5f5'
+        mock_generate_synthesizer_id.return_value = synthesizer_id
         synthesizer_mock = Mock(_fitted=False, _synthesizer_id=None)
         cloudpickle_mock.load.return_value = synthesizer_mock
 
@@ -1421,5 +1423,5 @@ class TestBaseMultiTableSynthesizer:
         cloudpickle_mock.load.assert_called_once_with(mock_file.return_value)
         assert loaded_instance == synthesizer_mock
         mock_check_synthesizer_version.assert_called_once_with(synthesizer_mock)
-        assert loaded_instance._synthesizer_id == 'BaseMultiTableSynthesizer_1.0.0_123456789abc'
+        assert loaded_instance._synthesizer_id == synthesizer_id
         mock_generate_synthesizer_id.assert_called_once_with(synthesizer_mock)

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -67,7 +67,8 @@ class TestBaseSingleTableSynthesizer:
         """Test instantiating with default values."""
         # Setup
         metadata = Mock()
-        mock_generate_synthesizer_id.return_value = 'BaseSingleTableSynthesizer_1.0.0_123456789abc'
+        synthesizer_id = 'BaseSingleTableSynthesizer_1.0.0_92aff11e9a5649d1a280990d1231a5f5'
+        mock_generate_synthesizer_id.return_value = synthesizer_id
 
         # Run
         instance = BaseSingleTableSynthesizer(metadata)
@@ -78,7 +79,7 @@ class TestBaseSingleTableSynthesizer:
         assert instance._data_processor == mock_data_processor.return_value
         assert instance._random_state_set is False
         assert instance._fitted is False
-        assert instance._synthesizer_id == 'BaseSingleTableSynthesizer_1.0.0_123456789abc'
+        assert instance._synthesizer_id == synthesizer_id
         mock_data_processor.assert_called_once_with(
             metadata=metadata,
             enforce_rounding=instance.enforce_rounding,
@@ -1764,7 +1765,8 @@ class TestBaseSingleTableSynthesizer:
         """Test that the ``load`` method loads a stored synthesizer."""
         # Setup
         synthesizer_mock = Mock(_fitted=False, _synthesizer_id=None)
-        mock_generate_synthesizer_id.return_value = 'BaseSingleTableSynthesizer_1.0.0_123456789abc'
+        synthesizer_id = 'BaseSingleTableSynthesizer_1.0.0_92aff11e9a5649d1a280990d1231a5f5'
+        mock_generate_synthesizer_id.return_value = synthesizer_id
         cloudpickle_mock.load.return_value = synthesizer_mock
 
         # Run
@@ -1775,7 +1777,7 @@ class TestBaseSingleTableSynthesizer:
         cloudpickle_mock.load.assert_called_once_with(mock_file.return_value)
         mock_check_sdv_versions_and_warn.assert_called_once_with(loaded_instance)
         assert loaded_instance == synthesizer_mock
-        assert loaded_instance._synthesizer_id == 'BaseSingleTableSynthesizer_1.0.0_123456789abc'
+        assert loaded_instance._synthesizer_id == synthesizer_id
         mock_check_synthesizer_version.assert_called_once_with(synthesizer_mock)
         mock_generate_synthesizer_id.assert_called_once_with(synthesizer_mock)
 

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -59,12 +59,15 @@ class TestBaseSingleTableSynthesizer:
         # Assert
         instance.metadata._updated = False
 
+    @patch('sdv.single_table.base.generate_synthesizer_id')
     @patch('sdv.single_table.base.DataProcessor')
     @patch('sdv.single_table.base.BaseSingleTableSynthesizer._check_metadata_updated')
-    def test___init__(self, mock_check_metadata_updated, mock_data_processor):
+    def test___init__(self, mock_check_metadata_updated, mock_data_processor,
+                      mock_generate_synthesizer_id):
         """Test instantiating with default values."""
         # Setup
         metadata = Mock()
+        mock_generate_synthesizer_id.return_value = 'BaseSingleTableSynthesizer_1.0.0_123456789abc'
 
         # Run
         instance = BaseSingleTableSynthesizer(metadata)
@@ -75,6 +78,7 @@ class TestBaseSingleTableSynthesizer:
         assert instance._data_processor == mock_data_processor.return_value
         assert instance._random_state_set is False
         assert instance._fitted is False
+        assert instance._synthesizer_id == 'BaseSingleTableSynthesizer_1.0.0_123456789abc'
         mock_data_processor.assert_called_once_with(
             metadata=metadata,
             enforce_rounding=instance.enforce_rounding,
@@ -83,6 +87,7 @@ class TestBaseSingleTableSynthesizer:
         )
         metadata.validate.assert_called_once_with()
         mock_check_metadata_updated.assert_called_once()
+        mock_generate_synthesizer_id.assert_called_once_with(instance)
 
     @patch('sdv.single_table.base.DataProcessor')
     def test___init__custom(self, mock_data_processor):
@@ -1749,15 +1754,17 @@ class TestBaseSingleTableSynthesizer:
         # Assert
         cloudpickle_mock.dump.assert_called_once_with(synthesizer, ANY)
 
+    @patch('sdv.single_table.base.generate_synthesizer_id')
     @patch('sdv.single_table.base.check_synthesizer_version')
     @patch('sdv.single_table.base.check_sdv_versions_and_warn')
     @patch('sdv.single_table.base.cloudpickle')
     @patch('builtins.open', new_callable=mock_open)
-    def test_load(self, mock_file, cloudpickle_mock,
-                  mock_check_sdv_versions_and_warn, mock_check_synthesizer_version):
+    def test_load(self, mock_file, cloudpickle_mock, mock_check_sdv_versions_and_warn,
+                  mock_check_synthesizer_version, mock_generate_synthesizer_id):
         """Test that the ``load`` method loads a stored synthesizer."""
         # Setup
-        synthesizer_mock = Mock(_fitted=False)
+        synthesizer_mock = Mock(_fitted=False, _synthesizer_id=None)
+        mock_generate_synthesizer_id.return_value = 'BaseSingleTableSynthesizer_1.0.0_123456789abc'
         cloudpickle_mock.load.return_value = synthesizer_mock
 
         # Run
@@ -1768,7 +1775,9 @@ class TestBaseSingleTableSynthesizer:
         cloudpickle_mock.load.assert_called_once_with(mock_file.return_value)
         mock_check_sdv_versions_and_warn.assert_called_once_with(loaded_instance)
         assert loaded_instance == synthesizer_mock
+        assert loaded_instance._synthesizer_id == 'BaseSingleTableSynthesizer_1.0.0_123456789abc'
         mock_check_synthesizer_version.assert_called_once_with(synthesizer_mock)
+        mock_generate_synthesizer_id.assert_called_once_with(synthesizer_mock)
 
     def test_load_custom_constraint_classes(self):
         """Test that ``load_custom_constraint_classes`` calls the ``DataProcessor``'s method."""

--- a/tests/unit/test__utils.py
+++ b/tests/unit/test__utils.py
@@ -659,4 +659,4 @@ def test_generate_synthesizer_id(mock_version, mock_uuid):
     result = generate_synthesizer_id(synthesizer)
 
     # Assert
-    assert result == 'BaseSingleTableSynthesizer_1.0.0_990d1231a5f5'
+    assert result == 'BaseSingleTableSynthesizer_1.0.0_92aff11e9a5649d1a280990d1231a5f5'

--- a/tests/unit/test__utils.py
+++ b/tests/unit/test__utils.py
@@ -11,8 +11,10 @@ from sdv import version
 from sdv._utils import (
     _compare_versions, _convert_to_timedelta, _create_unique_name, _get_datetime_format,
     _get_root_tables, _is_datetime_type, _validate_foreign_keys_not_null,
-    check_sdv_versions_and_warn, check_synthesizer_version)
+    check_sdv_versions_and_warn, check_synthesizer_version, generate_synthesizer_id)
 from sdv.errors import SDVVersionWarning, SynthesizerInputError, VersionError
+from sdv.metadata.single_table import SingleTableMetadata
+from sdv.single_table.base import BaseSingleTableSynthesizer
 from tests.utils import SeriesMatcher
 
 
@@ -641,3 +643,20 @@ def test_check_synthesizer_version_check_synthesizer_is_greater_both_missmatch(m
     )
     with pytest.raises(VersionError, match=message):
         check_synthesizer_version(synthesizer, is_fit_method=True, compare_operator=operator.lt)
+
+
+@patch('sdv._utils.uuid')
+@patch('sdv._utils.version')
+def test_generate_synthesizer_id(mock_version, mock_uuid):
+    """Test that ``generate_synthesizer_id`` returns the expected id."""
+    # Setup
+    mock_version.public = '1.0.0'
+    mock_uuid.uuid4.return_value = '92aff11e-9a56-49d1-a280-990d1231a5f5'
+    metadata = SingleTableMetadata()
+    synthesizer = BaseSingleTableSynthesizer(metadata)
+
+    # Run
+    result = generate_synthesizer_id(synthesizer)
+
+    # Assert
+    assert result == 'BaseSingleTableSynthesizer_1.0.0_990d1231a5f5'


### PR DESCRIPTION
Resolves #1902 
CU-86b00mxjz

This is how the `IDS` look :
<img width="777" alt="image" src="https://github.com/sdv-dev/SDV/assets/41479552/f03a6974-c161-40d7-8935-e534d83ea504">

I'm printing both `instance` and `id` just in case we wanted to change the `representation` to be the id of the synthesizer.