### PR TITLE
Numerical unknowns should not be converted to sdv-pii-????

### DIFF
--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -587,13 +587,23 @@ class DataProcessor:
 
             elif sdtype == 'unknown':
                 sdtypes[column] = 'pii'
-                transformers[column] = AnonymizedFaker(
-                    function_name='bothify',
-                )
-                transformers[column].function_kwargs = {
+                function_name = 'bothify'
+                function_kwargs = {
                     'text': 'sdv-pii-?????',
                     'letters': '0123456789abcdefghijklmnopqrstuvwxyz',
                 }
+                if pd.api.types.is_numeric_dtype(data[column]):
+                    digits = data[column].apply(lambda x: len(str(abs(x))))
+                    max_digits = max(digits)
+                    text = '!' * max_digits
+                    function_name = 'numerify'
+                    function_kwargs = {
+                        'text': text,
+                    }
+                transformers[column] = AnonymizedFaker(
+                    function_name=function_name,
+                )
+                transformers[column].function_kwargs = function_kwargs
 
             elif pii:
                 sdtypes[column] = 'pii'

--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -595,7 +595,8 @@ class DataProcessor:
                 if pd.api.types.is_numeric_dtype(data[column]):
                     digits = data[column].apply(lambda x: len(str(abs(x))))
                     max_digits = max(digits)
-                    text = '!' * max_digits
+                    min_digits = min(digits)
+                    text = ('!' * (max_digits - min_digits)) + '%' + ('#' * (min_digits - 1))
                     function_name = 'numerify'
                     function_kwargs = {
                         'text': text,

--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -593,9 +593,8 @@ class DataProcessor:
                     'letters': '0123456789abcdefghijklmnopqrstuvwxyz',
                 }
                 if pd.api.types.is_numeric_dtype(data[column]):
-                    digits = data[column].apply(lambda x: len(str(abs(x))))
-                    max_digits = max(digits)
-                    min_digits = min(digits)
+                    max_digits = len(str(abs(max(data[column]))))
+                    min_digits = len(str(abs(min(data[column]))))
                     text = ('!' * (max_digits - min_digits)) + '%' + ('#' * (min_digits - 1))
                     function_name = 'numerify'
                     function_kwargs = {

--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -244,6 +244,13 @@ class BaseHierarchicalSampler:
             synthesizer = self._table_synthesizers.get(table_name)
             dtypes = synthesizer._data_processor._dtypes
             for name, dtype in dtypes.items():
+                is_pii = (
+                    self.metadata.tables.get(table_name, {}).columns.get(name, {}).get('pii', False)
+                )
+                # If pii column, the original dtype should be converted to object and not the original type
+                # as the reverse transform will remain in a pii format
+                if is_pii:
+                    dtype = 'object'
                 table_rows[name] = table_rows[name].dropna().astype(dtype)
 
             final_data[table_name] = table_rows[list(dtypes.keys())]

--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -245,7 +245,7 @@ class BaseHierarchicalSampler:
                     table_rows[name] = table_rows[name].dropna().astype(dtype)
                 except Exception:
                     LOGGER.info(
-                        'Could not cast back to transformer dtype, keeping original typing.'
+                        "Could not cast back to column's original dtype, keeping original typing."
                     )
                     table_rows[name] = table_rows[name].dropna()
 

--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -243,9 +243,9 @@ class BaseHierarchicalSampler:
             for name, dtype in dtypes.items():
                 try:
                     table_rows[name] = table_rows[name].dropna().astype(dtype)
-                except:
+                except Exception:
                     LOGGER.info(
-                        f'Could not cast back to transformer dtype, keeping original typing.'
+                        'Could not cast back to transformer dtype, keeping original typing.'
                     )
                     table_rows[name] = table_rows[name].dropna()
 

--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -251,6 +251,7 @@ class BaseHierarchicalSampler:
                 # as the reverse transform will remain in a pii format
                 if is_pii:
                     dtype = 'object'
+
                 table_rows[name] = table_rows[name].dropna().astype(dtype)
 
             final_data[table_name] = table_rows[list(dtypes.keys())]

--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -247,7 +247,7 @@ class BaseHierarchicalSampler:
                 is_pii = (
                     self.metadata.tables.get(table_name, {}).columns.get(name, {}).get('pii', False)
                 )
-                # If pii column, the original dtype should be converted to object and not the original type
+                # If pii column, the original dtype should be converted to object and not the transformer dtype
                 # as the reverse transform will remain in a pii format
                 if is_pii:
                     dtype = 'object'

--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -244,15 +244,13 @@ class BaseHierarchicalSampler:
             synthesizer = self._table_synthesizers.get(table_name)
             dtypes = synthesizer._data_processor._dtypes
             for name, dtype in dtypes.items():
-                is_pii = (
-                    self.metadata.tables.get(table_name, {}).columns.get(name, {}).get('pii', False)
-                )
-                # If pii column, the original dtype should be converted to object and not the transformer dtype
-                # as the reverse transform will remain in a pii format
-                if is_pii:
-                    dtype = 'object'
-
-                table_rows[name] = table_rows[name].dropna().astype(dtype)
+                try:
+                    table_rows[name] = table_rows[name].dropna().astype(dtype)
+                except:
+                    LOGGER.info(
+                        f'Could not cast back to transformer dtype, keeping original typing.'
+                    )
+                    table_rows[name] = table_rows[name].dropna()
 
             final_data[table_name] = table_rows[list(dtypes.keys())]
 

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -1398,7 +1398,7 @@ class TestHMASynthesizer:
         table2 = pd.DataFrame({
             'company': [fake.company() for i in range(20)],
             'employee_count': np.random.randint(15, 4000, 20),
-            'revenue': np.random.randint(100_000, 4_000_000_000),
+            'revenue': np.random.randint(100_000, 1_000_000_000),
         })
 
         tables_dict = {'people': table1, 'company': table2}

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -1412,19 +1412,24 @@ class TestHMASynthesizer:
         sample_data = synth.sample(1)
 
         # Assert
-        expected_people_dtypes = pd.Series({
-            'name': 'object',
-            'salary': 'int64',
-            'age': 'int64',
-            'address': 'object',
-        })
-        expected_company_dtypes = pd.Series({
-            'company': 'object',
-            'employee_count': 'int64',
-            'revenue': 'int64',
-        })
-        pd.testing.assert_series_equal(sample_data['people'].dtypes, expected_people_dtypes)
-        pd.testing.assert_series_equal(sample_data['company'].dtypes, expected_company_dtypes)
+        people_sample = sample_data['people']
+        company_sample = sample_data['company']
+
+        # Since these values are inferred, windows and mac may have different int types
+        # so check if it is numeric
+        numeric_data = [
+            people_sample['salary'],
+            people_sample['age'],
+            company_sample['employee_count'],
+            company_sample['revenue'],
+        ]
+        object_data = [
+            people_sample['name'].dtype,
+            people_sample['address'].dtype,
+            company_sample['company'].dtype,
+        ]
+        assert all(pd.api.types.is_numeric_dtype(dtype) for dtype in numeric_data)
+        assert all(dtype == 'object' for dtype in object_data)
 
 
 @pytest.mark.parametrize('num_rows', [(10), (1000)])

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -894,8 +894,6 @@ class TestDataProcessor:
         )
 
         # Assert
-        print(output)
-        print(mock_rdt.transformers.RegexGenerator.return_value)
         assert output == mock_rdt.transformers.RegexGenerator.return_value
         mock_rdt.transformers.RegexGenerator.assert_called_once_with(
             regex_format='ID_00', enforce_uniqueness=True, generation_order='scrambled'

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -1419,6 +1419,24 @@ class TestDataProcessor:
         assert isinstance(config['transformers']['phone_number'], AnonymizedFaker)
         assert isinstance(config['transformers']['email'], CustomTransformer)
 
+    def test__create_config_with_unknown_numerical_data(self):
+        """Test the ``_create_config`` method with unknown numerical columns."""
+        # Setup
+        data = pd.DataFrame({
+            'numerical_column': [12321, 198, 1958],
+        })
+        metadata = SingleTableMetadata().load_from_dict({
+            'METADATA_SPEC_VERSION': 'SINGLE_TABLE_V1',
+            'columns': {'numerical_column': {'sdtype': 'unknown', 'pii': True}},
+        })
+        dp = DataProcessor(metadata)
+
+        # Run
+        config = dp._create_config(data, set())
+
+        # Assert
+        assert config['transformers']['numerical_column'].function_kwargs['text'] == '!!%##'
+
     def test_update_transformers_not_fitted(self):
         """Test when ``self._hyper_transformer`` is ``None`` raises a ``NotFittedError``."""
         # Setup

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -894,6 +894,8 @@ class TestDataProcessor:
         )
 
         # Assert
+        print(output)
+        print(mock_rdt.transformers.RegexGenerator.return_value)
         assert output == mock_rdt.transformers.RegexGenerator.return_value
         mock_rdt.transformers.RegexGenerator.assert_called_once_with(
             regex_format='ID_00', enforce_uniqueness=True, generation_order='scrambled'

--- a/tests/unit/multi_table/test_hma.py
+++ b/tests/unit/multi_table/test_hma.py
@@ -335,6 +335,15 @@ class TestHMASynthesizer:
         # Setup
         instance = Mock()
         metadata = Mock()
+        # Mock metadata
+        metadata.tables = MagicMock()
+        mock_table = MagicMock()
+        metadata.tables.get.side_effect = lambda table_name, default: mock_table
+        mock_table.columns = MagicMock()
+        mock_column = MagicMock()
+        mock_table.columns.get.side_effect = lambda column_name, default: mock_column
+        mock_column.get.side_effect = lambda key, default: {'pii': False}.get(key, default)
+
         metadata._get_parent_map.return_value = {
             'sessions': ['users'],
             'transactions': ['sessions'],

--- a/tests/unit/multi_table/test_hma.py
+++ b/tests/unit/multi_table/test_hma.py
@@ -154,8 +154,7 @@ class TestHMASynthesizer:
 
         # Assert
         expected = pd.DataFrame({'__nesreca__id_upravna_enota__num_rows': [1, 1, 1, 1]})
-        instance._get_pbar_args.assert_called_once_with(
-            desc="(1/2) Tables 'A' and 'B' ('user_id')")
+        instance._get_pbar_args.assert_called_once_with(desc="(1/2) Tables 'A' and 'B' ('user_id')")
 
         pd.testing.assert_frame_equal(result, expected)
 
@@ -211,8 +210,7 @@ class TestHMASynthesizer:
         # Setup
         instance = Mock()
         instance.metadata._get_all_foreign_keys.return_value = ['a', 'b']
-        table_data = pd.DataFrame({'a': [1, 2, 3], 'b': [2, 3, 4],
-                                  'c': ['John', 'Doe', 'Johanna']})
+        table_data = pd.DataFrame({'a': [1, 2, 3], 'b': [2, 3, 4], 'c': ['John', 'Doe', 'Johanna']})
 
         # Run
         result = HMASynthesizer._pop_foreign_keys(instance, table_data, 'table_name')
@@ -372,8 +370,7 @@ class TestHMASynthesizer:
             'country': str,
         }
         transactions_synth = Mock()
-        transactions_synth._data_processor._dtypes = {
-            'transaction_id': np.int64, 'session_id': str}
+        transactions_synth._data_processor._dtypes = {'transaction_id': np.int64, 'session_id': str}
 
         instance._table_synthesizers = {
             'users': users_synth,
@@ -467,8 +464,7 @@ class TestHMASynthesizer:
         instance.metadata._get_foreign_keys.return_value = ['session_id']
         instance._table_parameters = {'users': {'a': 1}}
         instance._table_synthesizers = {'users': table_synthesizer}
-        instance._default_parameters = {
-            'users': {'colA': 'default_param', 'colB': 'default_param'}}
+        instance._default_parameters = {'users': {'colA': 'default_param', 'colB': 'default_param'}}
 
         # Run
         synthesizer = HMASynthesizer._recreate_child_synthesizer(

--- a/tests/unit/multi_table/test_hma.py
+++ b/tests/unit/multi_table/test_hma.py
@@ -154,7 +154,8 @@ class TestHMASynthesizer:
 
         # Assert
         expected = pd.DataFrame({'__nesreca__id_upravna_enota__num_rows': [1, 1, 1, 1]})
-        instance._get_pbar_args.assert_called_once_with(desc="(1/2) Tables 'A' and 'B' ('user_id')")
+        instance._get_pbar_args.assert_called_once_with(
+            desc="(1/2) Tables 'A' and 'B' ('user_id')")
 
         pd.testing.assert_frame_equal(result, expected)
 
@@ -210,7 +211,8 @@ class TestHMASynthesizer:
         # Setup
         instance = Mock()
         instance.metadata._get_all_foreign_keys.return_value = ['a', 'b']
-        table_data = pd.DataFrame({'a': [1, 2, 3], 'b': [2, 3, 4], 'c': ['John', 'Doe', 'Johanna']})
+        table_data = pd.DataFrame({'a': [1, 2, 3], 'b': [2, 3, 4],
+                                  'c': ['John', 'Doe', 'Johanna']})
 
         # Run
         result = HMASynthesizer._pop_foreign_keys(instance, table_data, 'table_name')
@@ -335,7 +337,6 @@ class TestHMASynthesizer:
         # Setup
         instance = Mock()
         metadata = Mock()
-
         metadata._get_parent_map.return_value = {
             'sessions': ['users'],
             'transactions': ['sessions'],
@@ -371,7 +372,8 @@ class TestHMASynthesizer:
             'country': str,
         }
         transactions_synth = Mock()
-        transactions_synth._data_processor._dtypes = {'transaction_id': np.int64, 'session_id': str}
+        transactions_synth._data_processor._dtypes = {
+            'transaction_id': np.int64, 'session_id': str}
 
         instance._table_synthesizers = {
             'users': users_synth,
@@ -465,7 +467,8 @@ class TestHMASynthesizer:
         instance.metadata._get_foreign_keys.return_value = ['session_id']
         instance._table_parameters = {'users': {'a': 1}}
         instance._table_synthesizers = {'users': table_synthesizer}
-        instance._default_parameters = {'users': {'colA': 'default_param', 'colB': 'default_param'}}
+        instance._default_parameters = {
+            'users': {'colA': 'default_param', 'colB': 'default_param'}}
 
         # Run
         synthesizer = HMASynthesizer._recreate_child_synthesizer(

--- a/tests/unit/multi_table/test_hma.py
+++ b/tests/unit/multi_table/test_hma.py
@@ -335,14 +335,6 @@ class TestHMASynthesizer:
         # Setup
         instance = Mock()
         metadata = Mock()
-        # Mock metadata
-        metadata.tables = MagicMock()
-        mock_table = MagicMock()
-        metadata.tables.get.side_effect = lambda table_name, default: mock_table
-        mock_table.columns = MagicMock()
-        mock_column = MagicMock()
-        mock_table.columns.get.side_effect = lambda column_name, default: mock_column
-        mock_column.get.side_effect = lambda key, default: {'pii': False}.get(key, default)
 
         metadata._get_parent_map.return_value = {
             'sessions': ['users'],

--- a/tests/unit/sampling/test_hierarchical_sampler.py
+++ b/tests/unit/sampling/test_hierarchical_sampler.py
@@ -373,14 +373,6 @@ class TestBaseHierarchicalSampler:
         # Setup
         instance = Mock()
         metadata = Mock()
-        # Mock metadata
-        metadata.tables = MagicMock()
-        mock_table = MagicMock()
-        metadata.tables.get.side_effect = lambda table_name, default: mock_table
-        mock_table.columns = MagicMock()
-        mock_column = MagicMock()
-        mock_table.columns.get.side_effect = lambda column_name, default: mock_column
-        mock_column.get.side_effect = lambda key, default: {'pii': False}.get(key, default)
         metadata._get_parent_map.return_value = {
             'sessions': ['users'],
             'transactions': ['sessions'],

--- a/tests/unit/sampling/test_hierarchical_sampler.py
+++ b/tests/unit/sampling/test_hierarchical_sampler.py
@@ -373,6 +373,14 @@ class TestBaseHierarchicalSampler:
         # Setup
         instance = Mock()
         metadata = Mock()
+        # Mock metadata
+        metadata.tables = MagicMock()
+        mock_table = MagicMock()
+        metadata.tables.get.side_effect = lambda table_name, default: mock_table
+        mock_table.columns = MagicMock()
+        mock_column = MagicMock()
+        mock_table.columns.get.side_effect = lambda column_name, default: mock_column
+        mock_column.get.side_effect = lambda key, default: {'pii': False}.get(key, default)
         metadata._get_parent_map.return_value = {
             'sessions': ['users'],
             'transactions': ['sessions'],


### PR DESCRIPTION
resolves #2064 
CU-86b0wh849

PII Type adds the prefix `sdv-pii`. If the sdtype is unknown, the transformers will auto-assign but the reverse transform for a `pii` sdtype should always have the dtype of `object` as it will contain a prefix. If a numerical column is detected we will add change the `Faker` function to use `numerify` and cap at the max amount of digits.

Adjusted some unit test to avoid test failures due to mocking