### PR TITLE
Always create a sample size of 1 no matter how small the scale.

### DIFF
--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -287,7 +287,7 @@ class BaseHierarchicalSampler():
 
         if send_min_sample_warning:
             warn_msg = (
-                "The 'scale' parameter it too small. Some tables may have 1 row."
+                "The 'scale' parameter is too small. Some tables may have 1 row."
                 ' For better quality data, please choose a larger scale.'
             )
             warnings.warn(warn_msg)

--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -139,7 +139,7 @@ class BaseHierarchicalSampler():
             sampled_data (dict):
                 A dictionary mapping table names to sampled data (pd.DataFrame).
         """
-        total_num_rows = max(round(self._table_sizes[child_name] * scale), 1)
+        total_num_rows = round(self._table_sizes[child_name] * scale)
         for foreign_key in self.metadata._get_foreign_keys(table_name, child_name):
             num_rows_key = f'__{child_name}__{foreign_key}__num_rows'
             min_rows = getattr(self, '_min_child_rows', {num_rows_key: 0})[num_rows_key]

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -1853,7 +1853,7 @@ def test_small_sample():
 
     # Run and Assert
     warn_msg = re.escape(
-        "The 'scale' parameter it too small. Some tables may have 1 row."
+        "The 'scale' parameter is too small. Some tables may have 1 row."
         ' For better quality data, please choose a larger scale.'
     )
     with pytest.warns(Warning, match=warn_msg):

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -1839,3 +1839,27 @@ def test_disjointed_tables():
     # Assert
     for table in real_data:
         assert list(real_data[table].columns) == list(disjoin_synthetic_data[table].columns)
+
+
+def test_small_sample():
+    """Test that the sample function still works with a small scale"""
+    # Setup
+    data, metadata = download_demo(
+        modality='multi_table',
+        dataset_name='fake_hotels'
+    )
+    synthesizer = HMASynthesizer(metadata)
+    synthesizer.fit(data)
+
+    # Run and Assert
+    warn_msg = re.escape(
+        "The 'scale' parameter it too small. Some tables may have 1 row."
+        ' For better quality data, please choose a larger scale.'
+    )
+    with pytest.warns(Warning, match=warn_msg):
+        synthetic_data = synthesizer.sample(scale=0.01)
+
+    assert (len(synthetic_data['hotels']) == 1)
+    assert (len(synthetic_data['guests']) >= len(data['guests']) * .01)
+    assert synthetic_data['hotels'].columns.tolist() == data['hotels'].columns.tolist()
+    assert synthetic_data['guests'].columns.tolist() == data['guests'].columns.tolist()

--- a/tests/unit/sampling/test_hierarchical_sampler.py
+++ b/tests/unit/sampling/test_hierarchical_sampler.py
@@ -667,3 +667,33 @@ class TestBaseHierarchicalSampler():
 
         # Assert
         assert data['parent']['__child__fk__num_rows'].to_list() == [2, 2, 4]
+
+    def test___enforce_table_size_too_small_sample(self):
+        """Test it enforces the sampled data to have the same size as the real data.
+
+        If the sample scale is too small ensure that the function doesn't error out.
+        """
+        # Setup
+        instance = MagicMock()
+        data = {
+            'parent': pd.DataFrame({
+                'fk': ['a', 'b', 'c'],
+                '__child__fk__num_rows': [1, 2, 3]
+            })
+        }
+        instance.metadata._get_foreign_keys.return_value = ['fk']
+        instance._min_child_rows = {'__child__fk__num_rows': 1}
+        instance._max_child_rows = {'__child__fk__num_rows': 3}
+        instance._table_sizes = {'child': 4}
+
+        # Run
+        BaseHierarchicalSampler._enforce_table_size(
+            instance,
+            'child',
+            'parent',
+            .001,
+            data
+        )
+
+        # Assert
+        assert data['parent']['__child__fk__num_rows'].to_list() == [0, 0, 0]


### PR DESCRIPTION
resolves #2045 
CU-86b0reety

Make sure that the minimum size of root tables of 1 is used for sampling of small scales to avoid errors. Throw a warning that sample size should be bigger for better quality data as cardinality will likely no be accurate. 

