### PR TITLE
Make sure categorical data stays categorical in par synthesizer

### DIFF
--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -334,7 +334,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         context_metadata: SingleTableMetadata = self._get_context_metadata()
         if self.context_columns or self._extra_context_columns:
             context_cols = (
-                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns +
+                list(self._extra_context_columns.keys())
             )
             context = transformed[context_cols]
         else:
@@ -361,7 +362,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             for column in timeseries_data.columns
             if column
             not in (
-                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns +
+                list(self._extra_context_columns.keys())
             )
         ]
 
@@ -380,6 +382,10 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             kind = dtype.kind
             if kind in ('i', 'f'):
                 data_type = 'continuous'
+                # Check if metadata overrides this data type
+                if field in self.metadata.columns:
+                    if self.metadata.columns[field].get('sdtype', None) == 'categorical':
+                        data_type = 'categorical'
             elif kind in ('O', 'b'):
                 data_type = 'categorical'
             else:

--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -381,9 +381,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             if kind in ('i', 'f'):
                 data_type = 'continuous'
                 # Check if metadata overrides this data type
-                if field in self.metadata.columns:
-                    if self.metadata.columns[field].get('sdtype', None) == 'categorical':
-                        data_type = 'categorical'
+                if self.metadata.columns.get(field, {}).get('sdtype', None) == 'categorical':
+                    data_type = 'categorical'
             elif kind in ('O', 'b'):
                 data_type = 'categorical'
             else:

--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -334,8 +334,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         context_metadata: SingleTableMetadata = self._get_context_metadata()
         if self.context_columns or self._extra_context_columns:
             context_cols = (
-                self._sequence_key + self.context_columns +
-                list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
             )
             context = transformed[context_cols]
         else:
@@ -362,8 +361,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             for column in timeseries_data.columns
             if column
             not in (
-                self._sequence_key + self.context_columns +
-                list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
             )
         ]
 

--- a/tests/integration/sequential/test_par.py
+++ b/tests/integration/sequential/test_par.py
@@ -117,7 +117,7 @@ def test_save_and_load(tmp_path):
     assert metadata == instance.metadata
 
 
-def test_sythesize_sequences(tmp_path):
+def test_synthesize_sequences(tmp_path):
     """End to end test for synthesizing sequences.
 
     The following functionalities are being tested:
@@ -404,3 +404,20 @@ def test_init_error_sequence_key_in_context():
     # Run and Assert
     with pytest.raises(SynthesizerInputError, match=sequence_key_context_column_error_msg):
         PARSynthesizer(metadata, context_columns=['A'])
+
+
+def test_par_categorical_column_represented_by_floats():
+    """Test to see if categorical columns work fine  with float representation."""
+    # Setup
+    data, metadata = download_demo('sequential', 'nasdaq100_2019')
+    data['category'] = [100.0 if i % 2 == 0 else 50.0 for i in data.index]
+    metadata.add_column('category', sdtype='categorical')
+
+    # Run
+    synth = PARSynthesizer(metadata)
+    synth.fit(data)
+    sampled = synth.sample(num_sequences=10)
+
+    # Assert
+    synth.validate(sampled)
+    assert sampled['category'].isin(data['category']).all()


### PR DESCRIPTION
resolve #1910 
CU-86b01mjx8

Ensures that categorical labeled columns do not get altered by the inferred type by pandas.