### PR TITLE
Allow for disconnected tables

### DIFF
--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -512,13 +512,6 @@ class MultiTableMetadata:
                                            primary_key,
                                            sdtype=original_foreign_key_sdtype)
                         continue
-        try:
-            self._validate_all_tables_connected(self._get_parent_map(), self._get_child_map())
-        except InvalidMetadataError as invalid_error:
-            warning_msg = (
-                f'Could not automatically add relationships for all tables. {str(invalid_error)}'
-            )
-            warnings.warn(warning_msg)
 
     def detect_table_from_dataframe(self, table_name, data):
         """Detect the metadata for a table from a dataframe.

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -512,6 +512,13 @@ class MultiTableMetadata:
                                            primary_key,
                                            sdtype=original_foreign_key_sdtype)
                         continue
+        try:
+            self._validate_all_tables_connected(self._get_parent_map(), self._get_child_map())
+        except InvalidMetadataError as invalid_error:
+            warning_msg = (
+                f'Could not automatically add relationships for all tables. {str(invalid_error)}'
+            )
+            warnings.warn(warning_msg)
 
     def detect_table_from_dataframe(self, table_name, data):
         """Detect the metadata for a table from a dataframe.

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -475,19 +475,19 @@ class MultiTableMetadata:
                 if not connected[child] and child not in queue:
                     queue.append(child)
 
-        if not all(connected.values()):
-            disconnected_tables = [table for table, value in connected.items() if not value]
-            if len(disconnected_tables) > 1:
-                table_msg = (
-                    f'Tables {disconnected_tables} are not connected to any of the other tables.'
-                )
-            else:
-                table_msg = (
-                    f'Table {disconnected_tables} is not connected to any of the other tables.'
-                )
+        # if not all(connected.values()):
+        #     disconnected_tables = [table for table, value in connected.items() if not value]
+        #     if len(disconnected_tables) > 1:
+        #         table_msg = (
+        #             f'Tables {disconnected_tables} are not connected to any of the other tables.'
+        #         )
+        #     else:
+        #         table_msg = (
+        #             f'Table {disconnected_tables} is not connected to any of the other tables.'
+        #         )
 
-            raise InvalidMetadataError(
-                f'The relationships in the dataset are disjointed. {table_msg}')
+        #     raise InvalidMetadataError(
+        #         f'The relationships in the dataset are disjointed. {table_msg}')
 
     def _detect_relationships(self):
         """Automatically detect relationships between tables."""

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -1818,3 +1818,24 @@ def test_table_name_logging(caplog):
     # Assert
     for msg in caplog.messages:
         assert 'table parent_data' in msg or 'table child_data' in msg
+
+
+def test_disjointed_tables():
+    """Test to see if synthesizer works with disjointed tables."""
+    # Setup
+    real_data, metadata = download_demo('multi_table', 'Bupa_v1')
+
+    # Delete Some Relationships to make it disjointed
+    remove_some_dict = metadata.to_dict()
+    half_list = remove_some_dict['relationships'][1::2]
+    remove_some_dict['relationships'] = half_list
+    disjoined_metadata = MultiTableMetadata.load_from_dict(remove_some_dict)
+
+    # Run
+    disjoin_synthesizer = HMASynthesizer(disjoined_metadata)
+    disjoin_synthesizer.fit(real_data)
+    disjoin_synthetic_data = disjoin_synthesizer.sample(1.0)
+
+    # Assert
+    for table in real_data:
+        assert list(real_data[table].columns) == list(disjoin_synthetic_data[table].columns)

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -1178,8 +1178,10 @@ class TestMultiTableMetadata:
 
     def test_validate_raises_errors(self):
         """Test the method ``validate``.
+
         Test that when an invalid ``MultiTableMetadata`` has been provided, all different errors
         are being raised.
+
         Setup:
             - Instance of ``MultiTableMetadata`` with all valid tables and relationships.
         """
@@ -1208,13 +1210,13 @@ class TestMultiTableMetadata:
             instance.validate()
 
     def test__validate_all_tables_connected_raises_errors(self):
-        """Test the method ``validate``.
+        """Test the method ``_validate_all_tables_connected``.
 
-        Test that when an invalid ``MultiTableMetadata`` has been provided, all different errors
-        are being raised.
+        Test that when a disjointed table is validated with `_validate_all_tables_connected`
 
         Setup:
-            - Instance of ``MultiTableMetadata`` with all valid tables and relationships.
+            - Instance of ``MultiTableMetadata`` with all valid tables and
+            missing relationships.
         """
         # Setup
         instance = self.get_metadata()

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -1178,6 +1178,37 @@ class TestMultiTableMetadata:
 
     def test_validate_raises_errors(self):
         """Test the method ``validate``.
+        Test that when an invalid ``MultiTableMetadata`` has been provided, all different errors
+        are being raised.
+        Setup:
+            - Instance of ``MultiTableMetadata`` with all valid tables and relationships.
+        """
+        # Setup
+        instance = self.get_metadata()
+        instance.tables['users'].primary_key = None
+        instance.tables['transactions'].columns['session_id']['sdtype'] = 'datetime'
+        instance.tables['payments'].columns['date']['sdtype'] = 'id'
+        instance.tables['payments'].columns['date']['regex_format'] = '[A-z{'
+        instance.relationships.pop(-1)
+
+        # Run
+        error_msg = re.escape(
+            'The metadata is not valid\n'
+            '\nTable: payments'
+            "\nInvalid regex format string '[A-z{' for id column 'date'."
+            '\n\nRelationships:'
+            "\nThe parent table 'users' does not have a primary key set. "
+            "Please use 'set_primary_key' in order to set one."
+            "\nRelationship between tables ('sessions', 'transactions') is invalid. "
+            'The primary and foreign key columns are not the same type.'
+        )
+
+        # Run and Assert
+        with pytest.raises(InvalidMetadataError, match=error_msg):
+            instance.validate()
+
+    def test__validate_all_tables_connected_raises_errors(self):
+        """Test the method ``validate``.
 
         Test that when an invalid ``MultiTableMetadata`` has been provided, all different errors
         are being raised.

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -2319,44 +2319,6 @@ class TestMultiTableMetadata:
         assert instance.relationships == expected_relationships
         assert instance.tables['sessions'].columns['user_id']['sdtype'] == 'id'
 
-    @patch('sdv.metadata.multi_table.warnings')
-    def test__detect_relationships_disconnected_warning(self, warnings_mock):
-        """Test that ``_detect_relationships`` warns about tables it could not connect."""
-        # Setup
-        parent_table = Mock()
-        parent_table.primary_key = 'id'
-        parent_table.columns = {
-            'id': {'sdtype': 'id'},
-            'user_name': {'sdtype': 'categorical'},
-            'transactions': {'sdtype': 'numerical'},
-        }
-
-        child_table = SingleTableMetadata()
-        child_table.primary_key = 'session_id'
-        child_table.columns = {
-            'user_id': {'sdtype': 'categorical'},
-            'session_id': {'sdtype': 'numerical'},
-            'timestamp': {'sdtype': 'datetime'},
-        }
-
-        instance = MultiTableMetadata()
-        instance.tables = {
-            'users': parent_table,
-            'sessions': child_table,
-        }
-
-        # Run
-        instance._detect_relationships()
-
-        # Assert
-        expected_warning = (
-            'Could not automatically add relationships for all tables. The relationships in '
-            "the dataset are disjointed. Tables ['users', 'sessions'] are not connected to "
-            'any of the other tables.'
-        )
-        warnings_mock.warn.assert_called_once_with(expected_warning)
-        assert instance.relationships == []
-
     def test__detect_relationships_circular(self):
         """Test that relationships that invalidate the metadata are not added."""
         # Setup

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -1201,7 +1201,10 @@ class TestMultiTableMetadata:
 
         # Run and Assert
         with pytest.raises(InvalidMetadataError, match=error_msg):
-            instance._validate_all_tables_connected(instance._get_parent_map(), instance._get_child_map())
+            instance._validate_all_tables_connected(
+                instance._get_parent_map(),
+                instance._get_child_map()
+            )
 
     def test_validate_child_key_is_primary_key(self):
         """Test it crashes if the child key is a primary key."""

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -1195,21 +1195,13 @@ class TestMultiTableMetadata:
 
         # Run
         error_msg = re.escape(
-            'The metadata is not valid\n'
-            '\nTable: payments'
-            "\nInvalid regex format string '[A-z{' for id column 'date'."
-            '\n\nRelationships:'
-            "\nThe parent table 'users' does not have a primary key set. "
-            "Please use 'set_primary_key' in order to set one."
-            "\nRelationship between tables ('sessions', 'transactions') is invalid. "
-            'The primary and foreign key columns are not the same type.'
-            "\nThe relationships in the dataset are disjointed. Table ['payments'] "
-            'is not connected to any of the other tables.'
+            'The relationships in the dataset are disjointed. '
+            "Table ['payments'] is not connected to any of the other tables."
         )
 
         # Run and Assert
         with pytest.raises(InvalidMetadataError, match=error_msg):
-            instance.validate()
+            instance._validate_all_tables_connected(instance._get_parent_map(), instance._get_child_map())
 
     def test_validate_child_key_is_primary_key(self):
         """Test it crashes if the child key is a primary key."""


### PR DESCRIPTION
resolves #2047 
CU-86b092r53
[Issue](https://github.com/datacebo/SDV-Enterprise/issues/549)

Allow for disconnected schemas by removing the check.

Metadata visualization still works
All other synthesizers work fine with no relationships defined in metadata (HMA and SDV Enterprise multi-table synthesizers)
Evaluations and quality report still work (Eye test scores look fine, cardinality and intertable trends drop in score)

Does not require any other fixes for running multi-table synthesizer