### PR TITLE
Add the dummy context column to metadata and not to extra_context_column

### DIFF
--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -239,6 +239,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
 
     def _fit_context_model(self, transformed):
         LOGGER.debug(f'Fitting context synthesizer {self._context_synthesizer.__class__.__name__}')
+        context_metadata: SingleTableMetadata = self._get_context_metadata()
         if self.context_columns or self._extra_context_columns:
             context_cols = (
                 self._sequence_key + self.context_columns +
@@ -250,9 +251,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             # Add constant column to allow modeling
             constant_column = str(uuid.uuid4())
             context[constant_column] = 0
-            self._extra_context_columns[constant_column] = {'sdtype': 'numerical'}
+            context_metadata.add_column(constant_column, sdtype='numerical')
 
-        context_metadata = self._get_context_metadata()
         self._context_synthesizer = GaussianCopulaSynthesizer(
             context_metadata,
             enforce_min_max_values=self._context_synthesizer.enforce_min_max_values,

--- a/tests/integration/sequential/test_par.py
+++ b/tests/integration/sequential/test_par.py
@@ -249,3 +249,36 @@ def test_par_subset_of_data_simplified():
 
     # Assert
     assert not pd.isna(synthetic_data['date']).any()
+
+
+def test_par_missing_sequence_index():
+    """Test if PAR Synthesizer can run without a sequence key"""
+    # Setup
+    metadata_dict = {
+        'columns': {
+            'value': {
+                'sdtype': 'numerical'
+            },
+            'e_id': {
+                'sdtype': 'id'
+            }
+        },
+        'METADATA_SPEC_VERSION': 'SINGLE_TABLE_V1',
+        'sequence_key': 'e_id'
+    }
+
+    metadata = SingleTableMetadata().load_from_dict(metadata_dict)
+
+    data = pd.DataFrame({
+        'value': [10, 20, 30],
+        'e_id': [1, 2, 3]
+    })
+
+    # Run
+    synthesizer = PARSynthesizer(metadata)
+    synthesizer.fit(data)
+    sampled = synthesizer.sample(num_sequences=3)
+
+    # Assert
+    assert sampled.shape == data.shape
+    assert (sampled.dtypes == data.dtypes).all()


### PR DESCRIPTION
resolves #1972 
CU-86b08wr44

When sequence index is missing, par.py adds a constant column to allow for modeling as seen [here](https://github.com/sdv-dev/SDV/blob/main/sdv/sequential/par.py#L250). The added context column does not exist in the data though causing KeyErrors.

We only need the dummy column for context so only add it to metadata and not to extra_context_column which has downstream effects.