### PR TITLE
Use metadata over singletablemetadata

### DIFF
--- a/latest_requirements.txt
+++ b/latest_requirements.txt
@@ -7,5 +7,5 @@ numpy==1.26.4
 pandas==2.2.2
 platformdirs==4.2.2
 rdt==1.12.2
-sdmetrics==0.14.1
+sdmetrics==0.15.0
 tqdm==4.66.4

--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -169,8 +169,8 @@ class Constraint(metaclass=ConstraintMeta):
         """Validate the metadata against the constraint.
 
         Args:
-            metadata (sdv.metadata.SingleTableMetadata):
-                Single table metadata instance.
+            metadata (sdv.metadata.Metadata):
+                Metadata instance with a single table.
             **kwargs (dict):
                 Any required kwargs for the constraint.
 

--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -18,6 +18,7 @@ from sdv.constraints.errors import (
     MissingConstraintColumnError,
 )
 from sdv.errors import ConstraintsNotMetError
+from sdv.metadata.metadata import Metadata
 
 LOGGER = logging.getLogger(__name__)
 
@@ -147,6 +148,7 @@ class Constraint(metaclass=ConstraintMeta):
 
     @classmethod
     def _validate_metadata_columns(cls, metadata, **kwargs):
+        Metadata._convert_to_unified_metadata(metadata)
         if 'column_name' in kwargs:
             column_names = [kwargs.get('column_name')]
         else:
@@ -179,6 +181,7 @@ class Constraint(metaclass=ConstraintMeta):
                 All the errors from validating the metadata.
         """
         errors = []
+        metadata = Metadata._convert_to_unified_metadata(metadata)
         try:
             cls._validate_inputs(**kwargs)
         except AggregateConstraintsError as agg_error:

--- a/sdv/constraints/base.py
+++ b/sdv/constraints/base.py
@@ -152,7 +152,7 @@ class Constraint(metaclass=ConstraintMeta):
         else:
             column_names = kwargs.get('column_names')
 
-        missing_columns = set(column_names) - set(metadata.columns) - {None}
+        missing_columns = set(column_names) - set(metadata.get_columns()) - {None}
         if missing_columns:
             article = 'An' if cls.__name__ == 'Inequality' else 'A'
             raise ConstraintMetadataError(

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -53,6 +53,7 @@ from sdv.constraints.utils import (
     revert_nans_columns,
     sigmoid,
 )
+from sdv.metadata.metadata import Metadata
 
 INEQUALITY_TO_OPERATION = {
     '>': np.greater,
@@ -251,6 +252,7 @@ class FixedCombinations(Constraint):
 
     @staticmethod
     def _validate_metadata_specific_to_constraint(metadata, **kwargs):
+        metadata = Metadata._convert_to_unified_metadata(metadata)
         invalid_columns = []
         column_names = kwargs.get('column_names')
         for column in column_names:
@@ -390,11 +392,13 @@ class Inequality(Constraint):
 
     @classmethod
     def _validate_metadata_columns(cls, metadata, **kwargs):
+        metadata = Metadata._convert_to_unified_metadata(metadata)
         kwargs['column_names'] = [kwargs.get('high_column_name'), kwargs.get('low_column_name')]
         super()._validate_metadata_columns(metadata, **kwargs)
 
     @staticmethod
     def _validate_metadata_specific_to_constraint(metadata, **kwargs):
+        metadata = Metadata._convert_to_unified_metadata(metadata)
         high = kwargs.get('high_column_name')
         low = kwargs.get('low_column_name')
         high_sdtype = metadata.get_columns().get(high, {}).get('sdtype')
@@ -599,6 +603,7 @@ class ScalarInequality(Constraint):
 
     @staticmethod
     def _validate_metadata_specific_to_constraint(metadata, **kwargs):
+        metadata = Metadata._convert_to_unified_metadata(metadata)
         column_name = kwargs.get('column_name')
         sdtype = metadata.get_columns().get(column_name, {}).get('sdtype')
         value = kwargs.get('value')
@@ -772,6 +777,7 @@ class Positive(ScalarInequality):
 
     @staticmethod
     def _validate_metadata_specific_to_constraint(metadata, **kwargs):
+        metadata = Metadata._convert_to_unified_metadata(metadata)
         column_name = kwargs.get('column_name')
         sdtype = metadata.get_columns().get(column_name, {}).get('sdtype')
         if sdtype != 'numerical':
@@ -801,6 +807,7 @@ class Negative(ScalarInequality):
 
     @staticmethod
     def _validate_metadata_specific_to_constraint(metadata, **kwargs):
+        metadata = Metadata._convert_to_unified_metadata(metadata)
         column_name = kwargs.get('column_name')
         sdtype = metadata.get_columns().get(column_name, {}).get('sdtype')
         if sdtype != 'numerical':
@@ -839,6 +846,7 @@ class Range(Constraint):
 
     @classmethod
     def _validate_metadata_columns(cls, metadata, **kwargs):
+        metadata = Metadata._convert_to_unified_metadata(metadata)
         high = kwargs.get('high_column_name')
         low = kwargs.get('low_column_name')
         middle = kwargs.get('middle_column_name')
@@ -847,6 +855,7 @@ class Range(Constraint):
 
     @staticmethod
     def _validate_metadata_specific_to_constraint(metadata, **kwargs):
+        metadata = Metadata._convert_to_unified_metadata(metadata)
         high = kwargs.get('high_column_name')
         low = kwargs.get('low_column_name')
         middle = kwargs.get('middle_column_name')
@@ -1087,6 +1096,7 @@ class ScalarRange(Constraint):
 
     @staticmethod
     def _validate_metadata_specific_to_constraint(metadata, **kwargs):
+        metadata = Metadata._convert_to_unified_metadata(metadata)
         column_name = kwargs.get('column_name')
         if column_name not in metadata.get_columns():
             raise ConstraintMetadataError(
@@ -1442,6 +1452,7 @@ class Unique(Constraint):
 
     @staticmethod
     def _validate_metadata_specific_to_constraint(metadata, **kwargs):
+        metadata = Metadata._convert_to_unified_metadata(metadata)
         column_names = kwargs.get('column_names')
         keys = set()
         if isinstance(metadata.get_primary_key(), tuple):

--- a/sdv/io/local/local.py
+++ b/sdv/io/local/local.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from sdv.metadata import MultiTableMetadata
+from sdv.metadata import Metadata
 
 
 class BaseLocalHandler:
@@ -25,11 +25,11 @@ class BaseLocalHandler:
                 Dictionary of table names to dataframes.
 
         Returns:
-            MultiTableMetadata:
-                An ``sdv.metadata.MultiTableMetadata`` object with the detected metadata
+            Metadata:
+                An ``sdv.metadata.Metadata`` object with the detected metadata
                 properties from the data.
         """
-        metadata = MultiTableMetadata()
+        metadata = Metadata()
         metadata.detect_from_dataframes(data)
         return metadata
 

--- a/sdv/lite/single_table.py
+++ b/sdv/lite/single_table.py
@@ -8,7 +8,7 @@ import warnings
 import cloudpickle
 
 from sdv.metadata.metadata import Metadata
-from sdv.metadata.single_table import DEPRECATION_MSG as sdv_DEPRECATION_MSG
+from sdv.metadata.single_table import DEPRECATION_MSG as SDV_DEPRECATION_MSG
 from sdv.metadata.single_table import SingleTableMetadata
 from sdv.single_table import GaussianCopulaSynthesizer
 
@@ -55,7 +55,7 @@ class SingleTablePreset:
         if name == FAST_ML_PRESET:
             if isinstance(metadata, SingleTableMetadata):
                 metadata = Metadata().load_from_dict(metadata.to_dict())
-                warnings.warn(sdv_DEPRECATION_MSG, FutureWarning)
+                warnings.warn(SDV_DEPRECATION_MSG, FutureWarning)
             self._setup_fast_preset(metadata, self.locales)
 
     def add_constraints(self, constraints):

--- a/sdv/lite/single_table.py
+++ b/sdv/lite/single_table.py
@@ -7,6 +7,9 @@ import warnings
 
 import cloudpickle
 
+from sdv.metadata.metadata import Metadata
+from sdv.metadata.single_table import DEPRECATION_MSG as sdv_DEPRECATION_MSG
+from sdv.metadata.single_table import SingleTableMetadata
 from sdv.single_table import GaussianCopulaSynthesizer
 
 LOGGER = logging.getLogger(__name__)
@@ -50,6 +53,9 @@ class SingleTablePreset:
 
         self.name = name
         if name == FAST_ML_PRESET:
+            if isinstance(metadata, SingleTableMetadata):
+                metadata = Metadata().load_from_dict(metadata.to_dict())
+                warnings.warn(sdv_DEPRECATION_MSG, FutureWarning)
             self._setup_fast_preset(metadata, self.locales)
 
     def add_constraints(self, constraints):

--- a/sdv/lite/single_table.py
+++ b/sdv/lite/single_table.py
@@ -28,8 +28,8 @@ class SingleTablePreset:
     """Class for all single table synthesizer presets.
 
     Args:
-        metadata (sdv.metadata.SingleTableMetadata):
-            ``SingleTableMetadata`` instance.
+        metadata (sdv.metadata.Metadata):
+            ``Metadata`` instance with a single table.
         name (str):
             The preset to use.
         locales (list or str):
@@ -71,7 +71,7 @@ class SingleTablePreset:
         self._synthesizer.add_constraints(constraints)
 
     def get_metadata(self):
-        """Return the ``SingleTableMetadata`` for this synthesizer."""
+        """Return the ``Metadata`` for this synthesizer."""
         warnings.warn(DEPRECATION_MSG, FutureWarning)
         return self._synthesizer.get_metadata()
 

--- a/sdv/lite/single_table.py
+++ b/sdv/lite/single_table.py
@@ -8,7 +8,7 @@ import warnings
 import cloudpickle
 
 from sdv.metadata.metadata import Metadata
-from sdv.metadata.single_table import DEPRECATION_MSG as SDV_DEPRECATION_MSG
+from sdv.metadata.single_table import DEPRECATION_MSG as METADATA_DEPRECATION_MSG
 from sdv.metadata.single_table import SingleTableMetadata
 from sdv.single_table import GaussianCopulaSynthesizer
 
@@ -55,7 +55,7 @@ class SingleTablePreset:
         if name == FAST_ML_PRESET:
             if isinstance(metadata, SingleTableMetadata):
                 metadata = Metadata().load_from_dict(metadata.to_dict())
-                warnings.warn(SDV_DEPRECATION_MSG, FutureWarning)
+                warnings.warn(METADATA_DEPRECATION_MSG, FutureWarning)
             self._setup_fast_preset(metadata, self.locales)
 
     def add_constraints(self, constraints):

--- a/sdv/metadata/metadata.py
+++ b/sdv/metadata/metadata.py
@@ -1,5 +1,6 @@
 """Metadata."""
 
+import warnings
 from pathlib import Path
 
 import pandas as pd
@@ -9,6 +10,10 @@ from sdv.metadata.single_table import SingleTableMetadata
 from sdv.metadata.utils import read_json
 
 DEFAULT_TABLE_NAME = 'default_table_name'
+DEPRECATION_MSG = (
+    "'SingleTableMetadata'/'MultiTableMetadata' is deprecated. Please "
+    "use the new 'Metadata' class for synthesizers."
+)
 
 
 class Metadata(MultiTableMetadata):
@@ -34,6 +39,14 @@ class Metadata(MultiTableMetadata):
         filename = Path(filepath).stem
         metadata = read_json(filepath)
         return cls.load_from_dict(metadata, filename)
+
+    @classmethod
+    def _convert_to_unified_metadata(cls, metadata):
+        """Convert the metadata to Metadata."""
+        if type(metadata) == SingleTableMetadata or type(metadata) == MultiTableMetadata:
+            metadata = Metadata().load_from_dict(metadata.to_dict())
+            warnings.warn(DEPRECATION_MSG, FutureWarning)
+        return metadata
 
     @classmethod
     def load_from_dict(cls, metadata_dict, single_table_name=None):

--- a/sdv/metadata/metadata.py
+++ b/sdv/metadata/metadata.py
@@ -43,7 +43,7 @@ class Metadata(MultiTableMetadata):
     @classmethod
     def _convert_to_unified_metadata(cls, metadata):
         """Convert the metadata to Metadata."""
-        if type(metadata) == SingleTableMetadata or type(metadata) == MultiTableMetadata:
+        if type(metadata) is SingleTableMetadata or type(metadata) is MultiTableMetadata:
             metadata = Metadata().load_from_dict(metadata.to_dict())
             warnings.warn(DEPRECATION_MSG, FutureWarning)
         return metadata

--- a/sdv/metadata/metadata.py
+++ b/sdv/metadata/metadata.py
@@ -84,10 +84,11 @@ class Metadata(MultiTableMetadata):
                     'This metadata contains more than one table. '
                     'Please provide a table name in the method.'
                 )
+
             single_table = next(iter(self.tables.values()), None)
             return single_table
-        else:
-            return self.tables[table_name]
+
+        return self.tables[table_name]
 
     def _get_table_name(self, table_name=None):
         if table_name is None:
@@ -96,7 +97,9 @@ class Metadata(MultiTableMetadata):
                     'This metadata contains more than one table. '
                     'Please provide a table name in the method.'
                 )
+
             table_name = next(iter(self.tables), None)
+
         return table_name
 
     def get_column_relationships(self, table_name=None):
@@ -115,9 +118,7 @@ class Metadata(MultiTableMetadata):
                 Returns a list of column relationships dicts
         """
         table = self._get_table_or_default(table_name)
-        if table is None:
-            return []
-        return table.column_relationships
+        return getattr(table, 'column_relationships', [])
 
     def get_primary_key(self, table_name=None):
         """Get the primary key for a table.
@@ -135,9 +136,7 @@ class Metadata(MultiTableMetadata):
                 Returns the name of the primary key for the table.
         """
         table = self._get_table_or_default(table_name)
-        if table is None:
-            return None
-        return table.primary_key
+        return getattr(table, 'primary_key', None)
 
     def get_alternate_keys(self, table_name=None):
         """Get the alternate keys for a table.
@@ -155,9 +154,7 @@ class Metadata(MultiTableMetadata):
                 List of alternate keys found in the table.
         """
         table = self._get_table_or_default(table_name)
-        if table is None:
-            return []
-        return table.alternate_keys
+        return getattr(table, 'alternate_keys', [])
 
     def get_columns(self, table_name=None):
         """Get the columns for a table.
@@ -175,9 +172,7 @@ class Metadata(MultiTableMetadata):
                 Returns dict describing columns of the given table.
         """
         table = self._get_table_or_default(table_name)
-        if table is None:
-            return {}
-        return table.columns
+        return getattr(table, 'columns', {})
 
     def validate_data(self, data):
         """Validate the data matches the metadata.
@@ -232,6 +227,7 @@ class Metadata(MultiTableMetadata):
         if table_name is None:
             self.tables[DEFAULT_TABLE_NAME] = SingleTableMetadata()
             table_name = DEFAULT_TABLE_NAME
+
         super().add_column(table_name, column_name, **kwargs)
 
     def set_sequence_key(self, column_name, table_name=None):
@@ -345,9 +341,7 @@ class Metadata(MultiTableMetadata):
                 Sequence key name
         """
         table = self._get_table_or_default(table_name)
-        if table is None:
-            return None
-        return table.sequence_key
+        return getattr(table, 'sequence_key', None)
 
     def get_sequence_index(self, table_name=None):
         """Get sequence index for a table.
@@ -365,9 +359,7 @@ class Metadata(MultiTableMetadata):
                 Sequence Index name for the given table.
         """
         table = self._get_table_or_default(table_name)
-        if table is None:
-            return None
-        return table.sequence_index
+        return getattr(table, 'sequence_key', None)
 
     def get_valid_column_relationships(self, table_name=None):
         """Get valid columns relationships for a table.

--- a/sdv/metadata/metadata.py
+++ b/sdv/metadata/metadata.py
@@ -2,9 +2,13 @@
 
 from pathlib import Path
 
+import pandas as pd
+
 from sdv.metadata.multi_table import MultiTableMetadata
 from sdv.metadata.single_table import SingleTableMetadata
 from sdv.metadata.utils import read_json
+
+DEFAULT_TABLE_NAME = 'default_table_name'
 
 
 class Metadata(MultiTableMetadata):
@@ -68,6 +72,350 @@ class Metadata(MultiTableMetadata):
             super()._set_metadata_dict(metadata)
         else:
             if single_table_name is None:
-                single_table_name = 'default_table_name'
+                single_table_name = DEFAULT_TABLE_NAME
 
-            self.tables[single_table_name] = SingleTableMetadata.load_from_dict(metadata)
+            if 'columns' in metadata:
+                self.tables[single_table_name] = SingleTableMetadata.load_from_dict(metadata)
+
+    def _get_table_or_default(self, table_name=None):
+        if table_name is None:
+            if len(self.tables) > 1:
+                raise ValueError(
+                    'This metadata contains more than one table. '
+                    'Please provide a table name in the method.'
+                )
+            single_table = next(iter(self.tables.values()), None)
+            return single_table
+        else:
+            return self.tables[table_name]
+
+    def _get_table_name(self, table_name=None):
+        if table_name is None:
+            if len(self.tables) > 1:
+                raise ValueError(
+                    'This metadata contains more than one table. '
+                    'Please provide a table name in the method.'
+                )
+            table_name = next(iter(self.tables), None)
+        return table_name
+
+    def get_column_relationships(self, table_name=None):
+        """Get column relationships for a table.
+
+        Grab the column relationships for a single table given a name or the first table if no
+        table is given. (Must contain only one table to use None)
+
+        Args:
+            table_name (str or None):
+                Table name, if there is no table name provided, chooses the default
+                table only if there is a single table.
+
+        Returns:
+            list:
+                Returns a list of column relationships dicts
+        """
+        table = self._get_table_or_default(table_name)
+        if table is None:
+            return []
+        return table.column_relationships
+
+    def get_primary_key(self, table_name=None):
+        """Get the primary key for a table.
+
+        Grab the primary key for a single table given a name or the first table if no
+        table is given. (Must contain only one table to use None)
+
+        Args:
+            table_name (str or None):
+                Table name, if there is no table name provided, chooses the default
+                table only if there is a single table.
+
+        Returns:
+            str:
+                Returns the name of the primary key for the table.
+        """
+        table = self._get_table_or_default(table_name)
+        if table is None:
+            return None
+        return table.primary_key
+
+    def get_alternate_keys(self, table_name=None):
+        """Get the alternate keys for a table.
+
+        Grab the alternate keys for a single table given a name or the first table if no
+        table is given. (Must contain only one table to use None)
+
+        Args:
+            table_name (str or None):
+                Table name, if there is no table name provided, chooses the default
+                table only if there is a single table.
+
+        Returns:
+            list:
+                List of alternate keys found in the table.
+        """
+        table = self._get_table_or_default(table_name)
+        if table is None:
+            return []
+        return table.alternate_keys
+
+    def get_columns(self, table_name=None):
+        """Get the columns for a table.
+
+        Grab the columns for a single table given a name or the first table if no
+        table is given. (Must contain only one table to use None)
+
+        Args:
+            table_name (str or None):
+                Table name, if there is no table name provided, chooses the default
+                table only if there is a single table.
+
+        Returns:
+            dict:
+                Returns dict describing columns of the given table.
+        """
+        table = self._get_table_or_default(table_name)
+        if table is None:
+            return {}
+        return table.columns
+
+    def validate_data(self, data):
+        """Validate the data matches the metadata.
+
+        Checks the following rules:
+            * all tables of the metadata are present in the data
+            * every table of the data satisfies its own metadata
+            * all foreign keys belong to a primay key
+
+        Args:
+            data (pd.DataFrame or dict):
+                The data to validate. If the data is a single dataframe it is converted to
+                a dictionary and mapped to a metadata single table (if there is only one otherwise
+                it throws an error).
+
+        Raises:
+            InvalidDataError:
+                - This error is being raised if the data is not matching its sdtype requirements.
+                - A dataframe is passed but there is more than one table that exists.
+
+        Warns:
+            A warning is being raised if ``datetime_format`` is missing from a column represented
+            as ``object`` in the dataframe and its sdtype is ``datetime``.
+        """
+        data_to_validate = data
+        if isinstance(data, pd.DataFrame):
+            table_name = self._get_table_name()
+            data_to_validate = {table_name: data}
+
+        super().validate_data(data_to_validate)
+
+    def add_column(self, column_name, table_name=None, **kwargs):
+        """Add a column to a table in the ``MultiTableMetadata``.
+
+        Args:
+            column_name (str):
+                The column name to be added.
+            table_name (str or None):
+                Name of the table to add the column to. If None is passed, default to only table
+                if there is only one table.
+            **kwargs (type):
+                Any additional key word arguments for the column, where ``sdtype`` is required.
+
+        Raises:
+            - ``InvalidMetadataError`` if the column already exists.
+            - ``InvalidMetadataError`` if the ``kwargs`` do not contain ``sdtype``.
+            - ``InvalidMetadataError`` if the column has unexpected values or ``kwargs`` for the
+              given ``sdtype``.
+            - ``InvalidMetadataError`` if the table doesn't exist in the ``MultiTableMetadata``.
+        """
+        table_name = self._get_table_name(table_name)
+        if table_name is None:
+            self.tables[DEFAULT_TABLE_NAME] = SingleTableMetadata()
+            table_name = DEFAULT_TABLE_NAME
+        super().add_column(table_name, column_name, **kwargs)
+
+    def set_sequence_key(self, column_name, table_name=None):
+        """Set the sequence key of a table.
+
+        Args:
+            table_name (str or None):
+                Name of the table to set the sequence key. If None, defaults to the single
+                table if there is only one.
+            column_name (str, tuple[str]):
+                Name (or tuple of names) of the sequence key column(s).
+        """
+        table_name = self._get_table_name(table_name)
+        super().set_sequence_key(table_name, column_name)
+
+    def add_alternate_keys(self, column_names, table_name=None):
+        """Set the alternate keys of a table.
+
+        Args:
+            table_name (str or None):
+                Name of the table to set the sequence key. If None, defaults to the single
+                table if there is only one.
+            column_names (list[str], list[tuple]):
+                List of names (or tuple of names) of the alternate key columns.
+        """
+        table_name = self._get_table_name(table_name)
+        super().add_alternate_keys(table_name, column_names)
+
+    def get_primary_and_alternate_keys(self, table_name=None):
+        """Get primary and alternate keys for a table.
+
+        Grab the primary and alternate keys  for a single table given a name
+        or the first table if no table is given. (Must contain only one table to use None)
+
+        Args:
+            table_name (str or None):
+                Table name, if there is no table name provided, chooses the default
+                table only if there is a single table.
+
+        Returns:
+            set:
+                Set of keys.
+        """
+        table = self._get_table_or_default(table_name)
+        return table._get_primary_and_alternate_keys()
+
+    def get_set_of_sequence_keys(self, table_name=None):
+        """Get sequence keys for a table.
+
+        Grab the sequence keys for a single table given a name
+        or the first table if no table is given. (Must contain only one table to use None)
+
+        Args:
+            table_name (str or None):
+                Table name, if there is no table name provided, chooses the default
+                table only if there is a single table.
+
+        Returns:
+            set:
+                Set of keys.
+        """
+        table = self._get_table_or_default(table_name)
+        return table._get_set_of_sequence_keys()
+
+    def set_primary_key(self, column_name, table_name=None):
+        """Set the primary key for a table.
+
+        Set the primary key for a single table given a name
+        or the first table if no table is given. (Must contain only one table to use None)
+
+        Args:
+            table_name (str or None):
+                Table name, if there is no table name provided, chooses the default
+                table only if there is a single table.
+        """
+        table_name = self._get_table_name(table_name)
+        return super().set_primary_key(table_name, column_name)
+
+    def detect_from_dataframes(self, data):
+        """Detect the metadata for all tables in a dictionary of dataframes.
+
+        This method automatically detects the ``sdtypes`` for the given ``pandas.DataFrame``.
+        All data column names are converted to strings.
+
+        Args:
+            data (dict or DataFrame):
+                Dictionary of table names to dataframes. If the data is a single dataframe
+                it is converted to a dictionary and mapped to a metadata single table (if
+                there is only one otherwise it throws an error).
+        """
+        data_to_detect = data
+        if isinstance(data, pd.DataFrame):
+            table_name = self._get_table_name()
+            data_to_detect = {table_name: data}
+
+        super().detect_from_dataframes(data_to_detect)
+
+    def get_sequence_key(self, table_name=None):
+        """Get sequence key for a table.
+
+        Grab the sequence key for a single table given a name
+        or the first table if no table is given. (Must contain only one table to use None)
+
+        Args:
+            table_name (str or None):
+                Table name, if there is no table name provided, chooses the default
+                table only if there is a single table.
+
+        Returns:
+            str:
+                Sequence key name
+        """
+        table = self._get_table_or_default(table_name)
+        if table is None:
+            return None
+        return table.sequence_key
+
+    def get_sequence_index(self, table_name=None):
+        """Get sequence index for a table.
+
+        Grab the sequence index for a single table given a name
+        or the first table if no table is given. (Must contain only one table to use None)
+
+        Args:
+            table_name (str or None):
+                Table name, if there is no table name provided, chooses the default
+                table only if there is a single table.
+
+        Returns:
+            str:
+                Sequence Index name for the given table.
+        """
+        table = self._get_table_or_default(table_name)
+        if table is None:
+            return None
+        return table.sequence_index
+
+    def get_valid_column_relationships(self, table_name=None):
+        """Get valid columns relationships for a table.
+
+        Grab the valid columns relationships for a single table given a name
+        or the first table if no table is given. (Must contain only one table to use None)
+
+        Args:
+            table_name (str or None):
+                Table name, if there is no table name provided, chooses the default
+                table only if there is a single table.
+        """
+        table = self._get_table_or_default(table_name)
+        return table._valid_column_relationships
+
+    def add_column_relationship(self, relationship_type, column_names, table_name=None):
+        """Add a column relationship to a table in the metadata.
+
+        Args:
+            table_name (str):
+                The name of the table to add this relationship to. If there is no table
+                name provided, chooses the default table only if there is a single table.
+            relationship_type (str):
+                The type of the relationship.
+            column_names (list[str]):
+                The list of column names involved in this relationship.
+        """
+        table_name = self._get_table_name(table_name)
+        super().add_column_relationship(table_name, relationship_type, column_names)
+
+    def update_column(self, column_name, table_name=None, **kwargs):
+        """Update an existing column for a table in the ``Metadata``.
+
+        Args:
+            table_name (str or None):
+                Name of table the column belongs to. If there is no table name provided,
+                chooses the default table only if there is a single table.
+            column_name (str):
+                The column name to be updated.
+            **kwargs (type):
+                Any key word arguments that describe metadata for the column.
+
+        Raises:
+            - ``InvalidMetadataError`` if the column doesn't already exist in the
+              ``SingleTableMetadata``.
+            - ``InvalidMetadataError`` if the column has unexpected values or ``kwargs`` for the
+              current ``sdtype``.
+            - ``InvalidMetadataError`` if the table doesn't exist in the ``MultiTableMetadata``.
+        """
+        table_name = self._get_table_name(table_name)
+        return super().update_column(table_name, column_name, **kwargs)

--- a/sdv/metadata/metadata.py
+++ b/sdv/metadata/metadata.py
@@ -359,7 +359,7 @@ class Metadata(MultiTableMetadata):
                 Sequence Index name for the given table.
         """
         table = self._get_table_or_default(table_name)
-        return getattr(table, 'sequence_key', None)
+        return getattr(table, 'sequence_index', None)
 
     def get_valid_column_relationships(self, table_name=None):
         """Get valid columns relationships for a table.

--- a/sdv/metadata/metadata_upgrader.py
+++ b/sdv/metadata/metadata_upgrader.py
@@ -2,18 +2,6 @@
 
 import warnings
 
-from sdv.constraints import (
-    FixedCombinations,
-    Inequality,
-    Negative,
-    OneHotEncoding,
-    Positive,
-    Range,
-    ScalarInequality,
-    ScalarRange,
-    Unique,
-)
-
 
 def _upgrade_columns_and_keys(old_metadata):
     new_metadata = {}
@@ -74,7 +62,7 @@ def _upgrade_positive_negative(old_constraint):
     strict = old_constraint.get('strict')
     old_name = old_constraint.get('constraint')
     is_positive = old_name == 'sdv.constraints.tabular.Positive'
-    constraint_name = Positive.__name__ if is_positive else Negative.__name__
+    constraint_name = 'Positive' if is_positive else 'Negative'
     columns = old_constraint.get('columns')
     if not isinstance(columns, list):
         columns = [columns]
@@ -92,7 +80,7 @@ def _upgrade_positive_negative(old_constraint):
 
 def _upgrade_unique_combinations(old_constraint):
     new_constraint = {
-        'constraint_name': FixedCombinations.__name__,
+        'constraint_name': 'FixedCombinations',
         'column_names': old_constraint.get('columns'),
     }
 
@@ -117,12 +105,12 @@ def _upgrade_greater_than(old_constraint):
             warnings.warn(
                 f"Unable to upgrade the GreaterThan constraint specified for 'high' "
                 f"{high_column_name} and 'low' {low_column_name}. Manually add "
-                f'{Inequality.__name__} constraints to capture this logic.'
+                'Inequality constraints to capture this logic.'
             )
             return []
 
         new_constraint = {
-            'constraint_name': Inequality.__name__,
+            'constraint_name': 'Inequality',
             'high_column_name': high if high_is_string else high[0],
             'low_column_name': low if low_is_string else low[0],
             'strict_boundaries': strict,
@@ -133,7 +121,7 @@ def _upgrade_greater_than(old_constraint):
         high = [high] if high_is_string else high
         for column in high:
             new_constraint = {
-                'constraint_name': ScalarInequality.__name__,
+                'constraint_name': 'ScalarInequality',
                 'column_name': column,
                 'relation': '>' if strict else '>=',
                 'value': low,
@@ -144,7 +132,7 @@ def _upgrade_greater_than(old_constraint):
         low = [low] if low_is_string else low
         for column in low:
             new_constraint = {
-                'constraint_name': ScalarInequality.__name__,
+                'constraint_name': 'ScalarInequality',
                 'column_name': column,
                 'relation': '<' if strict else '<=',
                 'value': high,
@@ -164,7 +152,7 @@ def _upgrade_between(old_constraint):
     new_constraints = []
     if high_is_scalar and low_is_scalar:
         new_constraint = {
-            'constraint_name': ScalarRange.__name__,
+            'constraint_name': 'ScalarRange',
             'column_name': constraint_column,
             'low_value': low,
             'high_value': high,
@@ -174,13 +162,13 @@ def _upgrade_between(old_constraint):
 
     elif high_is_scalar and not low_is_scalar:
         inequality_constraint = {
-            'constraint_name': Inequality.__name__,
+            'constraint_name': 'Inequality',
             'low_column_name': low,
             'high_column_name': constraint_column,
             'strict_boundaries': strict,
         }
         scalar_constraint = {
-            'constraint_name': ScalarInequality.__name__,
+            'constraint_name': 'ScalarInequality',
             'column_name': constraint_column,
             'relation': '<' if strict else '<=',
             'value': high,
@@ -190,13 +178,13 @@ def _upgrade_between(old_constraint):
 
     elif not high_is_scalar and low_is_scalar:
         inequality_constraint = {
-            'constraint_name': Inequality.__name__,
+            'constraint_name': 'Inequality',
             'low_column_name': constraint_column,
             'high_column_name': high,
             'strict_boundaries': strict,
         }
         scalar_constraint = {
-            'constraint_name': ScalarInequality.__name__,
+            'constraint_name': 'ScalarInequality',
             'column_name': constraint_column,
             'relation': '>' if strict else '>=',
             'value': low,
@@ -206,7 +194,7 @@ def _upgrade_between(old_constraint):
 
     else:
         new_constraint = {
-            'constraint_name': Range.__name__,
+            'constraint_name': 'Range',
             'low_column_name': low,
             'middle_column_name': constraint_column,
             'high_column_name': high,
@@ -219,7 +207,7 @@ def _upgrade_between(old_constraint):
 
 def _upgrade_one_hot_encoding(old_constraint):
     new_constraint = {
-        'constraint_name': OneHotEncoding.__name__,
+        'constraint_name': 'OneHotEncoding',
         'column_names': old_constraint.get('columns'),
     }
     return [new_constraint]
@@ -227,7 +215,7 @@ def _upgrade_one_hot_encoding(old_constraint):
 
 def _upgrade_unique(old_constraint):
     new_constraint = {
-        'constraint_name': Unique.__name__,
+        'constraint_name': 'Unique',
         'column_names': old_constraint.get('columns'),
     }
     return [new_constraint]

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -507,14 +507,18 @@ class MultiTableMetadata:
                     try:
                         original_foreign_key_sdtype = child_meta.columns[primary_key]['sdtype']
                         if original_foreign_key_sdtype != 'id':
-                            self.update_column(child_candidate, primary_key, sdtype='id')
+                            self.update_column(
+                                table_name=child_candidate, column_name=primary_key, sdtype='id'
+                            )
 
                         self.add_relationship(
                             parent_candidate, child_candidate, primary_key, primary_key
                         )
                     except InvalidMetadataError:
                         self.update_column(
-                            child_candidate, primary_key, sdtype=original_foreign_key_sdtype
+                            table_name=child_candidate,
+                            column_name=primary_key,
+                            sdtype=original_foreign_key_sdtype,
                         )
                         continue
 

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -26,6 +26,10 @@ from sdv.metadata.visualization import (
 LOGGER = logging.getLogger(__name__)
 MULTITABLEMETADATA_LOGGER = get_sdv_logger('MultiTableMetadata')
 WARNINGS_COLUMN_ORDER = ['Table Name', 'Column Name', 'sdtype', 'datetime_format']
+DEPRECATION_MSG = (
+    "The 'MultiTableMetadata' is deprecated. Please use the new "
+    "'Metadata' class for synthesizers."
+)
 
 
 class MultiTableMetadata:

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -918,6 +918,47 @@ class MultiTableMetadata:
         self._validate_table_exists(table_name)
         return deepcopy(self.tables[table_name])
 
+    def anonymize(self):
+        """Anonymize metadata by obfuscating column names.
+
+        Returns:
+            MultiTableMetadata:
+                An anonymized MultiTableMetadata instance.
+        """
+        anonymized_metadata = {'tables': {}, 'relationships': []}
+        anonymized_table_map = {}
+        counter = 1
+        for table, table_metadata in self.tables.items():
+            anonymized_table_name = f'table{counter}'
+            anonymized_table_map[table] = anonymized_table_name
+
+            anonymized_metadata['tables'][anonymized_table_name] = (
+                table_metadata.anonymize().to_dict()
+            )
+            counter += 1
+
+        for relationship in self.relationships:
+            parent_table = relationship['parent_table_name']
+            anonymized_parent_table = anonymized_table_map[parent_table]
+
+            child_table = relationship['child_table_name']
+            anonymized_child_table = anonymized_table_map[child_table]
+
+            foreign_key = relationship['child_foreign_key']
+            anonymized_foreign_key = self.tables[child_table]._anonymized_column_map[foreign_key]
+
+            primary_key = relationship['parent_primary_key']
+            anonymized_primary_key = self.tables[parent_table]._anonymized_column_map[primary_key]
+
+            anonymized_metadata['relationships'].append({
+                'parent_table_name': anonymized_parent_table,
+                'child_table_name': anonymized_child_table,
+                'child_foreign_key': anonymized_foreign_key,
+                'parent_primary_key': anonymized_primary_key,
+            })
+
+        return MultiTableMetadata.load_from_dict(anonymized_metadata)
+
     def visualize(
         self, show_table_details='full', show_relationship_labels=True, output_filepath=None
     ):

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -36,6 +36,11 @@ from sdv.metadata.visualization import (
 LOGGER = logging.getLogger(__name__)
 SINGLETABLEMETADATA_LOGGER = get_sdv_logger('SingleTableMetadata')
 
+DEPRECATION_MSG = (
+    "The 'SingleTableMetadata' is deprecated. Please use the new "
+    "'Metadata' class for synthesizers."
+)
+
 
 class SingleTableMetadata:
     """Single Table Metadata class."""

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -1406,7 +1406,7 @@ class SingleTableMetadata:
             if len(tables) > 1:
                 raise InvalidMetadataError(
                     'There are multiple tables specified in the JSON. '
-                    'Try using the MultiTableMetadata class to upgrade this file.'
+                    'Try using the Metadata class to upgrade this file.'
                 )
 
             else:

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -1223,6 +1223,41 @@ class SingleTableMetadata:
         if errors:
             raise InvalidDataError(errors)
 
+    def anonymize(self):
+        """Anonymize metadata by obfuscating column names.
+
+        Returns:
+            SingleTableMetadata:
+                An anonymized SingleTableMetadata instance.
+        """
+        anonymized_metadata = {'columns': {}}
+
+        self._anonymized_column_map = {}
+        counter = 1
+        for column, column_metadata in self.columns.items():
+            anonymized_column = f'col{counter}'
+            self._anonymized_column_map[column] = anonymized_column
+            anonymized_metadata['columns'][anonymized_column] = column_metadata
+            counter += 1
+
+        if self.primary_key:
+            anonymized_metadata['primary_key'] = self._anonymized_column_map[self.primary_key]
+
+        if self.alternate_keys:
+            anonymized_alternate_keys = []
+            for alternate_key in self.alternate_keys:
+                anonymized_alternate_keys.append(self._anonymized_column_map[alternate_key])
+
+            anonymized_metadata['alternate_keys'] = anonymized_alternate_keys
+
+        if self.sequence_key:
+            anonymized_metadata['sequence_key'] = self._anonymized_column_map[self.sequence_key]
+
+        if self.sequence_index:
+            anonymized_metadata['sequence_index'] = self._anonymized_column_map[self.sequence_index]
+
+        return SingleTableMetadata.load_from_dict(anonymized_metadata)
+
     def visualize(self, show_table_details='full', output_filepath=None):
         """Create a visualization of the single-table dataset.
 

--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -26,6 +26,8 @@ from sdv.errors import (
     SynthesizerInputError,
 )
 from sdv.logging import disable_single_table_logger, get_sdv_logger
+from sdv.metadata.metadata import Metadata
+from sdv.metadata.multi_table import DEPRECATION_MSG, MultiTableMetadata
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
 
 SYNTHESIZER_LOGGER = get_sdv_logger('MultiTableSynthesizer')
@@ -38,9 +40,8 @@ class BaseMultiTableSynthesizer:
     multi table synthesizers need to implement, as well as common functionality.
 
     Args:
-        metadata (sdv.metadata.multi_table.MultiTableMetadata):
-            Multi table metadata representing the data tables that this synthesizer will be used
-            for.
+        metadata (sdv.metadata.Metadata):
+            Metadata representing the data tables that this synthesizer will utilize.
         locales (list or str):
             The default locale(s) to use for AnonymizedFaker transformers.
             Defaults to ``['en_US']``.
@@ -71,8 +72,9 @@ class BaseMultiTableSynthesizer:
         with disable_single_table_logger():
             for table_name, table_metadata in self.metadata.tables.items():
                 synthesizer_parameters = self._table_parameters.get(table_name, {})
+                metadata = Metadata.load_from_dict(table_metadata.to_dict())
                 self._table_synthesizers[table_name] = self._synthesizer(
-                    metadata=table_metadata, locales=self.locales, **synthesizer_parameters
+                    metadata=metadata, locales=self.locales, **synthesizer_parameters
                 )
                 self._table_synthesizers[table_name]._data_processor.table_name = table_name
 
@@ -97,6 +99,9 @@ class BaseMultiTableSynthesizer:
 
     def __init__(self, metadata, locales=['en_US'], synthesizer_kwargs=None):
         self.metadata = metadata
+        if type(metadata) is MultiTableMetadata:
+            self.metadata = Metadata().load_from_dict(metadata.to_dict())
+            warnings.warn(DEPRECATION_MSG, FutureWarning)
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', message=r'.*column relationship.*')
             self.metadata.validate()

--- a/sdv/multi_table/hma.py
+++ b/sdv/multi_table/hma.py
@@ -23,7 +23,7 @@ class HMASynthesizer(BaseHierarchicalSampler, BaseMultiTableSynthesizer):
     """Hierarchical Modeling Algorithm One.
 
     Args:
-        metadata (sdv.metadata.multi_table.MultiTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Multi table metadata representing the data tables that this synthesizer will be used
             for.
         locales (list or str):
@@ -47,7 +47,7 @@ class HMASynthesizer(BaseHierarchicalSampler, BaseMultiTableSynthesizer):
         """Get the number of data columns, ie colums that are not id, for each table.
 
         Args:
-            metadata (MultiTableMetadata):
+            metadata (Metadata):
                 Metadata of the datasets.
         """
         columns_per_table = {}

--- a/sdv/multi_table/utils.py
+++ b/sdv/multi_table/utils.py
@@ -123,7 +123,7 @@ def _simplify_relationships_and_tables(metadata, tables_to_drop):
     Removes the tables that are not direct child or grandchild of the root table.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         tables_to_drop (set):
             Set of the tables that relationships will be removed.
@@ -149,7 +149,7 @@ def _simplify_grandchildren(metadata, grandchildren):
      - Drop all modelables columns.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         grandchildren (set):
             Set of the grandchildren of the root table.
@@ -174,7 +174,7 @@ def _get_num_column_to_drop(metadata, child_table, max_col_per_relationships):
         - minimum number of column to drop = n + k - sqrt(k^2 + 1 + 2m)
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         child_table (str):
             Name of the child table.
@@ -232,7 +232,7 @@ def _simplify_child(metadata, child_table, max_col_per_relationships):
     """Simplify the child table.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         child_table (str):
             Name of the child table.
@@ -252,7 +252,7 @@ def _simplify_children(metadata, children, root_table, num_data_column):
      - Drop some modelable columns to have at most MAX_NUMBER_OF_COLUMNS columns to model.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         children (set):
             Set of the children of the root table.
@@ -288,11 +288,11 @@ def _simplify_metadata(metadata):
      - Drop some modelable columns in the children to have at most 1000 columns to model.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
 
     Returns:
-        MultiTableMetadata:
+        Metadata:
             Simplified metadata.
     """
     simplified_metadata = deepcopy(metadata)
@@ -330,7 +330,7 @@ def _simplify_data(data, metadata):
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
 
     Returns:
@@ -375,7 +375,7 @@ def _get_rows_to_drop(data, metadata):
     This ensures that we preserve the referential integrity between all the relationships.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         data (dict):
             Dictionary that maps each table name (string) to the data for that
@@ -470,7 +470,7 @@ def _subsample_table_and_descendants(data, metadata, table, num_rows):
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         table (str):
             Name of the table.
@@ -496,7 +496,7 @@ def _get_primary_keys_referenced(data, metadata):
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
 
     Returns:
@@ -568,7 +568,7 @@ def _subsample_ancestors(data, metadata, table, primary_keys_referenced):
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         table (str):
             Name of the table.
@@ -604,7 +604,7 @@ def _subsample_data(data, metadata, main_table_name, num_rows):
       referenced by the descendants and some unreferenced rows.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         data (dict):
             Dictionary that maps each table name (string) to the data for that

--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -12,7 +12,7 @@ class BaseHierarchicalSampler:
     """Hierarchical sampler mixin.
 
     Args:
-        metadata (sdv.metadata.multi_table.MultiTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Multi-table metadata representing the data tables that this sampler will be used for.
         table_synthesizers (dict):
             Dictionary mapping each table to a synthesizer. Should be instantiated and passed to

--- a/sdv/sampling/independent_sampler.py
+++ b/sdv/sampling/independent_sampler.py
@@ -106,7 +106,7 @@ class BaseIndependentSampler:
                 try:
                     table_rows[name] = table_rows[name].dropna().astype(dtype)
                 except ValueError as e:
-                    column_metadata = metadata.columns.get(name)
+                    column_metadata = metadata.get_columns().get(name)
                     sdtype = column_metadata.get('sdtype')
                     if sdtype not in dtypes_to_sdtype.values():
                         LOGGER.info(

--- a/sdv/sampling/independent_sampler.py
+++ b/sdv/sampling/independent_sampler.py
@@ -10,7 +10,7 @@ class BaseIndependentSampler:
     """Independent sampler mixin.
 
     Args:
-        metadata (sdv.metadata.multi_table.MultiTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Multi-table metadata representing the data tables that this sampler will be used for.
         table_synthesizers (dict):
             Dictionary mapping each table to a synthesizer. Should be instantiated and passed to

--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -30,7 +30,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
     to be passed into PAR.
 
     Args:
-        metadata (sdv.metadata.SingleTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Single table metadata representing the data that this synthesizer will be used for.
         enforce_min_max_values (bool):
             Specify whether or not to clip the data returned by ``reverse_transform`` of

--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -344,6 +344,12 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             context[constant_column] = 0
             context_metadata.add_column(constant_column, sdtype='numerical')
 
+        for column in self.context_columns:
+            # Context datetime SDTypes for PAR have already been converted to float timestamp
+            if context_metadata.columns[column]['sdtype'] == 'datetime':
+                if pd.api.types.is_numeric_dtype(context[column]):
+                    context_metadata.update_column(column, sdtype='numerical')
+
         self._context_synthesizer = GaussianCopulaSynthesizer(
             context_metadata,
             enforce_min_max_values=self._context_synthesizer.enforce_min_max_values,

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -510,6 +510,7 @@ class BaseSynthesizer:
         with open(filepath, 'rb') as f:
             try:
                 synthesizer = cloudpickle.load(f)
+                synthesizer.metadata = Metadata._convert_to_unified_metadata(synthesizer.metadata)
             except RuntimeError as e:
                 err_msg = (
                     'Attempting to deserialize object on a CUDA device but '

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -52,7 +52,7 @@ class BaseSynthesizer:
     ``Synthesizers`` need to implement, as well as common functionality.
 
     Args:
-        metadata (sdv.metadata.SingleTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Single table metadata representing the data that this synthesizer will be used for.
         enforce_min_max_values (bool):
             Specify whether or not to clip the data returned by ``reverse_transform`` of
@@ -258,7 +258,7 @@ class BaseSynthesizer:
         return instantiated_parameters
 
     def get_metadata(self):
-        """Return the ``SingleTableMetadata`` for this synthesizer."""
+        """Return the ``Metadata`` for this synthesizer."""
         return self.metadata
 
     def load_custom_constraint_classes(self, filepath, class_names):

--- a/sdv/single_table/copulagan.py
+++ b/sdv/single_table/copulagan.py
@@ -163,7 +163,7 @@ class CopulaGANSynthesizer(CTGANSynthesizer):
             cuda=cuda,
         )
 
-        validate_numerical_distributions(numerical_distributions, self.metadata.columns)
+        validate_numerical_distributions(numerical_distributions, self.metadata.get_columns())
         self.numerical_distributions = numerical_distributions or {}
         self.default_distribution = default_distribution or 'beta'
 
@@ -176,7 +176,7 @@ class CopulaGANSynthesizer(CTGANSynthesizer):
         }
 
     def _create_gaussian_normalizer_config(self, processed_data):
-        columns = self.metadata.columns
+        columns = self.metadata.get_columns()
         transformers = {}
         sdtypes = {}
         for column in processed_data.columns:

--- a/sdv/single_table/copulagan.py
+++ b/sdv/single_table/copulagan.py
@@ -59,7 +59,7 @@ class CopulaGANSynthesizer(CTGANSynthesizer):
 
 
     Args:
-        metadata (sdv.metadata.SingleTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Single table metadata representing the data that this synthesizer will be used for.
         enforce_min_max_values (bool):
             Specify whether or not to clip the data returned by ``reverse_transform`` of

--- a/sdv/single_table/copulas.py
+++ b/sdv/single_table/copulas.py
@@ -109,7 +109,7 @@ class GaussianCopulaSynthesizer(BaseSingleTableSynthesizer):
             enforce_rounding=enforce_rounding,
             locales=locales,
         )
-        validate_numerical_distributions(numerical_distributions, self.metadata.columns)
+        validate_numerical_distributions(numerical_distributions, self.metadata.get_columns())
 
         self.default_distribution = default_distribution or 'beta'
         self._default_distribution = self.get_distribution_class(self.default_distribution)
@@ -182,7 +182,7 @@ class GaussianCopulaSynthesizer(BaseSingleTableSynthesizer):
     def _get_valid_columns_from_metadata(self, columns):
         valid_columns = []
         for column in columns:
-            for valid_column in self.metadata.columns:
+            for valid_column in self.metadata.get_columns():
                 if column.startswith(valid_column):
                     valid_columns.append(column)
                     break

--- a/sdv/single_table/copulas.py
+++ b/sdv/single_table/copulas.py
@@ -29,7 +29,7 @@ class GaussianCopulaSynthesizer(BaseSingleTableSynthesizer):
     """Model wrapping ``copulas.multivariate.GaussianMultivariate`` copula.
 
     Args:
-        metadata (sdv.metadata.SingleTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Single table metadata representing the data that this synthesizer will be used for.
         enforce_min_max_values (bool):
             Specify whether or not to clip the data returned by ``reverse_transform`` of

--- a/sdv/single_table/ctgan.py
+++ b/sdv/single_table/ctgan.py
@@ -98,7 +98,7 @@ class CTGANSynthesizer(LossValuesMixin, BaseSingleTableSynthesizer):
     """Model wrapping ``CTGAN`` model.
 
     Args:
-        metadata (sdv.metadata.SingleTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Single table metadata representing the data that this synthesizer will be used for.
         enforce_min_max_values (bool):
             Specify whether or not to clip the data returned by ``reverse_transform`` of
@@ -314,7 +314,7 @@ class TVAESynthesizer(LossValuesMixin, BaseSingleTableSynthesizer):
     """Model wrapping ``TVAE`` model.
 
     Args:
-        metadata (sdv.metadata.SingleTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Single table metadata representing the data that this synthesizer will be used for.
         enforce_min_max_values (bool):
             Specify whether or not to clip the data returned by ``reverse_transform`` of

--- a/sdv/single_table/utils.py
+++ b/sdv/single_table/utils.py
@@ -6,6 +6,8 @@ import warnings
 import numpy as np
 
 from sdv.errors import SynthesizerInputError
+from sdv.metadata.metadata import Metadata
+from sdv.metadata.single_table import DEPRECATION_MSG, SingleTableMetadata
 
 DISABLE_TMP_FILE = 'disable'
 IGNORED_DICT_KEYS = ['fitted', 'distribution', 'type']
@@ -33,10 +35,13 @@ def detect_discrete_columns(metadata, data, transformers):
         discrete_columns (list):
             A list of discrete columns to be used with some of ``sdv`` synthesizers.
     """
+    if isinstance(metadata, SingleTableMetadata):
+        metadata = Metadata().load_from_dict(metadata.to_dict())
+        warnings.warn(DEPRECATION_MSG, FutureWarning)
     discrete_columns = []
     for column in data.columns:
-        if column in metadata.columns:
-            sdtype = metadata.columns[column]['sdtype']
+        if column in metadata.get_columns():
+            sdtype = metadata.get_columns()[column]['sdtype']
             # Numerical and datetime columns never get preprocessed into categorical ones
             if sdtype in ['numerical', 'datetime']:
                 continue

--- a/sdv/single_table/utils.py
+++ b/sdv/single_table/utils.py
@@ -21,7 +21,7 @@ def detect_discrete_columns(metadata, data, transformers):
     discrete.
 
     Args:
-        metadata (sdv.metadata.SingleTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Metadata that belongs to the given ``data``.
 
         data (pandas.DataFrame):

--- a/sdv/utils/poc.py
+++ b/sdv/utils/poc.py
@@ -40,7 +40,7 @@ def simplify_schema(data, metadata, verbose=True):
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         verbose (bool):
             If True, print information about the simplification process.
@@ -50,7 +50,7 @@ def simplify_schema(data, metadata, verbose=True):
         tuple:
             dict:
                 Dictionary with the simplified dataframes.
-            MultiTableMetadata:
+            Metadata:
                 Simplified metadata.
     """
     try:
@@ -93,7 +93,7 @@ def get_random_subset(data, metadata, main_table_name, num_rows, verbose=True):
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         main_table_name (str):
             Name of the main table.

--- a/sdv/utils/utils.py
+++ b/sdv/utils/utils.py
@@ -18,7 +18,7 @@ def drop_unknown_references(data, metadata, drop_missing_values=True, verbose=Tr
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         drop_missing_values (bool):
             Boolean describing whether or not to also drop foreign keys with missing values

--- a/tests/integration/metadata/test_metadata.py
+++ b/tests/integration/metadata/test_metadata.py
@@ -1,6 +1,9 @@
+import pytest
+
 from sdv.datasets.demo import download_demo
-from sdv.metadata.metadata import Metadata
+from sdv.metadata.metadata import DEFAULT_TABLE_NAME, Metadata
 from sdv.metadata.multi_table import MultiTableMetadata
+from sdv.single_table.copulas import GaussianCopulaSynthesizer
 
 
 def test_metadata():
@@ -217,3 +220,38 @@ def test_detect_table_from_csv(tmp_path):
     }
 
     assert metadata.to_dict() == expected_metadata
+
+
+def test_single_table_compatibility(tmp_path):
+    """Test if SingleMetadataTable still has compatibility with single table synthesizers."""
+    # Setup
+    data, metadata = download_demo('single_table', 'fake_hotel_guests')
+    warn_msg = (
+        "The 'SingleTableMetadata' is deprecated. Please use the new "
+        "'Metadata' class for synthesizers."
+    )
+
+    # Run
+    with pytest.warns(FutureWarning, match=warn_msg):
+        synthesizer = GaussianCopulaSynthesizer(metadata)
+    synthesizer.fit(data)
+    model_path = tmp_path / 'synthesizer.pkl'
+    synthesizer.save(model_path)
+
+    # Assert
+    assert model_path.exists()
+    assert model_path.is_file()
+    loaded_synthesizer = GaussianCopulaSynthesizer.load(model_path)
+    assert isinstance(synthesizer, GaussianCopulaSynthesizer)
+    assert loaded_synthesizer.get_info() == synthesizer.get_info()
+    assert isinstance(loaded_synthesizer.metadata, Metadata)
+    assert loaded_synthesizer.metadata.tables[DEFAULT_TABLE_NAME].to_dict() == metadata.to_dict()
+    loaded_sample = loaded_synthesizer.sample(10)
+    synthesizer.validate(loaded_sample)
+
+    # Run against Metadata
+    synthesizer_2 = GaussianCopulaSynthesizer(Metadata._convert_to_unified_metadata(metadata))
+    synthesizer_2.fit(data)
+    metadata_sample = synthesizer.sample(10)
+    assert loaded_synthesizer.metadata.to_dict() == synthesizer_2.metadata.to_dict()
+    assert metadata_sample.columns.to_list() == loaded_sample.columns.to_list()

--- a/tests/integration/metadata/test_metadata.py
+++ b/tests/integration/metadata/test_metadata.py
@@ -1,9 +1,13 @@
+import os
+import re
+
 import pytest
 
 from sdv.datasets.demo import download_demo
 from sdv.metadata.metadata import DEFAULT_TABLE_NAME, Metadata
 from sdv.metadata.multi_table import MultiTableMetadata
 from sdv.metadata.single_table import SingleTableMetadata
+from sdv.multi_table.hma import HMASynthesizer
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
 
 
@@ -118,7 +122,7 @@ def test_detect_from_csvs(tmp_path):
     metadata = Metadata()
 
     for table_name, dataframe in real_data.items():
-        csv_path = tmp_path / f'{table_name}.csv'
+        csv_path = os.path.join(tmp_path, f'{table_name}.csv')
         dataframe.to_csv(csv_path, index=False)
 
     # Run
@@ -181,11 +185,11 @@ def test_detect_table_from_csv(tmp_path):
     metadata = Metadata()
 
     for table_name, dataframe in real_data.items():
-        csv_path = tmp_path / f'{table_name}.csv'
+        csv_path = os.path.join(tmp_path, f'{table_name}.csv')
         dataframe.to_csv(csv_path, index=False)
 
     # Run
-    metadata.detect_table_from_csv('hotels', tmp_path / 'hotels.csv')
+    metadata.detect_table_from_csv('hotels', os.path.join(tmp_path, 'hotels.csv'))
 
     # Assert
     metadata.update_column(
@@ -254,12 +258,12 @@ def test_single_table_compatibility(tmp_path):
     with pytest.warns(FutureWarning, match=warn_msg):
         synthesizer = GaussianCopulaSynthesizer(metadata)
     synthesizer.fit(data)
-    model_path = tmp_path / 'synthesizer.pkl'
+    model_path = os.path.join(tmp_path, 'synthesizer.pkl')
     synthesizer.save(model_path)
 
     # Assert
-    assert model_path.exists()
-    assert model_path.is_file()
+    assert os.path.exists(model_path)
+    assert os.path.isfile(model_path)
     loaded_synthesizer = GaussianCopulaSynthesizer.load(model_path)
     assert isinstance(synthesizer, GaussianCopulaSynthesizer)
     assert loaded_synthesizer.get_info() == synthesizer.get_info()
@@ -274,3 +278,93 @@ def test_single_table_compatibility(tmp_path):
     metadata_sample = synthesizer.sample(10)
     assert loaded_synthesizer.metadata.to_dict() == synthesizer_2.metadata.to_dict()
     assert metadata_sample.columns.to_list() == loaded_sample.columns.to_list()
+
+
+def test_multi_table_compatibility(tmp_path):
+    """Test if MultiTableMetadata still has compatibility with multi table synthesizers."""
+    # Setup
+    data, _ = download_demo('multi_table', 'fake_hotels')
+    warn_msg = re.escape(
+        "The 'MultiTableMetadata' is deprecated. Please use the new "
+        "'Metadata' class for synthesizers."
+    )
+
+    multi_dict = {
+        'tables': {
+            'guests': {
+                'primary_key': 'guest_email',
+                'columns': {
+                    'guest_email': {'sdtype': 'email', 'pii': True},
+                    'hotel_id': {'sdtype': 'id', 'regex_format': '[A-Za-z]{5}'},
+                    'has_rewards': {'sdtype': 'boolean'},
+                    'room_type': {'sdtype': 'categorical'},
+                    'amenities_fee': {'sdtype': 'numerical', 'computer_representation': 'Float'},
+                    'checkin_date': {'sdtype': 'datetime', 'datetime_format': '%d %b %Y'},
+                    'checkout_date': {'sdtype': 'datetime', 'datetime_format': '%d %b %Y'},
+                    'room_rate': {'sdtype': 'numerical', 'computer_representation': 'Float'},
+                    'billing_address': {'sdtype': 'address', 'pii': True},
+                    'credit_card_number': {'sdtype': 'credit_card_number', 'pii': True},
+                },
+            },
+            'hotels': {
+                'primary_key': 'hotel_id',
+                'columns': {
+                    'hotel_id': {'sdtype': 'id', 'regex_format': 'HID_[0-9]{3}'},
+                    'city': {'sdtype': 'categorical'},
+                    'state': {'sdtype': 'categorical'},
+                    'rating': {'sdtype': 'numerical', 'computer_representation': 'Float'},
+                    'classification': {'sdtype': 'categorical'},
+                },
+            },
+        },
+        'relationships': [
+            {
+                'parent_table_name': 'hotels',
+                'parent_primary_key': 'hotel_id',
+                'child_table_name': 'guests',
+                'child_foreign_key': 'hotel_id',
+            }
+        ],
+        'METADATA_SPEC_VERSION': 'MULTI_TABLE_V1',
+    }
+    metadata = MultiTableMetadata.load_from_dict(multi_dict)
+    assert type(metadata) is MultiTableMetadata
+
+    # Run
+    with pytest.warns(FutureWarning, match=warn_msg):
+        synthesizer = HMASynthesizer(metadata)
+
+    synthesizer.fit(data)
+    model_path = os.path.join(tmp_path, 'synthesizer.pkl')
+    synthesizer.save(model_path)
+
+    # Assert
+    assert os.path.exists(model_path)
+    assert os.path.isfile(model_path)
+
+    # Load HMASynthesizer
+    loaded_synthesizer = HMASynthesizer.load(model_path)
+
+    # Asserts
+    assert isinstance(synthesizer, HMASynthesizer)
+    assert loaded_synthesizer.get_info() == synthesizer.get_info()
+    assert isinstance(loaded_synthesizer.metadata, Metadata)
+
+    # Load Metadata
+    expected_metadata = metadata.to_dict()
+    expected_metadata['METADATA_SPEC_VERSION'] = 'V1'
+
+    # Asserts
+    assert loaded_synthesizer.metadata.to_dict() == expected_metadata
+
+    # Sample from loaded synthesizer
+    loaded_sample = loaded_synthesizer.sample(10)
+    synthesizer.validate(loaded_sample)
+
+    # Run against Metadata
+    synthesizer_2 = HMASynthesizer(Metadata._convert_to_unified_metadata(metadata))
+    synthesizer_2.fit(data)
+    metadata_sample = synthesizer.sample(10)
+    assert loaded_synthesizer.metadata.to_dict() == synthesizer_2.metadata.to_dict()
+    for table in metadata_sample:
+        assert metadata_sample[table].columns.to_list() == loaded_sample[table].columns.to_list()

--- a/tests/integration/metadata/test_metadata.py
+++ b/tests/integration/metadata/test_metadata.py
@@ -226,14 +226,31 @@ def test_detect_table_from_csv(tmp_path):
 def test_single_table_compatibility(tmp_path):
     """Test if SingleMetadataTable still has compatibility with single table synthesizers."""
     # Setup
-    data, metadata = download_demo('single_table', 'fake_hotel_guests')
+    data, _ = download_demo('single_table', 'fake_hotel_guests')
     warn_msg = (
         "The 'SingleTableMetadata' is deprecated. Please use the new "
         "'Metadata' class for synthesizers."
     )
 
-    # Run
+    single_table_metadata_dict = {
+        'primary_key': 'guest_email',
+        'METADATA_SPEC_VERSION': 'SINGLE_TABLE_V1',
+        'columns': {
+            'guest_email': {'sdtype': 'email', 'pii': True},
+            'has_rewards': {'sdtype': 'boolean'},
+            'room_type': {'sdtype': 'categorical'},
+            'amenities_fee': {'sdtype': 'numerical', 'computer_representation': 'Float'},
+            'checkin_date': {'sdtype': 'datetime', 'datetime_format': '%d %b %Y'},
+            'checkout_date': {'sdtype': 'datetime', 'datetime_format': '%d %b %Y'},
+            'room_rate': {'sdtype': 'numerical', 'computer_representation': 'Float'},
+            'billing_address': {'sdtype': 'address', 'pii': True},
+            'credit_card_number': {'sdtype': 'credit_card_number', 'pii': True},
+        },
+    }
+    metadata = SingleTableMetadata.load_from_dict(single_table_metadata_dict)
     assert isinstance(metadata, SingleTableMetadata)
+
+    # Run
     with pytest.warns(FutureWarning, match=warn_msg):
         synthesizer = GaussianCopulaSynthesizer(metadata)
     synthesizer.fit(data)

--- a/tests/integration/metadata/test_metadata.py
+++ b/tests/integration/metadata/test_metadata.py
@@ -1,17 +1,18 @@
 from sdv.datasets.demo import download_demo
 from sdv.metadata.metadata import Metadata
+from sdv.metadata.multi_table import MultiTableMetadata
 
 
 def test_metadata():
     """Test ``MultiTableMetadata``."""
     # Create an instance
-    instance = Metadata()
+    instance = MultiTableMetadata()
 
     # To dict
     result = instance.to_dict()
 
     # Assert
-    assert result == {'tables': {}, 'relationships': [], 'METADATA_SPEC_VERSION': 'V1'}
+    assert result == {'tables': {}, 'relationships': [], 'METADATA_SPEC_VERSION': 'MULTI_TABLE_V1'}
     assert instance.tables == {}
     assert instance.relationships == []
 
@@ -21,7 +22,7 @@ def test_detect_from_dataframes_multi_table():
     # Setup
     real_data, _ = download_demo(modality='multi_table', dataset_name='fake_hotels')
 
-    metadata = Metadata()
+    metadata = MultiTableMetadata()
 
     # Run
     metadata.detect_from_dataframes(real_data)
@@ -69,7 +70,7 @@ def test_detect_from_dataframes_multi_table():
                 'child_foreign_key': 'hotel_id',
             }
         ],
-        'METADATA_SPEC_VERSION': 'V1',
+        'METADATA_SPEC_VERSION': 'MULTI_TABLE_V1',
     }
     assert metadata.to_dict() == expected_metadata
 

--- a/tests/integration/metadata/test_metadata.py
+++ b/tests/integration/metadata/test_metadata.py
@@ -3,6 +3,7 @@ import pytest
 from sdv.datasets.demo import download_demo
 from sdv.metadata.metadata import DEFAULT_TABLE_NAME, Metadata
 from sdv.metadata.multi_table import MultiTableMetadata
+from sdv.metadata.single_table import SingleTableMetadata
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
 
 
@@ -232,6 +233,7 @@ def test_single_table_compatibility(tmp_path):
     )
 
     # Run
+    assert isinstance(metadata, SingleTableMetadata)
     with pytest.warns(FutureWarning, match=warn_msg):
         synthesizer = GaussianCopulaSynthesizer(metadata)
     synthesizer.fit(data)

--- a/tests/integration/metadata/test_multi_table.py
+++ b/tests/integration/metadata/test_multi_table.py
@@ -375,3 +375,60 @@ def test_get_table_metadata():
         'column_relationships': [{'type': 'gps', 'column_names': ['latitude', 'longitude']}],
     }
     assert table_metadata.to_dict() == expected_metadata
+
+
+def test_anonymize():
+    """Test the ``anonymize`` method."""
+    # Setup
+    metadata_dict = {
+        'tables': {
+            'real_table1': {
+                'columns': {
+                    'table1_primary_key': {'sdtype': 'id', 'regex_format': 'ID_[0-9]{3}'},
+                    'table1_column2': {'sdtype': 'categorical'},
+                },
+                'primary_key': 'table1_primary_key',
+            },
+            'real_table2': {
+                'columns': {
+                    'table2_primary_key': {'sdtype': 'email'},
+                    'table2_foreign_key': {'sdtype': 'id', 'regex_format': 'ID_[0-9]{3}'},
+                },
+                'primary_key': 'table2_primary_key',
+            },
+        },
+        'relationships': [
+            {
+                'parent_table_name': 'real_table1',
+                'parent_primary_key': 'table1_primary_key',
+                'child_table_name': 'real_table2',
+                'child_foreign_key': 'table2_foreign_key',
+            }
+        ],
+    }
+    metadata = MultiTableMetadata.load_from_dict(metadata_dict)
+    table1_metadata = metadata.tables['real_table1']
+    table2_metadata = metadata.tables['real_table2']
+    metadata.validate()
+
+    # Run
+    anonymized = metadata.anonymize()
+
+    # Assert
+    anonymized.validate()
+
+    assert anonymized.tables.keys() == {'table1', 'table2'}
+    assert len(anonymized.relationships) == len(metadata.relationships)
+    assert anonymized.relationships[0]['parent_table_name'] == 'table1'
+    assert anonymized.relationships[0]['child_table_name'] == 'table2'
+    assert anonymized.relationships[0]['parent_primary_key'] == 'col1'
+    assert anonymized.relationships[0]['child_foreign_key'] == 'col2'
+
+    anon_primary_key_metadata = anonymized.tables['table1'].columns['col1']
+    assert anon_primary_key_metadata == table1_metadata.columns['table1_primary_key']
+
+    anon_foreign_key_metadata = anonymized.tables['table2'].columns['col2']
+    assert anon_foreign_key_metadata == table2_metadata.columns['table2_foreign_key']
+
+    assert anonymized.tables['table1'].to_dict() == table1_metadata.anonymize().to_dict()
+    assert anonymized.tables['table2'].to_dict() == table2_metadata.anonymize().to_dict()

--- a/tests/integration/metadata/test_single_table.py
+++ b/tests/integration/metadata/test_single_table.py
@@ -551,3 +551,49 @@ def test_metadata_set_same_sequence_primary():
     )
     with pytest.raises(InvalidMetadataError, match=error_msg_sequence):
         metadata_primary.set_sequence_key('A')
+
+
+def test_anonymize():
+    """Test the ``anonymize`` method."""
+    # Setup
+    metadata_dict = {
+        'columns': {
+            'primary_key': {'sdtype': 'id', 'regex_format': 'ID_[0-9]{3}'},
+            'sequence_index': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+            'sequence_key': {'sdtype': 'id'},
+            'alternate_id1': {'sdtype': 'email', 'pii': True},
+            'alternate_id2': {'sdtype': 'name', 'pii': True},
+            'numerical': {'sdtype': 'numerical', 'computer_representation': 'Float'},
+            'categorical': {'sdtype': 'categorical'},
+        },
+        'primary_key': 'primary_key',
+        'sequence_index': 'sequence_index',
+        'sequence_key': 'sequence_key',
+        'alternate_keys': ['alternate_id1', 'alternate_id2'],
+    }
+    metadata = SingleTableMetadata.load_from_dict(metadata_dict)
+    metadata.validate()
+
+    # Run
+    anonymized = metadata.anonymize()
+
+    # Assert
+    anonymized.validate()
+
+    assert all(original_col not in anonymized.columns for original_col in metadata.columns)
+    for original_col, anonymized_col in metadata._anonymized_column_map.items():
+        assert metadata.columns[original_col] == anonymized.columns[anonymized_col]
+
+    anon_primary_key = anonymized.primary_key
+    assert anonymized.columns[anon_primary_key] == metadata.columns['primary_key']
+
+    anon_alternate_keys = anonymized.alternate_keys
+    assert len(anon_alternate_keys) == len(metadata.alternate_keys)
+    assert anonymized.columns[anon_alternate_keys[0]] == metadata.columns['alternate_id1']
+    assert anonymized.columns[anon_alternate_keys[1]] == metadata.columns['alternate_id2']
+
+    anon_sequence_index = anonymized.sequence_index
+    assert anonymized.columns[anon_sequence_index] == metadata.columns['sequence_index']
+
+    anon_sequence_key = anonymized.sequence_key
+    assert anonymized.columns[anon_sequence_key] == metadata.columns['sequence_key']

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -1250,7 +1250,9 @@ class TestHMASynthesizer:
             instance.fit(data)
 
         # Assert
-        assert len(captured_warnings) == 0
+        for warning in captured_warnings:
+            assert warning.category is FutureWarning
+        assert len(captured_warnings) == 3
 
         # Run 2
         metadata_detect = MultiTableMetadata()
@@ -1269,7 +1271,9 @@ class TestHMASynthesizer:
             instance.fit(data)
 
         # Assert
-        assert len(captured_warnings) == 0
+        for warning in captured_warnings:
+            assert warning.category is FutureWarning
+        assert len(captured_warnings) == 3
 
         # Run 3
         instance = HMASynthesizer(metadata_detect)
@@ -1312,7 +1316,16 @@ class TestHMASynthesizer:
             instance.fit(data)
 
         # Assert
-        assert len(record) == 1
+        future_warnings = 0
+        user_warnings = 0
+        for warning in record:
+            if warning.category is FutureWarning:
+                future_warnings += 1
+            if warning.category is UserWarning:
+                user_warnings += 1
+        assert future_warnings == 3
+        assert user_warnings == 1
+        assert len(record) == 4
 
     def test_null_foreign_keys(self):
         """Test that the synthesizer crashes when there are null foreign keys."""

--- a/tests/integration/sequential/test_par.py
+++ b/tests/integration/sequential/test_par.py
@@ -406,6 +406,40 @@ def test_init_error_sequence_key_in_context():
         PARSynthesizer(metadata, context_columns=['A'])
 
 
+def test_par_with_datetime_context():
+    """Test PARSynthesizer with a datetime as a context column"""
+    # Setup
+    data = pd.DataFrame(
+        data={
+            'user_id': ['ID_00'] * 5 + ['ID_01'] * 5,
+            'birthdate': ['1995-05-06'] * 5 + ['1982-01-21'] * 5,
+            'timestamp': ['2023-06-21', '2023-06-22', '2023-06-23', '2023-06-24', '2023-06-25'] * 2,
+            'heartrate': [67, 66, 68, 65, 64, 80, 82, 91, 88, 84],
+        }
+    )
+
+    metadata = SingleTableMetadata.load_from_dict({
+        'columns': {
+            'user_id': {'sdtype': 'id', 'regex_format': 'ID_[0-9]{2}'},
+            'birthdate': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+            'timestamp': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+            'heartrate': {'sdtype': 'numerical'},
+        },
+        'sequence_key': 'user_id',
+        'sequence_index': 'timestamp',
+    })
+
+    # Run
+    synth = PARSynthesizer(metadata, epochs=50, verbose=True, context_columns=['birthdate'])
+
+    synth.fit(data)
+    sample = synth.sample(num_sequences=1)
+    expected_birthdate = pd.Series(['1984-02-23'] * 5, name='birthdate')
+
+    # Assert
+    pd.testing.assert_series_equal(sample['birthdate'], expected_birthdate)
+
+
 def test_par_categorical_column_represented_by_floats():
     """Test to see if categorical columns work fine  with float representation."""
     # Setup

--- a/tests/integration/sequential/test_par.py
+++ b/tests/integration/sequential/test_par.py
@@ -9,6 +9,7 @@ from deepecho import load_demo
 from sdv.datasets.demo import download_demo
 from sdv.errors import SynthesizerInputError
 from sdv.metadata import SingleTableMetadata
+from sdv.metadata.metadata import Metadata
 from sdv.sequential import PARSynthesizer
 
 
@@ -89,6 +90,7 @@ def test_column_after_date_complex():
     """Test that adding multiple columns after the ``sequence_index`` column works."""
     # Setup
     data, metadata = _get_par_data_and_metadata()
+    metadata = Metadata.load_from_dict(metadata.to_dict())
 
     # Run
     model = PARSynthesizer(metadata=metadata, context_columns=['context'], epochs=1)
@@ -105,6 +107,7 @@ def test_save_and_load(tmp_path):
     """Test that synthesizers can be saved and loaded properly."""
     # Setup
     _, metadata = _get_par_data_and_metadata()
+    metadata = Metadata.load_from_dict(metadata.to_dict())
     instance = PARSynthesizer(metadata)
     synthesizer_path = tmp_path / 'synthesizer.pkl'
     instance.save(synthesizer_path)
@@ -183,7 +186,8 @@ def test_synthesize_sequences(tmp_path):
     assert model_path.exists()
     assert model_path.is_file()
     assert loaded_synthesizer.get_info() == synthesizer.get_info()
-    assert loaded_synthesizer.metadata.to_dict() == metadata.to_dict()
+    single_table_metadata = loaded_synthesizer.metadata.get_table_metadata('default_table_name')
+    assert single_table_metadata.to_dict() == metadata.to_dict()
     synthesizer.validate(synthetic_data)
     synthesizer.validate(custom_synthetic_data)
     synthesizer.validate(custom_synthetic_data_conditional)

--- a/tests/integration/single_table/test_base.py
+++ b/tests/integration/single_table/test_base.py
@@ -13,6 +13,7 @@ from sdv import version
 from sdv.datasets.demo import download_demo
 from sdv.errors import SamplingError, SynthesizerInputError, VersionError
 from sdv.metadata import SingleTableMetadata
+from sdv.metadata.metadata import Metadata
 from sdv.sampling import Condition
 from sdv.single_table import (
     CopulaGANSynthesizer,
@@ -521,12 +522,12 @@ def test_save_and_load(tmp_path):
 
     # Assert
     assert isinstance(loaded_instance, BaseSingleTableSynthesizer)
-    assert loaded_instance.metadata.columns == {}
-    assert loaded_instance.metadata.primary_key is None
-    assert loaded_instance.metadata.alternate_keys == []
-    assert loaded_instance.metadata.sequence_key is None
-    assert loaded_instance.metadata.sequence_index is None
-    assert loaded_instance.metadata._version == 'SINGLE_TABLE_V1'
+    assert loaded_instance.metadata.get_columns() == {}
+    assert loaded_instance.metadata.get_primary_key() is None
+    assert loaded_instance.metadata.get_alternate_keys() == []
+    assert loaded_instance.metadata.get_sequence_key() is None
+    assert loaded_instance.metadata.get_sequence_index() is None
+    assert loaded_instance.metadata.METADATA_SPEC_VERSION == 'V1'
     assert instance._synthesizer_id == loaded_instance._synthesizer_id
 
 
@@ -545,12 +546,12 @@ def test_save_and_load_no_id(tmp_path):
 
     # Assert
     assert isinstance(loaded_instance, BaseSingleTableSynthesizer)
-    assert loaded_instance.metadata.columns == {}
-    assert loaded_instance.metadata.primary_key is None
-    assert loaded_instance.metadata.alternate_keys == []
-    assert loaded_instance.metadata.sequence_key is None
-    assert loaded_instance.metadata.sequence_index is None
-    assert loaded_instance.metadata._version == 'SINGLE_TABLE_V1'
+    assert loaded_instance.metadata.get_columns() == {}
+    assert loaded_instance.metadata.get_primary_key() is None
+    assert loaded_instance.metadata.get_alternate_keys() == []
+    assert loaded_instance.metadata.get_sequence_key() is None
+    assert loaded_instance.metadata.get_sequence_index() is None
+    assert loaded_instance.metadata.METADATA_SPEC_VERSION == 'V1'
     assert hasattr(instance, '_synthesizer_id') is False
     assert hasattr(loaded_instance, '_synthesizer_id') is True
     assert isinstance(loaded_instance._synthesizer_id, str) is True
@@ -587,7 +588,7 @@ def test_metadata_updated_no_warning(mock__fit, tmp_path):
             initialization, but is saved to a file before fitting.
     """
     # Setup
-    metadata_from_dict = SingleTableMetadata().load_from_dict({
+    metadata_from_dict = Metadata().load_from_dict({
         'columns': {
             'col 1': {'sdtype': 'numerical'},
             'col 2': {'sdtype': 'numerical'},
@@ -610,8 +611,8 @@ def test_metadata_updated_no_warning(mock__fit, tmp_path):
     assert len(captured_warnings) == 0
 
     # Run 2
-    metadata_detect = SingleTableMetadata()
-    metadata_detect.detect_from_dataframe(data)
+    metadata_detect = Metadata()
+    metadata_detect.detect_from_dataframes(data)
     file_name = tmp_path / 'singletable.json'
     metadata_detect.save_to_json(file_name)
     with warnings.catch_warnings(record=True) as captured_warnings:
@@ -648,8 +649,8 @@ def test_metadata_updated_warning_detect(mock__fit):
         'col 2': [4, 5, 6],
         'col 3': ['a', 'b', 'c'],
     })
-    metadata = SingleTableMetadata()
-    metadata.detect_from_dataframe(data)
+    metadata = Metadata()
+    metadata.detect_from_dataframes(data)
     expected_message = re.escape(
         "We strongly recommend saving the metadata using 'save_to_json' for replicability"
         ' in future SDV versions.'
@@ -684,7 +685,7 @@ def test_metadata_updated_warning(method, kwargs):
     The warning should be raised during synthesizer initialization.
     """
     # Setup
-    metadata = SingleTableMetadata().load_from_dict({
+    metadata = Metadata().load_from_dict({
         'columns': {
             'col 1': {'sdtype': 'id'},
             'col 2': {'sdtype': 'id'},
@@ -704,7 +705,7 @@ def test_metadata_updated_warning(method, kwargs):
         BaseSingleTableSynthesizer(metadata)
 
     # Assert
-    assert metadata._updated is False
+    assert metadata._check_updated_flag() is False
 
 
 def test_fit_raises_version_error():

--- a/tests/integration/single_table/test_constraints.py
+++ b/tests/integration/single_table/test_constraints.py
@@ -12,6 +12,7 @@ from sdv.constraints import Constraint, create_custom_constraint_class
 from sdv.constraints.errors import AggregateConstraintsError
 from sdv.datasets.demo import download_demo
 from sdv.metadata import SingleTableMetadata
+from sdv.metadata.metadata import Metadata
 from sdv.sampling import Condition
 from sdv.single_table import GaussianCopulaSynthesizer
 from tests.integration.single_table.custom_constraints import MyConstraint
@@ -136,7 +137,7 @@ def test_fit_with_unique_constraint_on_data_which_has_index_column():
         ],
     })
 
-    metadata = SingleTableMetadata()
+    metadata = Metadata()
     metadata.add_column('key', sdtype='id')
     metadata.add_column('index', sdtype='categorical')
     metadata.add_column('test_column', sdtype='categorical')

--- a/tests/integration/single_table/test_copulas.py
+++ b/tests/integration/single_table/test_copulas.py
@@ -16,6 +16,7 @@ from sdv.datasets.demo import download_demo
 from sdv.errors import ConstraintsNotMetError
 from sdv.evaluation.single_table import evaluate_quality, get_column_pair_plot, get_column_plot
 from sdv.metadata import SingleTableMetadata
+from sdv.metadata.metadata import Metadata
 from sdv.sampling import Condition
 from sdv.single_table import GaussianCopulaSynthesizer
 
@@ -28,6 +29,7 @@ def test_synthesize_table_gaussian_copula(tmp_path):
     """
     # Setup
     real_data, metadata = download_demo(modality='single_table', dataset_name='fake_hotel_guests')
+    metadata = SingleTableMetadata.load_from_dict(metadata.to_dict())
     synthesizer = GaussianCopulaSynthesizer(metadata)
     custom_synthesizer = GaussianCopulaSynthesizer(
         metadata,
@@ -106,7 +108,8 @@ def test_synthesize_table_gaussian_copula(tmp_path):
     loaded_synthesizer = GaussianCopulaSynthesizer.load(model_path)
     assert isinstance(synthesizer, GaussianCopulaSynthesizer)
     assert loaded_synthesizer.get_info() == synthesizer.get_info()
-    assert loaded_synthesizer.metadata.to_dict() == metadata.to_dict()
+    single_table_metadata = loaded_synthesizer.metadata.get_table_metadata('default_table_name')
+    assert single_table_metadata.to_dict() == metadata.to_dict()
     loaded_synthesizer.sample(20)
 
     # Assert - custom synthesizer
@@ -137,6 +140,7 @@ def test_adding_constraints(tmp_path):
     # Setup
     real_data, metadata = download_demo(modality='single_table', dataset_name='fake_hotel_guests')
 
+    metadata = Metadata.load_from_dict(metadata.to_dict())
     checkin_lessthan_checkout = {
         'constraint_class': 'Inequality',
         'constraint_parameters': {

--- a/tests/integration/single_table/test_ctgan.py
+++ b/tests/integration/single_table/test_ctgan.py
@@ -113,7 +113,8 @@ def test_synthesize_table_ctgan(tmp_path):
     loaded_synthesizer = CTGANSynthesizer.load(model_path)
     assert isinstance(synthesizer, CTGANSynthesizer)
     assert loaded_synthesizer.get_info() == synthesizer.get_info()
-    assert loaded_synthesizer.metadata.to_dict() == metadata.to_dict()
+    single_table_metadata = loaded_synthesizer.metadata.get_table_metadata('default_table_name')
+    assert single_table_metadata.to_dict() == metadata.to_dict()
     loaded_synthesizer.sample(20)
 
     # Assert - custom synthesizer

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -32,6 +32,7 @@ from sdv.constraints.tabular import (
     _validate_inputs_custom_constraint,
     create_custom_constraint_class,
 )
+from sdv.metadata.metadata import Metadata
 
 
 def dummy_transform_table(table_data):
@@ -202,8 +203,8 @@ class TestCreateCustomConstraint:
         """
         # Setup
         constraint_class = create_custom_constraint_class(sorted, sorted, sorted)
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         constraint_class._validate_metadata_columns(metadata, column_names=['a', 'b'])
@@ -224,8 +225,8 @@ class TestCreateCustomConstraint:
         """
         # Setup
         constraint_class = create_custom_constraint_class(sorted, sorted, sorted)
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         error_message = re.escape(
@@ -566,8 +567,8 @@ class TestFixedCombinations:
             - No error should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         FixedCombinations._validate_metadata_columns(metadata, column_names=['a', 'b'])
@@ -584,8 +585,8 @@ class TestFixedCombinations:
             - ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         error_message = re.escape(
@@ -598,8 +599,11 @@ class TestFixedCombinations:
     def test__validate_metadata_specific_to_constraint(self):
         """Test validating sdtypes with valid sdtypes."""
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'boolean'}, 'b': {'sdtype': 'categorical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
+            'a': {'sdtype': 'boolean'},
+            'b': {'sdtype': 'categorical'},
+        }
 
         # Run
         FixedCombinations._validate_metadata_specific_to_constraint(
@@ -609,8 +613,11 @@ class TestFixedCombinations:
     def test__validate_metadata_specific_to_constraint_incorrect_types(self):
         """Test validating sdtypes with invalid sdtypes"""
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'datetime'}, 'b': {'sdtype': 'numerical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
+            'a': {'sdtype': 'datetime'},
+            'b': {'sdtype': 'numerical'},
+        }
 
         # Run
         error_message = re.escape(
@@ -1019,8 +1026,8 @@ class TestInequality:
             - No error should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         Inequality._validate_metadata_columns(metadata, low_column_name='a', high_column_name='b')
@@ -1037,8 +1044,8 @@ class TestInequality:
             - ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         error_message = re.escape(
@@ -1060,8 +1067,11 @@ class TestInequality:
             - Metadata with sdtypes set to datetime for both the high and low column.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'datetime'}, 'b': {'sdtype': 'datetime'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
+            'a': {'sdtype': 'datetime'},
+            'b': {'sdtype': 'datetime'},
+        }
 
         # Run
         Inequality._validate_metadata_specific_to_constraint(
@@ -1078,8 +1088,11 @@ class TestInequality:
             - Metadata with sdtypes set to datetime for the high but not low column.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'datetime'}, 'b': {'sdtype': 'categorical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
+            'a': {'sdtype': 'datetime'},
+            'b': {'sdtype': 'categorical'},
+        }
 
         # Run
         error_message = re.escape(
@@ -1101,8 +1114,11 @@ class TestInequality:
             - Metadata with sdtypes set to numerical for both the high and low column.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'numerical'}, 'b': {'sdtype': 'numerical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
+            'a': {'sdtype': 'numerical'},
+            'b': {'sdtype': 'numerical'},
+        }
 
         # Run
         Inequality._validate_metadata_specific_to_constraint(
@@ -1119,8 +1135,11 @@ class TestInequality:
             - Metadata with sdtypes set to numerical for the high but not low column.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'numerical'}, 'b': {'sdtype': 'categorical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
+            'a': {'sdtype': 'numerical'},
+            'b': {'sdtype': 'categorical'},
+        }
 
         # Run
         error_message = re.escape(
@@ -1226,8 +1245,11 @@ class TestInequality:
         """
         # Setup
         instance = Inequality(low_column_name='a', high_column_name='b')
-        instance.metadata = Mock()
-        instance.metadata.columns = {'a': {'sdtype': 'datetime'}, 'b': {'sdtype': 'categorical'}}
+        instance.metadata = Mock(spec=Metadata)
+        instance.metadata.get_columns.return_value = {
+            'a': {'sdtype': 'datetime'},
+            'b': {'sdtype': 'categorical'},
+        }
 
         # Run / Assert
         err_msg = 'Both high and low must be datetime.'
@@ -1268,8 +1290,8 @@ class TestInequality:
         instance = Inequality(low_column_name='a', high_column_name='b')
         instance._validate_columns_exist = Mock()
         instance._get_is_datetime = Mock(return_value='abc')
-        instance.metadata = Mock()
-        instance.metadata.columns = {
+        instance.metadata = Mock(spec=Metadata)
+        instance.metadata.get_columns.return_value = {
             'a': {'sdtype': 'datetime', 'datetime_format': '%y %m, %d'},
             'b': {'sdtype': 'datetime', 'datetime_format': '%y %m, %d'},
         }
@@ -1296,8 +1318,11 @@ class TestInequality:
         # Setup
         table_data = pd.DataFrame({'a': [1, 2, 4], 'b': [4.0, 5.0, 6.0]})
         instance = Inequality(low_column_name='a', high_column_name='b')
-        instance.metadata = Mock()
-        instance.metadata.columns = {'a': {'sdtype': 'datetime'}, 'b': {'sdtype': 'datetime'}}
+        instance.metadata = Mock(spec=Metadata)
+        instance.metadata.get_columns.return_value = {
+            'a': {'sdtype': 'datetime'},
+            'b': {'sdtype': 'datetime'},
+        }
 
         # Run
         instance._fit(table_data)
@@ -1321,8 +1346,11 @@ class TestInequality:
             'b': pd.to_datetime(['2020-01-02']),
         })
         instance = Inequality(low_column_name='a', high_column_name='b')
-        instance.metadata = Mock()
-        instance.metadata.columns = {'a': {'sdtype': 'datetime'}, 'b': {'sdtype': 'datetime'}}
+        instance.metadata = Mock(spec=Metadata)
+        instance.metadata.get_columns.return_value = {
+            'a': {'sdtype': 'datetime'},
+            'b': {'sdtype': 'datetime'},
+        }
 
         # Run
         instance._fit(table_data)
@@ -1758,8 +1786,8 @@ class TestScalarInequality:
             - No error should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         ScalarInequality._validate_metadata_columns(metadata, column_name='a')
@@ -1776,8 +1804,8 @@ class TestScalarInequality:
             - ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         error_message = re.escape(
@@ -1800,8 +1828,8 @@ class TestScalarInequality:
             - The column name and a value set to a number.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'numerical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': {'sdtype': 'numerical'}}
 
         # Run
         ScalarInequality._validate_metadata_specific_to_constraint(
@@ -1821,8 +1849,8 @@ class TestScalarInequality:
             - The column name and a value set to a string.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'numerical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': {'sdtype': 'numerical'}}
 
         # Run
         error_message = "'value' must be an int or float."
@@ -1846,8 +1874,10 @@ class TestScalarInequality:
             - The column name and a value set to a datetime of the right format.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'datetime', 'datetime_format': 'm/d/y'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
+            'a': {'sdtype': 'datetime', 'datetime_format': 'm/d/y'}
+        }
         datetime_format_mock.return_value = True
 
         # Run
@@ -1873,8 +1903,10 @@ class TestScalarInequality:
             - A ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'datetime', 'datetime_format': 'm/d/y'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
+            'a': {'sdtype': 'datetime', 'datetime_format': 'm/d/y'}
+        }
         datetime_format_mock.return_value = False
 
         # Run
@@ -1900,8 +1932,8 @@ class TestScalarInequality:
             - A ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'categorical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': {'sdtype': 'categorical'}}
 
         # Run
         error_message = (
@@ -2026,7 +2058,8 @@ class TestScalarInequality:
         """
         # Setupy
         instance = ScalarInequality(column_name='a', value=1, relation='<')
-        instance.metadata = Mock(columns={'a': {'sdtype': 'datetime'}})
+        instance.metadata = Mock(spec=Metadata())
+        instance.metadata.get_columns.return_value = {'a': {'sdtype': 'datetime'}}
 
         # Run / Assert
         err_msg = 'Both column and value must be datetime.'
@@ -2090,7 +2123,7 @@ class TestScalarInequality:
         # Setup
         table_data = pd.DataFrame({'a': [1, 2, 4], 'b': [4.0, 5.0, 6.0]})
         instance = ScalarInequality(column_name='b', value=10, relation='>')
-        instance.metadata = MagicMock()
+        instance.metadata = MagicMock(spec=Metadata)
 
         # Run
         instance._fit(table_data)
@@ -2114,12 +2147,11 @@ class TestScalarInequality:
             'b': pd.to_datetime(['2020-01-02']),
         })
         instance = ScalarInequality(column_name='b', value='2020-01-01', relation='>')
-        instance.metadata = Mock(
-            columns={
-                'a': {'sdtype': 'datetime'},
-                'b': {'sdtype': 'datetime'},
-            }
-        )
+        instance.metadata = Mock(spec=Metadata())
+        instance.metadata.get_columns.return_value = {
+            'a': {'sdtype': 'datetime'},
+            'b': {'sdtype': 'datetime'},
+        }
 
         # Run
         instance._fit(table_data)
@@ -2435,8 +2467,8 @@ class TestPositive:
             - No error should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         Positive._validate_metadata_columns(metadata, column_name='a')
@@ -2453,8 +2485,8 @@ class TestPositive:
             - ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         error_message = re.escape(
@@ -2474,8 +2506,8 @@ class TestPositive:
             - Metadata with the column's sdtype set to numerical.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'numerical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': {'sdtype': 'numerical'}}
 
         # Run
         Positive._validate_metadata_specific_to_constraint(metadata, column_name='a')
@@ -2493,8 +2525,8 @@ class TestPositive:
             - Raises ConstraintMetadataError
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'datetime'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': {'sdtype': 'datetime'}}
 
         # Run
         error_message = (
@@ -2565,8 +2597,8 @@ class TestNegative:
             - No error should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         Negative._validate_metadata_columns(metadata, column_name='a')
@@ -2583,8 +2615,8 @@ class TestNegative:
             - ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         error_message = re.escape(
@@ -2604,8 +2636,8 @@ class TestNegative:
             - Metadata with the column's sdtype set to numerical.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'numerical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': {'sdtype': 'numerical'}}
 
         # Run
         Positive._validate_metadata_specific_to_constraint(metadata, column_name='a')
@@ -2623,8 +2655,8 @@ class TestNegative:
             - Raises ConstraintMetadataError
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'datetime'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': {'sdtype': 'datetime'}}
 
         # Run
         error_message = (
@@ -2700,8 +2732,8 @@ class TestRange:
             - No error should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2, 'c': 3}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2, 'c': 3}
 
         # Run
         Range._validate_metadata_columns(
@@ -2720,8 +2752,8 @@ class TestRange:
             - ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         error_message = re.escape(
@@ -2743,8 +2775,8 @@ class TestRange:
             - Metadata with sdtypes set to datetime for the high, middle and low column.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
             'a': {'sdtype': 'datetime'},
             'b': {'sdtype': 'datetime'},
             'c': {'sdtype': 'datetime'},
@@ -2766,8 +2798,8 @@ class TestRange:
             but not the middle.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
             'a': {'sdtype': 'datetime'},
             'b': {'sdtype': 'datetime'},
             'c': {'sdtype': 'numerical'},
@@ -2793,8 +2825,8 @@ class TestRange:
             - Metadata with sdtypes set to numerical for the high, middle and low column.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
             'a': {'sdtype': 'numerical'},
             'b': {'sdtype': 'numerical'},
             'c': {'sdtype': 'numerical'},
@@ -2816,8 +2848,8 @@ class TestRange:
             but not the middle.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
             'a': {'sdtype': 'numerical'},
             'b': {'sdtype': 'numerical'},
             'c': {'sdtype': 'datetime'},
@@ -2891,13 +2923,12 @@ class TestRange:
         """
         # Setup
         instance = Range('join_date', 'promotion_date', 'retirement_date')
-        instance.metadata = Mock(
-            columns={
-                'join_date': {'sdtype': 'datetime'},
-                'promotion_date': {'sdtype': 'datetime'},
-                'retirement_date': {'sdtype': 'datetime'},
-            }
-        )
+        instance.metadata = Mock(spec=Metadata)
+        instance.metadata.get_columns.return_value = {
+            'join_date': {'sdtype': 'datetime'},
+            'promotion_date': {'sdtype': 'datetime'},
+            'retirement_date': {'sdtype': 'datetime'},
+        }
 
         # Run
         is_datetime = instance._get_is_datetime()
@@ -2923,7 +2954,7 @@ class TestRange:
         """
         # Setup
         instance = Range('age_when_joined', 'current_age', 'retirement_age')
-        instance.metadata = MagicMock()
+        instance.metadata = MagicMock(spec=Metadata)
 
         # Run
         is_datetime = instance._get_is_datetime()
@@ -2950,13 +2981,12 @@ class TestRange:
         """
         # Setup
         instance = Range('join_date', 'promotion_date', 'current_age')
-        instance.metadata = Mock(
-            columns={
-                'join_date': {'sdtype': 'datetime'},
-                'promotion_date': {'sdtype': 'datetime'},
-                'current_age': {'sdtype': 'numerical'},
-            }
-        )
+        instance.metadata = Mock(spec=Metadata)
+        instance.metadata.get_columns.return_value = {
+            'join_date': {'sdtype': 'datetime'},
+            'promotion_date': {'sdtype': 'datetime'},
+            'current_age': {'sdtype': 'numerical'},
+        }
         expected_text = 'The constraint column and bounds must all be datetime.'
 
         # Run
@@ -2990,7 +3020,7 @@ class TestRange:
             dtype=np.int64,
         )
         instance = Range('age_when_joined', 'current_age', 'retirement_age')
-        instance.metadata = MagicMock()
+        instance.metadata = MagicMock(spec=Metadata)
 
         # Run
         instance._fit(table_data)
@@ -3177,7 +3207,7 @@ class TestRange:
             'b#c': [np.log(5), np.log(4), np.log(6)],
         })
         instance = Range('a', 'b', 'c')
-        instance.metadata = MagicMock()
+        instance.metadata = MagicMock(spec=Metadata)
 
         # Run
         instance.fit(table_data)
@@ -3202,13 +3232,12 @@ class TestRange:
         })
 
         instance = Range('a', 'b', 'c')
-        instance.metadata = Mock(
-            columns={
-                'a': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d %H:%M:%S'},
-                'b': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d %H:%M:%S'},
-                'c': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d %H:%M:%S'},
-            }
-        )
+        instance.metadata = Mock(spec=Metadata)
+        instance.metadata.get_columns.return_value = {
+            'a': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d %H:%M:%S'},
+            'b': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d %H:%M:%S'},
+            'c': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d %H:%M:%S'},
+        }
 
         # Run
         instance.fit(table_data)
@@ -3252,8 +3281,8 @@ class TestScalarRange:
             - No error should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         ScalarRange._validate_metadata_columns(metadata, column_name='a')
@@ -3270,8 +3299,8 @@ class TestScalarRange:
             - ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         error_message = re.escape(
@@ -3294,8 +3323,8 @@ class TestScalarRange:
             - The column name and both high_value and low_value set to a number.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'numerical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': {'sdtype': 'numerical'}}
 
         # Run
         ScalarRange._validate_metadata_specific_to_constraint(
@@ -3315,8 +3344,8 @@ class TestScalarRange:
             - The column name, low_value set to a number and high_value set to a string.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'numerical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': {'sdtype': 'numerical'}}
 
         # Run
         error_message = "Both 'high_value' and 'low_value' must be ints or floats"
@@ -3338,8 +3367,8 @@ class TestScalarRange:
             - The column name, high_value set to a number and low_value set to a string.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'numerical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': {'sdtype': 'numerical'}}
 
         # Run
         error_message = "Both 'high_value' and 'low_value' must be ints or floats"
@@ -3364,8 +3393,10 @@ class TestScalarRange:
             right format.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'datetime', 'datetime_format': 'm/d/y'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
+            'a': {'sdtype': 'datetime', 'datetime_format': 'm/d/y'}
+        }
         datetime_format_mock.return_value = True
 
         # Run
@@ -3394,8 +3425,10 @@ class TestScalarRange:
             - A ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'datetime', 'datetime_format': 'm/d/y'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
+            'a': {'sdtype': 'datetime', 'datetime_format': 'm/d/y'}
+        }
         datetime_format_mock.side_effect = [False, True]
 
         # Run
@@ -3428,8 +3461,10 @@ class TestScalarRange:
             - A ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'datetime', 'datetime_format': 'm/d/y'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {
+            'a': {'sdtype': 'datetime', 'datetime_format': 'm/d/y'}
+        }
         datetime_format_mock.side_effect = [True, False]
 
         # Run
@@ -3457,8 +3492,8 @@ class TestScalarRange:
             - A ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': {'sdtype': 'categorical'}}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': {'sdtype': 'categorical'}}
 
         # Run
         error_message = (
@@ -3573,7 +3608,8 @@ class TestScalarRange:
         """
         # Setup
         instance = ScalarRange('promotion_date', '2021-02-10', '2050-10-11')
-        instance.metadata = Mock(columns={'promotion_date': {'sdtype': 'datetime'}})
+        instance.metadata = Mock(spec=Metadata)
+        instance.metadata.get_columns.return_value = {'promotion_date': {'sdtype': 'datetime'}}
 
         # Run
         is_datetime = instance._get_is_datetime()
@@ -3599,7 +3635,7 @@ class TestScalarRange:
         """
         # Setup
         instance = ScalarRange('current_age', 21, 30)
-        instance.metadata = MagicMock()
+        instance.metadata = MagicMock(spec=Metadata)
 
         # Run
         is_datetime = instance._get_is_datetime()
@@ -3625,7 +3661,8 @@ class TestScalarRange:
         """
         # Setup
         instance = ScalarRange('promotion_date', 18, 25)
-        instance.metadata = Mock(columns={'promotion_date': {'sdtype': 'datetime'}})
+        instance.metadata = Mock(spec=Metadata)
+        instance.metadata.get_columns.return_value = {'promotion_date': {'sdtype': 'datetime'}}
         expected_text = 'The constraint column and bounds must all be datetime.'
 
         # Run
@@ -3676,7 +3713,7 @@ class TestScalarRange:
         # Setup
         table_data = pd.DataFrame({'current_age': [21, 22, 25]})
         instance = ScalarRange('current_age', 18, 20)
-        instance.metadata = MagicMock()
+        instance.metadata = MagicMock(spec=Metadata)
 
         # Run
         instance._fit(table_data)
@@ -3705,7 +3742,8 @@ class TestScalarRange:
             ]
         })
         instance = ScalarRange('checkin', '2022-05-05', '2022-06-01')
-        instance.metadata = Mock(columns={'checkin': {'sdtype': 'datetime'}})
+        instance.metadata = Mock(spec=Metadata)
+        instance.metadata.get_columns.return_value = {'checkin': {'sdtype': 'datetime'}}
 
         # Run
         instance._fit(table_data)
@@ -3823,7 +3861,7 @@ class TestScalarRange:
         table_data = pd.DataFrame({'current_age': [21, 22, 25]})
         instance = ScalarRange('current_age', 20, 28)
         mock_logit.return_value = [1, 2, 3]
-        instance.metadata = MagicMock()
+        instance.metadata = MagicMock(spec=Metadata)
 
         # Run
         instance.fit(table_data)
@@ -3858,7 +3896,7 @@ class TestScalarRange:
         transformed_data = pd.DataFrame({'current_age#20#28': [1, 2, 3]})
         mock_sigmoid.return_value = pd.Series([21, 22, 25])
         instance = ScalarRange('current_age', 20, 28)
-        instance.metadata = MagicMock()
+        instance.metadata = MagicMock(spec=Metadata)
 
         # Run
         instance.fit(table_data)
@@ -3949,8 +3987,8 @@ class TestOneHotEncoding:
             - No error should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         OneHotEncoding._validate_metadata_columns(metadata, column_names=['a', 'b'])
@@ -3967,8 +4005,8 @@ class TestOneHotEncoding:
             - ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         error_message = re.escape(
@@ -4063,8 +4101,8 @@ class TestUnique:
             - No error should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         Unique._validate_metadata_columns(metadata, column_names=['a', 'b'])
@@ -4081,8 +4119,8 @@ class TestUnique:
             - ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         error_message = re.escape(
@@ -4103,9 +4141,9 @@ class TestUnique:
             - Column names with list of columns different htan the primary key and alternate keys.
         """
         # Setup
-        metadata = Mock()
-        metadata.primary_key = 'a'
-        metadata.alternate_keys = ['b', 'c']
+        metadata = Mock(spec=Metadata)
+        metadata.get_primary_key.return_value = 'a'
+        metadata.get_alternate_keys.return_value = ['b', 'c']
 
         # Run
         Unique._validate_metadata_specific_to_constraint(metadata, column_names=['a', 'b', 'd'])
@@ -4121,9 +4159,9 @@ class TestUnique:
             - Column names with list of columns different htan the primary key and alternate keys.
         """
         # Setup
-        metadata = Mock()
-        metadata.primary_key = 'a'
-        metadata.alternate_keys = [('b', 'c'), 'd']
+        metadata = Mock(spec=Metadata)
+        metadata.get_primary_key.return_value = 'a'
+        metadata.get_alternate_keys.return_value = [('b', 'c'), 'd']
 
         # Run
         error_message = re.escape(
@@ -4424,8 +4462,8 @@ class TestFixedIncrements:
             - No error should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         FixedIncrements._validate_metadata_columns(metadata, column_name='a')
@@ -4442,8 +4480,8 @@ class TestFixedIncrements:
             - ConstraintMetadataError should be raised.
         """
         # Setup
-        metadata = Mock()
-        metadata.columns = {'a': 1, 'b': 2}
+        metadata = Mock(spec=Metadata)
+        metadata.get_columns.return_value = {'a': 1, 'b': 2}
 
         # Run
         error_message = re.escape(

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -620,8 +620,8 @@ class TestDataProcessor:
         }
 
         metadata = SingleTableMetadata()
-        metadata.add_column('country_column', sdtype='country_code')
-        metadata.add_column('city_column', sdtype='city')
+        metadata.columns['country_column'] = {'sdtype': 'country_code', 'pii': True}
+        metadata.columns['city_column'] = {'sdtype': 'city', 'pii': True}
         custom_constraint = Mock()
 
         dp = DataProcessor(metadata)

--- a/tests/unit/io/local/test_local.py
+++ b/tests/unit/io/local/test_local.py
@@ -36,7 +36,7 @@ class TestBaseLocalHandler:
         # Assert
         assert isinstance(metadata, MultiTableMetadata)
         assert metadata.to_dict() == {
-            'METADATA_SPEC_VERSION': 'MULTI_TABLE_V1',
+            'METADATA_SPEC_VERSION': 'V1',
             'relationships': [],
             'tables': {
                 'guests': {

--- a/tests/unit/lite/test_single_table.py
+++ b/tests/unit/lite/test_single_table.py
@@ -8,6 +8,7 @@ import pytest
 
 from sdv.lite import SingleTablePreset
 from sdv.metadata import SingleTableMetadata
+from sdv.metadata.metadata import Metadata
 from sdv.single_table import GaussianCopulaSynthesizer
 from tests.utils import DataFrameMatcher
 
@@ -29,7 +30,7 @@ class TestSingleTablePreset:
         The method should pass the parameters to the ``GaussianCopulaSynthesizer`` class.
         """
         # Setup
-        metadata_mock = MagicMock(spec_set=SingleTableMetadata)
+        metadata_mock = MagicMock(spec_set=Metadata)
 
         # Run
         SingleTablePreset(metadata=metadata_mock, name='FAST_ML')
@@ -49,7 +50,7 @@ class TestSingleTablePreset:
         The method should pass the locales parameter to the ``GaussianCopulaSynthesizer`` class.
         """
         # Setup
-        metadata_mock = MagicMock(spec_set=SingleTableMetadata)
+        metadata_mock = MagicMock(spec_set=Metadata)
 
         # Run
         SingleTablePreset(metadata=metadata_mock, name='FAST_ML', locales=['en_US', 'fr_CA'])
@@ -79,7 +80,7 @@ class TestSingleTablePreset:
     def test_get_metadata(self, mock_data_processor):
         """Test that it returns the ``metadata`` object."""
         # Setup
-        metadata = Mock()
+        metadata = Mock(spec=Metadata)
         instance = SingleTablePreset(metadata, 'FAST_ML')
 
         # Run
@@ -279,7 +280,7 @@ class TestSingleTablePreset:
     def test___repr__(self):
         """Test that a string of format 'SingleTablePreset(name=<name>)' is returned"""
         # Setup
-        instance = SingleTablePreset(metadata=SingleTableMetadata(), name='FAST_ML')
+        instance = SingleTablePreset(metadata=Metadata(), name='FAST_ML')
 
         # Run
         res = repr(instance)

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -3163,7 +3163,7 @@ class TestSingleTableMetadata:
         # Run
         message = (
             'There are multiple tables specified in the JSON. '
-            'Try using the MultiTableMetadata class to upgrade this file.'
+            'Try using the Metadata class to upgrade this file.'
         )
         with pytest.raises(InvalidMetadataError, match=message):
             SingleTableMetadata.upgrade_metadata('old')

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -794,7 +794,7 @@ class TestSingleTableMetadata:
         with pytest.raises(InvalidMetadataError, match=error_msg):
             instance.update_columns(['col_1', 'col_2'], sdtype='numerical', pii=True)
 
-    def test_update_columns_multiple_erros(self):
+    def test_update_columns_multiple_errors(self):
         """Test the ``update_columns`` method.
 
         Test that ``update_columns`` with multiple errors.
@@ -1248,6 +1248,23 @@ class TestSingleTableMetadata:
         instance._determine_sdtype_for_numbers.assert_called_once()
         instance._determine_sdtype_for_objects.assert_called_once()
         mock__get_datetime_format.assert_called_once()
+
+    def test__detect_primary_key_missing_sdtypes(self):
+        """The method should raise an error if not all sdtypes were detected."""
+        # Setup
+        data = pd.DataFrame({
+            'string_id': ['1', '2', '3', '4', '5', '6'],
+            'num_id': [1, 2, 3, 4, 5, 6],
+        })
+        metadata = SingleTableMetadata()
+        metadata.columns = {'string_id': {'sdtype': 'id'}}
+
+        # Run and Assert
+        message = (
+            'All columns must have sdtypes detected or set manually to detect the primary key.'
+        )
+        with pytest.raises(RuntimeError, match=message):
+            metadata._detect_primary_key(data)
 
     def test_detect_from_dataframe_raises_error(self):
         """Test the ``detect_from_dataframe`` method.

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -3210,3 +3210,42 @@ class TestSingleTableMetadata:
             'Successfully converted the old metadata, but the metadata was not valid. '
             'To use this with the SDV, please fix the following errors.\n blah'
         )
+
+    def test_anonymize(self):
+        """Test the ``anonymize`` method."""
+        # Setup
+        instance = SingleTableMetadata()
+        instance.columns = {
+            'real_column1': {'sdtype': 'id', 'regex_format': r'\d{30}'},
+            'real_column2': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+            'real_column3': {'sdtype': 'numerical'},
+            'real_column4': {'sdtype': 'id'},
+        }
+        instance.primary_key = 'real_column1'
+        instance.alternate_keys = ['real_column4']
+        instance.sequence_index = 'real_column2'
+        instance.sequence_key = 'real_column4'
+
+        # Run
+        anonymized = instance.anonymize()
+
+        # Assert
+        anonymized.validate()
+
+        assert all(original_col not in anonymized.columns for original_col in instance.columns)
+        for original_col, anonymized_col in instance._anonymized_column_map.items():
+            assert instance.columns[original_col] == anonymized.columns[anonymized_col]
+
+        anon_primary_key = anonymized.primary_key
+        assert anonymized.columns[anon_primary_key] == instance.columns['real_column1']
+
+        anon_alternate_keys = anonymized.alternate_keys
+        assert anonymized.columns[anon_alternate_keys[0]] == instance.columns['real_column4']
+
+        anon_sequence_index = anonymized.sequence_index
+        assert anonymized.columns[anon_sequence_index] == instance.columns['real_column2']
+
+        anon_sequence_key = anonymized.sequence_key
+        assert anonymized.columns[anon_sequence_key] == instance.columns['real_column4']
+
+        assert anon_alternate_keys[0] == anon_sequence_key

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -618,8 +618,9 @@ class TestBaseMultiTableSynthesizer:
         # Run
         error_msg = re.escape(
             'The provided data does not match the metadata:\n'
-            "The columns ['col1'] are not present in the metadata.\n\n"
-            "The metadata columns ['id_nesreca', 'nesreca_val', 'upravna_enota'] "
+            "Table: 'default_table_name'\n"
+            "Error: The columns ['col1'] are not present in the metadata.\n"
+            "Error: The metadata columns ['id_nesreca', 'nesreca_val', 'upravna_enota'] "
             'are not present in the data.'
         )
 

--- a/tests/unit/multi_table/test_hma.py
+++ b/tests/unit/multi_table/test_hma.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from sdv.errors import SynthesizerInputError
+from sdv.metadata.metadata import Metadata
 from sdv.metadata.multi_table import MultiTableMetadata
 from sdv.multi_table.hma import HMASynthesizer
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
@@ -17,6 +18,7 @@ class TestHMASynthesizer:
         """Test the default initialization of the ``HMASynthesizer``."""
         # Run
         metadata = get_multi_table_metadata()
+        metadata = Metadata.load_from_dict(metadata.to_dict())
         metadata.validate = Mock()
         instance = HMASynthesizer(metadata)
 

--- a/tests/unit/sequential/test_par.py
+++ b/tests/unit/sequential/test_par.py
@@ -444,8 +444,7 @@ class TestPARSynthesizer:
             'columns': {'gender': {'sdtype': 'categorical'}, 'name': {'sdtype': 'id'}}
         })
         par._context_synthesizer = initial_synthesizer
-        par._get_context_metadata = Mock()
-        par._get_context_metadata.return_value = context_metadata
+        par._get_context_metadata = Mock(return_value=context_metadata)
 
         # Run
         par._fit_context_model(data)
@@ -460,6 +459,49 @@ class TestPARSynthesizer:
         expected_fitted_data = pd.DataFrame({
             'name': ['Doe', 'Jane', 'John'],
             'gender': ['M', 'F', 'M'],
+        })
+        pd.testing.assert_frame_equal(fitted_data.sort_values(by='name'), expected_fitted_data)
+
+    @patch('sdv.sequential.par.GaussianCopulaSynthesizer')
+    def test__fit_context_model_with_datetime_context_column(self, gaussian_copula_mock):
+        """Test that the method fits a synthesizer to the context columns.
+
+        If there are context columns, the method should create a new DataFrame that groups
+        the data by the sequence_key and only contains the context columns. Then a synthesizer
+        should be fit to this new data.
+        """
+        # Setup
+        metadata = self.get_metadata()
+        data = self.get_data()
+        data['time'] = pd.to_datetime(data['time'])
+        data['time'] = data['time'].apply(lambda x: x.timestamp())
+        par = PARSynthesizer(metadata, context_columns=['time'])
+        initial_synthesizer = Mock()
+        context_metadata = SingleTableMetadata.load_from_dict({
+            'columns': {'time': {'sdtype': 'datetime'}, 'name': {'sdtype': 'id'}}
+        })
+        par._context_synthesizer = initial_synthesizer
+        par._get_context_metadata = Mock()
+        par._get_context_metadata.return_value = context_metadata
+
+        # Run
+        par._fit_context_model(data)
+
+        converted_context_metadata = SingleTableMetadata.load_from_dict({
+            'columns': {'time': {'sdtype': 'numerical'}, 'name': {'sdtype': 'id'}}
+        })
+
+        # Assert
+        gaussian_copula_mock.assert_called_with(
+            context_metadata,
+            enforce_min_max_values=initial_synthesizer.enforce_min_max_values,
+            enforce_rounding=initial_synthesizer.enforce_rounding,
+        )
+        assert converted_context_metadata.columns == context_metadata.columns
+        fitted_data = gaussian_copula_mock().fit.mock_calls[0][1][0]
+        expected_fitted_data = pd.DataFrame({
+            'name': ['Doe', 'Jane', 'John'],
+            'time': [1.578010e09, 1.577837e09, 1.577923e09],
         })
         pd.testing.assert_frame_equal(fitted_data.sort_values(by='name'), expected_fitted_data)
 

--- a/tests/unit/single_table/test_copulas.py
+++ b/tests/unit/single_table/test_copulas.py
@@ -427,7 +427,11 @@ class TestGaussianCopulaSynthesizer:
         """Test that it returns a list with columns that are from the metadata."""
         # Seutp
         instance = Mock()
-        instance.metadata.columns = {'a_value': object(), 'n_value': object(), 'b_value': object()}
+        instance.metadata.get_columns.return_value = {
+            'a_value': object(),
+            'n_value': object(),
+            'b_value': object(),
+        }
         columns = ['a', 'a_value.is_null', '__b_value', '__a_value__b_value', 'n_value']
 
         # Run

--- a/tests/unit/single_table/test_ctgan.py
+++ b/tests/unit/single_table/test_ctgan.py
@@ -7,6 +7,7 @@ import pytest
 from sdmetrics import visualization
 
 from sdv.errors import InvalidDataTypeError, NotFittedError
+from sdv.metadata.metadata import Metadata
 from sdv.metadata.single_table import SingleTableMetadata
 from sdv.single_table.ctgan import CTGANSynthesizer, TVAESynthesizer, _validate_no_category_dtype
 
@@ -237,7 +238,7 @@ class TestCTGANSynthesizer:
         that have been detected by the utility function.
         """
         # Setup
-        metadata = SingleTableMetadata()
+        metadata = Metadata()
         instance = CTGANSynthesizer(metadata)
         processed_data = Mock()
 
@@ -436,7 +437,7 @@ class TestTVAESynthesizer:
         that have been detected by the utility function.
         """
         # Setup
-        metadata = SingleTableMetadata()
+        metadata = Metadata()
         instance = TVAESynthesizer(metadata)
         processed_data = Mock()
 


### PR DESCRIPTION
resolves #2128 
CU-86b19amxa

Made metadata work with single table synthesizers by converting  `SingleTableMetadata` to `Metadata` before inserting into the synthesizers. Write a wrapper method so that all single table synthesizers can use Metadata when there is only one table.

Wrote unit tests and update tests to use the methods instead of directly accessing `SingleTableMetadata` attributes.