### PR TITLE
Ensure that primary and sequence keys cannot be the same

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,6 @@ select = [
     "PD"
 ]
 ignore = [
-    "E501",
     # pydocstyle
     "D107",  # Missing docstring in __init__
     "D417",   # Missing argument descriptions in the docstring, this is a bug from pydocstyle: https://github.com/PyCQA/pydocstyle/issues/449

--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -128,7 +128,8 @@ class Constraint(metaclass=ConstraintMeta):
         if missing_values:
             errors.append(
                 ValueError(
-                    f'Missing required values {missing_values} in {article} {constraint} constraint.'
+                    f'Missing required values {missing_values} '
+                    f'in {article} {constraint} constraint.'
                 )
             )
 
@@ -136,7 +137,8 @@ class Constraint(metaclass=ConstraintMeta):
         if invalid_vals:
             errors.append(
                 ValueError(
-                    f'Invalid values {invalid_vals} are present in {article} {constraint} constraint.'
+                    f'Invalid values {invalid_vals} are present '
+                    f'in {article} {constraint} constraint.'
                 )
             )
 

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -666,12 +666,12 @@ class SingleTableMetadata:
                 raise InvalidMetadataError(f"'{key_type}_key' must be a string.")
 
             keys = {column_name} if isinstance(column_name, str) else set(column_name)
-            set_sequence_as_primary = key_type == 'primary' and column_name == self.sequence_key
-            set_primary_as_sequence = key_type == 'sequence' and column_name == self.primary_key
-            if set_sequence_as_primary or set_primary_as_sequence:
+            setting_sequence_as_primary = key_type == 'primary' and column_name == self.sequence_key
+            setting_primary_as_sequence = key_type == 'sequence' and column_name == self.primary_key
+            if setting_sequence_as_primary or setting_primary_as_sequence:
                 raise InvalidMetadataError(
-                    f'The column ({column_name}) cannot be set as {key_type}_key as it is already'
-                    f" set as the {'sequence' if key_type == 'primary' else 'primary'}_key."
+                    f'The column ({column_name}) cannot be set as {key_type}_key as it is already '
+                    f"set as the {'sequence' if key_type == 'primary' else 'primary'}_key."
                 )
 
             invalid_ids = keys - set(self.columns)

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -666,6 +666,14 @@ class SingleTableMetadata:
                 raise InvalidMetadataError(f"'{key_type}_key' must be a string.")
 
             keys = {column_name} if isinstance(column_name, str) else set(column_name)
+            if (key_type == 'primary' and column_name == self.sequence_key) or (
+                key_type == 'sequence' and column_name == self.primary_key
+            ):
+                raise InvalidMetadataError(
+                    f'The column ({column_name}) cannot be set as {key_type}_key as it is already set as the '
+                    f"{'sequence' if key_type == 'primary' else 'primary'}_key."
+                )
+
             invalid_ids = keys - set(self.columns)
             if invalid_ids:
                 raise InvalidMetadataError(

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -666,12 +666,12 @@ class SingleTableMetadata:
                 raise InvalidMetadataError(f"'{key_type}_key' must be a string.")
 
             keys = {column_name} if isinstance(column_name, str) else set(column_name)
-            setting_sequence_as_primary = key_type == 'primary' and column_name == self.sequence_key
-            setting_primary_as_sequence = key_type == 'sequence' and column_name == self.primary_key
-            if setting_sequence_as_primary or setting_primary_as_sequence:
+            set_sequence_as_primary = key_type == 'primary' and column_name == self.sequence_key
+            set_primary_as_sequence = key_type == 'sequence' and column_name == self.primary_key
+            if set_sequence_as_primary or set_primary_as_sequence:
                 raise InvalidMetadataError(
-                    f'The column ({column_name}) cannot be set as {key_type}_key as it is already set as the '
-                    f"{'sequence' if key_type == 'primary' else 'primary'}_key."
+                    f'The column ({column_name}) cannot be set as {key_type}_key as it is already'
+                    f" set as the {'sequence' if key_type == 'primary' else 'primary'}_key."
                 )
 
             invalid_ids = keys - set(self.columns)

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -666,9 +666,9 @@ class SingleTableMetadata:
                 raise InvalidMetadataError(f"'{key_type}_key' must be a string.")
 
             keys = {column_name} if isinstance(column_name, str) else set(column_name)
-            if (key_type == 'primary' and column_name == self.sequence_key) or (
-                key_type == 'sequence' and column_name == self.primary_key
-            ):
+            setting_sequence_as_primary = key_type == 'primary' and column_name == self.sequence_key
+            setting_primary_as_sequence = key_type == 'sequence' and column_name == self.primary_key
+            if setting_sequence_as_primary or setting_primary_as_sequence:
                 raise InvalidMetadataError(
                     f'The column ({column_name}) cannot be set as {key_type}_key as it is already set as the '
                     f"{'sequence' if key_type == 'primary' else 'primary'}_key."

--- a/tests/integration/metadata/test_single_table.py
+++ b/tests/integration/metadata/test_single_table.py
@@ -487,3 +487,67 @@ def test_column_relationship_validation():
     # Run and Assert
     with pytest.raises(InvalidMetadataError, match=expected_message):
         metadata.validate()
+
+
+def test_metadata_validate_same_sequence_primary():
+    """Test metadata validation when both primary and sequence keys are the same."""
+    # Setup
+    metadata = SingleTableMetadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'id'},
+            'B': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+            'C': {'sdtype': 'numerical'},
+            'D': {'sdtype': 'categorical'},
+        },
+        'primary_key': 'A',
+        'sequence_key': 'A',
+    })
+
+    expected_message = re.escape(
+        'The following errors were found in the metadata:\n\n'
+        'The column (A) cannot be set as primary_key as it is already set as the sequence_key.\n'
+        'The column (A) cannot be set as sequence_key as it is already set as the primary_key.'
+    )
+
+    # Run and Assert
+    with pytest.raises(InvalidMetadataError, match=expected_message):
+        metadata.validate()
+
+
+def test_metadata_set_same_sequence_primary():
+    """Test metadata throws error when setting the sequence and primary keys to be the same."""
+    # Setup
+    metadata_sequence = SingleTableMetadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'id'},
+            'B': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+            'C': {'sdtype': 'numerical'},
+            'D': {'sdtype': 'categorical'},
+        },
+    })
+
+    # Run and Assert
+    metadata_sequence.set_sequence_key('A')
+    error_msg_sequence = re.escape(
+        'The column (A) cannot be set as primary_key as it is already set as the sequence_key.'
+    )
+    with pytest.raises(InvalidMetadataError, match=error_msg_sequence):
+        metadata_sequence.set_primary_key('A')
+
+    # Setup primary first
+    metadata_primary = SingleTableMetadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'id'},
+            'B': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+            'C': {'sdtype': 'numerical'},
+            'D': {'sdtype': 'categorical'},
+        },
+    })
+
+    # Run and Assert
+    metadata_primary.set_primary_key('A')
+    error_msg_sequence = re.escape(
+        'The column (A) cannot be set as sequence_key as it is already set as the primary_key.'
+    )
+    with pytest.raises(InvalidMetadataError, match=error_msg_sequence):
+        metadata_primary.set_sequence_key('A')

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -1541,6 +1541,27 @@ class TestSingleTableMetadata:
         # Assert
         assert out is False
 
+    def test__validate_key_sequence_and_primary_key_same(self):
+        """Test ``_validate_key`` for a column used as both sequence and primary keys."""
+        # Setup
+        instance_primary = SingleTableMetadata()
+        instance_primary.primary_key = 'A'
+        error_msg_primary = re.escape(
+            'The column (A) cannot be set as sequence_key as it is already set as the primary_key.'
+        )
+
+        instance_sequence = SingleTableMetadata()
+        instance_sequence.sequence_key = 'A'
+        error_msg_sequence = re.escape(
+            'The column (A) cannot be set as primary_key as it is already set as the sequence_key.'
+        )
+
+        # Run and Assert
+        with pytest.raises(InvalidMetadataError, match=error_msg_primary):
+            instance_primary._validate_key('A', 'sequence')
+        with pytest.raises(InvalidMetadataError, match=error_msg_sequence):
+            instance_sequence._validate_key('A', 'primary')
+
     def test_set_primary_key_validation_dtype(self):
         """Test that ``set_primary_key`` crashes for invalid arguments.
 


### PR DESCRIPTION
resolves #2096 
CU-86b11yb3u

Make sure `_validate_key` prevents `primary_key` from being the same as `sequence_key`