### PR TITLE
Do not enforce min/max on sequence index column

### DIFF
--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -194,6 +194,28 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
 
         return data
 
+    def auto_assign_transformers(self, data):
+        """Automatically assign the required transformers for the given data and constraints.
+
+        This method will automatically set a configuration to the ``rdt.HyperTransformer``
+        with the required transformers for the current data.
+
+        Args:
+            data (dict):
+                Mapping of table name to pandas.DataFrame.
+
+        Raises:
+            InvalidDataError:
+                If a table of the data is not present in the metadata.
+        """
+        super().auto_assign_transformers(data)
+
+        # Ensure that sequence index does not get auto assigned with enforce_min_max_values
+        if self._sequence_index:
+            sequence_index_transformer = self.get_transformers()[self._sequence_index]
+            if sequence_index_transformer.enforce_min_max_values:
+                sequence_index_transformer.enforce_min_max_values = False
+
     def _preprocess(self, data):
         """Transform the raw data to numerical space.
 
@@ -216,9 +238,6 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         preprocessed = super()._preprocess(data)
 
         if self._sequence_index:
-            sequence_index_transformer = self.get_transformers()[self._sequence_index]
-            if sequence_index_transformer.enforce_min_max_values:
-                sequence_index_transformer.enforce_min_max_values = False
             preprocessed = self._transform_sequence_index(preprocessed)
 
         return preprocessed

--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -216,6 +216,9 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         preprocessed = super()._preprocess(data)
 
         if self._sequence_index:
+            sequence_index_transformer = self.get_transformers()[self._sequence_index]
+            if sequence_index_transformer.enforce_min_max_values:
+                sequence_index_transformer.enforce_min_max_values = False
             preprocessed = self._transform_sequence_index(preprocessed)
 
         return preprocessed

--- a/tests/integration/sequential/test_par.py
+++ b/tests/integration/sequential/test_par.py
@@ -307,7 +307,6 @@ def test_par_unique_sequence_index_with_enforce_min_max():
     })
     test_df[['visits', 'pre_date']] = test_df[['visits', 'pre_date']].apply(
         pd.to_datetime, format='%Y-%m-%d', errors='coerce')
-    test_df['pre_date'] = pd.to_datetime(test_df['pre_date'], unit='ns').astype(int)
     metadata = SingleTableMetadata()
     metadata.detect_from_dataframe(test_df)
     metadata.update_column(column_name='s_key', sdtype='id')

--- a/tests/integration/sequential/test_par.py
+++ b/tests/integration/sequential/test_par.py
@@ -310,7 +310,6 @@ def test_par_unique_sequence_index_with_enforce_min_max():
     test_df['pre_date'] = pd.to_datetime(test_df['pre_date'], unit='ns').astype(int)
     metadata = SingleTableMetadata()
     metadata.detect_from_dataframe(test_df)
-    metadata.update_column(column_name='pre_date', sdtype='numerical')
     metadata.update_column(column_name='s_key', sdtype='id')
     metadata.set_sequence_key('s_key')
     metadata.set_sequence_index('visits')

--- a/tests/unit/sequential/test_par.py
+++ b/tests/unit/sequential/test_par.py
@@ -340,6 +340,9 @@ class TestPARSynthesizer:
         par._transform_sequence_index = Mock()
         par.auto_assign_transformers = Mock()
         par.update_transformers = Mock()
+        get_transform_mock = Mock()
+        get_transform_mock.return_value = {'time': Mock()}
+        par.get_transformers = get_transform_mock
         par._data_processor._prepared_for_fitting = True
         data = self.get_data()
 


### PR DESCRIPTION
resolves #2031 
CU-86b0me61g



Do not enforce min/max on sequence index column so it does not cause duplication of the seq_index