### PR TITLE
Change loss chart visual to darker line

### DIFF
--- a/sdv/single_table/ctgan.py
+++ b/sdv/single_table/ctgan.py
@@ -71,10 +71,6 @@ class LossValuesMixin:
 
         # Tidy up the loss values data
         loss_df = self._model.loss_values.copy()
-        loss_df['Generator Loss'] = loss_df['Generator Loss'].apply(
-            lambda x: x.item() if isinstance(x, pd.Series) else x)
-        loss_df['Discriminator Loss'] = loss_df['Discriminator Loss'].apply(
-            lambda x: x.item() if isinstance(x, pd.Series) else x)
 
         # Create a pretty chart using Plotly Express
         fig = px.line(

--- a/sdv/single_table/ctgan.py
+++ b/sdv/single_table/ctgan.py
@@ -71,15 +71,17 @@ class LossValuesMixin:
 
         # Tidy up the loss values data
         loss_df = self._model.loss_values.copy()
-        loss_df['Generator Loss'] = loss_df['Generator Loss'].apply(lambda x: x.item())
-        loss_df['Discriminator Loss'] = loss_df['Discriminator Loss'].apply(lambda x: x.item())
+        loss_df['Generator Loss'] = loss_df['Generator Loss'].apply(
+            lambda x: x.item() if isinstance(x, pd.Series) else x)
+        loss_df['Discriminator Loss'] = loss_df['Discriminator Loss'].apply(
+            lambda x: x.item() if isinstance(x, pd.Series) else x)
 
         # Create a pretty chart using Plotly Express
         fig = px.line(
             loss_df, x='Epoch',
             y=['Generator Loss', 'Discriminator Loss'],
             color_discrete_map={
-                'Generator Loss': visualization.PlotConfig.DATACEBO_BLUE,
+                'Generator Loss': visualization.PlotConfig.DATACEBO_DARK,
                 'Discriminator Loss': visualization.PlotConfig.DATACEBO_GREEN
             },
         )

--- a/tests/unit/single_table/test_ctgan.py
+++ b/tests/unit/single_table/test_ctgan.py
@@ -330,7 +330,7 @@ class TestCTGANSynthesizer:
         assert (fig['x'] == 'Epoch')
         assert (fig['y'] == ['Generator Loss', 'Discriminator Loss'])
         assert (fig['color_discrete_map'] == {
-            'Generator Loss': visualization.PlotConfig.DATACEBO_BLUE,
+            'Generator Loss': visualization.PlotConfig.DATACEBO_DARK,
             'Discriminator Loss': visualization.PlotConfig.DATACEBO_GREEN
         })
 


### PR DESCRIPTION
resolves #1916 

Changes the color
Also added a type check so that the chart can work if the loss values are not pd.series.

<img width="1504" alt="Screenshot 2024-04-16 at 3 28 34 PM" src="https://github.com/sdv-dev/SDV/assets/10409759/5d0d8f4f-ca9f-4e53-9bf7-a34f07f8f29f">
