### PR TITLE
Context metadata adjusted for the transformed datetime sdtype

### DIFF
--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -337,8 +337,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         context_metadata: SingleTableMetadata = self._get_context_metadata()
         if self.context_columns or self._extra_context_columns:
             context_cols = (
-                self._sequence_key + self.context_columns +
-                list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
             )
             context = transformed[context_cols]
         else:
@@ -365,8 +364,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             for column in timeseries_data.columns
             if column
             not in (
-                self._sequence_key + self.context_columns +
-                list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
             )
         ]
 

--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -73,6 +73,9 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
 
         for column in context_columns:
             context_columns_dict[column] = self.metadata.columns[column]
+            # Context datetime SDTypes for PAR have already been converted to float timestamp
+            if context_columns_dict[column]['sdtype'] == 'datetime':
+                context_columns_dict[column] = {'sdtype': 'numerical'}
 
         for column, column_metadata in self._extra_context_columns.items():
             context_columns_dict[column] = column_metadata
@@ -334,7 +337,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         context_metadata: SingleTableMetadata = self._get_context_metadata()
         if self.context_columns or self._extra_context_columns:
             context_cols = (
-                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns +
+                list(self._extra_context_columns.keys())
             )
             context = transformed[context_cols]
         else:
@@ -361,7 +365,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             for column in timeseries_data.columns
             if column
             not in (
-                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns +
+                list(self._extra_context_columns.keys())
             )
         ]
 

--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -73,9 +73,6 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
 
         for column in context_columns:
             context_columns_dict[column] = self.metadata.columns[column]
-            # Context datetime SDTypes for PAR have already been converted to float timestamp
-            if context_columns_dict[column]['sdtype'] == 'datetime':
-                context_columns_dict[column] = {'sdtype': 'numerical'}
 
         for column, column_metadata in self._extra_context_columns.items():
             context_columns_dict[column] = column_metadata
@@ -346,6 +343,12 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             constant_column = str(uuid.uuid4())
             context[constant_column] = 0
             context_metadata.add_column(constant_column, sdtype='numerical')
+
+        for column in self.context_columns:
+            # Context datetime SDTypes for PAR have already been converted to float timestamp
+            if context_metadata.columns[column]['sdtype'] == 'datetime':
+                if pd.api.types.is_numeric_dtype(context[column]):
+                    context_metadata.update_column(column, sdtype='numerical')
 
         self._context_synthesizer = GaussianCopulaSynthesizer(
             context_metadata,

--- a/tests/integration/sequential/test_par.py
+++ b/tests/integration/sequential/test_par.py
@@ -439,6 +439,7 @@ def test_par_with_datetime_context():
     # Assert
     pd.testing.assert_series_equal(sample['birthdate'], expected_birthdate)
 
+
 def test_par_categorical_column_represented_by_floats():
     """Test to see if categorical columns work fine  with float representation."""
     # Setup

--- a/tests/integration/sequential/test_par.py
+++ b/tests/integration/sequential/test_par.py
@@ -404,3 +404,35 @@ def test_init_error_sequence_key_in_context():
     # Run and Assert
     with pytest.raises(SynthesizerInputError, match=sequence_key_context_column_error_msg):
         PARSynthesizer(metadata, context_columns=['A'])
+
+
+def test_par_with_datetime_context():
+    """Test PARSynthesizer with a datetime as a context column"""
+    # Setup
+    data = pd.DataFrame(
+        data={
+            'user_id': ['ID_00'] * 5 + ['ID_01'] * 5,
+            'birthdate': ['1995-05-06'] * 5 + ['1982-01-21'] * 5,
+            'timestamp': ['2023-06-21', '2023-06-22', '2023-06-23', '2023-06-24', '2023-06-25'] * 2,
+            'heartrate': [67, 66, 68, 65, 64, 80, 82, 91, 88, 84],
+        }
+    )
+
+    metadata = SingleTableMetadata.load_from_dict({
+        'columns': {
+            'user_id': {'sdtype': 'id', 'regex_format': 'ID_[0-9]{2}'},
+            'birthdate': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+            'timestamp': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+            'heartrate': {'sdtype': 'numerical'},
+        },
+        'sequence_key': 'user_id',
+        'sequence_index': 'timestamp',
+    })
+
+    # Run
+    synth = PARSynthesizer(metadata, epochs=50, verbose=True, context_columns=['birthdate'])
+
+    synth.fit(data)
+    sample = synth.sample(num_sequences=1)
+    expected_birthdate = pd.Series(['1984-02-23'] * 5, name='birthdate')
+    pd.testing.assert_series_equal(sample['birthdate'], expected_birthdate)

--- a/tests/unit/sequential/test_par.py
+++ b/tests/unit/sequential/test_par.py
@@ -444,8 +444,7 @@ class TestPARSynthesizer:
             'columns': {'gender': {'sdtype': 'categorical'}, 'name': {'sdtype': 'id'}}
         })
         par._context_synthesizer = initial_synthesizer
-        par._get_context_metadata = Mock()
-        par._get_context_metadata.return_value = context_metadata
+        par._get_context_metadata = Mock(return_value=context_metadata)
 
         # Run
         par._fit_context_model(data)


### PR DESCRIPTION
resolves #1485 
CU-85ztdkk6d


Since this datetime is being read incorrectly to the context model there are were a couple approaches:
- Do not transform the column before it gets to context synthesizer (unfortunately this causes errors when trying to map the context synthesizer values in the par model)
- Update transformers in the context model (cannot easily swap the transformers before validation occurs)
- Change the type of the context metadata to match

Went with last one because the context metadata is a deep copy of the metadata and is not surfaced/used to any other functionality besides fitting the context model.