### PR TITLE
Replace MultiTableMetadata with Metadata

### DIFF
--- a/sdv/io/local/local.py
+++ b/sdv/io/local/local.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from sdv.metadata import MultiTableMetadata
+from sdv.metadata import Metadata
 
 
 class BaseLocalHandler:
@@ -25,11 +25,11 @@ class BaseLocalHandler:
                 Dictionary of table names to dataframes.
 
         Returns:
-            MultiTableMetadata:
-                An ``sdv.metadata.MultiTableMetadata`` object with the detected metadata
+            Metadata:
+                An ``sdv.metadata.Metadata`` object with the detected metadata
                 properties from the data.
         """
-        metadata = MultiTableMetadata()
+        metadata = Metadata()
         metadata.detect_from_dataframes(data)
         return metadata
 

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -26,6 +26,10 @@ from sdv.metadata.visualization import (
 LOGGER = logging.getLogger(__name__)
 MULTITABLEMETADATA_LOGGER = get_sdv_logger('MultiTableMetadata')
 WARNINGS_COLUMN_ORDER = ['Table Name', 'Column Name', 'sdtype', 'datetime_format']
+DEPRECATION_MSG = (
+    "The 'MultiTableMetadata' is deprecated. Please use the new "
+    "'Metadata' class for synthesizers."
+)
 
 
 class MultiTableMetadata:

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -1371,7 +1371,7 @@ class SingleTableMetadata:
             if len(tables) > 1:
                 raise InvalidMetadataError(
                     'There are multiple tables specified in the JSON. '
-                    'Try using the MultiTableMetadata class to upgrade this file.'
+                    'Try using the Metadata class to upgrade this file.'
                 )
 
             else:

--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -41,8 +41,7 @@ class BaseMultiTableSynthesizer:
 
     Args:
         metadata (sdv.metadata.Metadata):
-            Table metadata representing the data tables that this synthesizer will be used
-            for.
+            Metadata representing the data tables that this synthesizer will utilize.
         locales (list or str):
             The default locale(s) to use for AnonymizedFaker transformers.
             Defaults to ``['en_US']``.

--- a/sdv/multi_table/hma.py
+++ b/sdv/multi_table/hma.py
@@ -23,7 +23,7 @@ class HMASynthesizer(BaseHierarchicalSampler, BaseMultiTableSynthesizer):
     """Hierarchical Modeling Algorithm One.
 
     Args:
-        metadata (sdv.metadata.multi_table.MultiTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Multi table metadata representing the data tables that this synthesizer will be used
             for.
         locales (list or str):
@@ -47,7 +47,7 @@ class HMASynthesizer(BaseHierarchicalSampler, BaseMultiTableSynthesizer):
         """Get the number of data columns, ie colums that are not id, for each table.
 
         Args:
-            metadata (MultiTableMetadata):
+            metadata (Metadata):
                 Metadata of the datasets.
         """
         columns_per_table = {}

--- a/sdv/multi_table/utils.py
+++ b/sdv/multi_table/utils.py
@@ -123,7 +123,7 @@ def _simplify_relationships_and_tables(metadata, tables_to_drop):
     Removes the tables that are not direct child or grandchild of the root table.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         tables_to_drop (set):
             Set of the tables that relationships will be removed.
@@ -149,7 +149,7 @@ def _simplify_grandchildren(metadata, grandchildren):
      - Drop all modelables columns.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         grandchildren (set):
             Set of the grandchildren of the root table.
@@ -174,7 +174,7 @@ def _get_num_column_to_drop(metadata, child_table, max_col_per_relationships):
         - minimum number of column to drop = n + k - sqrt(k^2 + 1 + 2m)
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         child_table (str):
             Name of the child table.
@@ -232,7 +232,7 @@ def _simplify_child(metadata, child_table, max_col_per_relationships):
     """Simplify the child table.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         child_table (str):
             Name of the child table.
@@ -252,7 +252,7 @@ def _simplify_children(metadata, children, root_table, num_data_column):
      - Drop some modelable columns to have at most MAX_NUMBER_OF_COLUMNS columns to model.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         children (set):
             Set of the children of the root table.
@@ -288,11 +288,11 @@ def _simplify_metadata(metadata):
      - Drop some modelable columns in the children to have at most 1000 columns to model.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
 
     Returns:
-        MultiTableMetadata:
+        Metadata:
             Simplified metadata.
     """
     simplified_metadata = deepcopy(metadata)
@@ -330,7 +330,7 @@ def _simplify_data(data, metadata):
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
 
     Returns:
@@ -375,7 +375,7 @@ def _get_rows_to_drop(data, metadata):
     This ensures that we preserve the referential integrity between all the relationships.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         data (dict):
             Dictionary that maps each table name (string) to the data for that
@@ -470,7 +470,7 @@ def _subsample_table_and_descendants(data, metadata, table, num_rows):
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         table (str):
             Name of the table.
@@ -496,7 +496,7 @@ def _get_primary_keys_referenced(data, metadata):
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
 
     Returns:
@@ -568,7 +568,7 @@ def _subsample_ancestors(data, metadata, table, primary_keys_referenced):
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         table (str):
             Name of the table.
@@ -604,7 +604,7 @@ def _subsample_data(data, metadata, main_table_name, num_rows):
       referenced by the descendants and some unreferenced rows.
 
     Args:
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         data (dict):
             Dictionary that maps each table name (string) to the data for that

--- a/sdv/sampling/hierarchical_sampler.py
+++ b/sdv/sampling/hierarchical_sampler.py
@@ -12,7 +12,7 @@ class BaseHierarchicalSampler:
     """Hierarchical sampler mixin.
 
     Args:
-        metadata (sdv.metadata.multi_table.MultiTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Multi-table metadata representing the data tables that this sampler will be used for.
         table_synthesizers (dict):
             Dictionary mapping each table to a synthesizer. Should be instantiated and passed to

--- a/sdv/sampling/independent_sampler.py
+++ b/sdv/sampling/independent_sampler.py
@@ -10,7 +10,7 @@ class BaseIndependentSampler:
     """Independent sampler mixin.
 
     Args:
-        metadata (sdv.metadata.multi_table.MultiTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Multi-table metadata representing the data tables that this sampler will be used for.
         table_synthesizers (dict):
             Dictionary mapping each table to a synthesizer. Should be instantiated and passed to

--- a/sdv/utils/poc.py
+++ b/sdv/utils/poc.py
@@ -40,7 +40,7 @@ def simplify_schema(data, metadata, verbose=True):
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         verbose (bool):
             If True, print information about the simplification process.
@@ -50,7 +50,7 @@ def simplify_schema(data, metadata, verbose=True):
         tuple:
             dict:
                 Dictionary with the simplified dataframes.
-            MultiTableMetadata:
+            Metadata:
                 Simplified metadata.
     """
     try:
@@ -93,7 +93,7 @@ def get_random_subset(data, metadata, main_table_name, num_rows, verbose=True):
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         main_table_name (str):
             Name of the main table.

--- a/sdv/utils/utils.py
+++ b/sdv/utils/utils.py
@@ -18,7 +18,7 @@ def drop_unknown_references(data, metadata, drop_missing_values=True, verbose=Tr
         data (dict):
             Dictionary that maps each table name (string) to the data for that
             table (pandas.DataFrame).
-        metadata (MultiTableMetadata):
+        metadata (Metadata):
             Metadata of the datasets.
         drop_missing_values (bool):
             Boolean describing whether or not to also drop foreign keys with missing values

--- a/tests/integration/metadata/test_metadata.py
+++ b/tests/integration/metadata/test_metadata.py
@@ -281,7 +281,7 @@ def test_single_table_compatibility(tmp_path):
 
 
 def test_multi_table_compatibility(tmp_path):
-    """Test if SingleMetadataTable still has compatibility with single table synthesizers."""
+    """Test if MultiTableMetadata still has compatibility with multi table synthesizers."""
     # Setup
     data, _ = download_demo('multi_table', 'fake_hotels')
     warn_msg = re.escape(
@@ -333,6 +333,7 @@ def test_multi_table_compatibility(tmp_path):
     # Run
     with pytest.warns(FutureWarning, match=warn_msg):
         synthesizer = HMASynthesizer(metadata)
+
     synthesizer.fit(data)
     model_path = os.path.join(tmp_path, 'synthesizer.pkl')
     synthesizer.save(model_path)
@@ -340,13 +341,23 @@ def test_multi_table_compatibility(tmp_path):
     # Assert
     assert os.path.exists(model_path)
     assert os.path.isfile(model_path)
+
+    # Load HMASynthesizer
     loaded_synthesizer = HMASynthesizer.load(model_path)
+
+    # Asserts
     assert isinstance(synthesizer, HMASynthesizer)
     assert loaded_synthesizer.get_info() == synthesizer.get_info()
     assert isinstance(loaded_synthesizer.metadata, Metadata)
+
+    # Load Metadata
     expected_metadata = metadata.to_dict()
     expected_metadata['METADATA_SPEC_VERSION'] = 'V1'
+
+    # Asserts
     assert loaded_synthesizer.metadata.to_dict() == expected_metadata
+
+    # Sample from loaded synthesizer
     loaded_sample = loaded_synthesizer.sample(10)
     synthesizer.validate(loaded_sample)
 

--- a/tests/integration/metadata/test_metadata.py
+++ b/tests/integration/metadata/test_metadata.py
@@ -5,8 +5,8 @@ import pytest
 from sdv.datasets.demo import download_demo
 from sdv.metadata.metadata import DEFAULT_TABLE_NAME, Metadata
 from sdv.metadata.multi_table import MultiTableMetadata
-from sdv.multi_table.hma import HMASynthesizer
 from sdv.metadata.single_table import SingleTableMetadata
+from sdv.multi_table.hma import HMASynthesizer
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
 
 

--- a/tests/integration/metadata/test_metadata.py
+++ b/tests/integration/metadata/test_metadata.py
@@ -121,7 +121,7 @@ def test_detect_from_csvs(tmp_path):
     metadata = Metadata()
 
     for table_name, dataframe in real_data.items():
-        csv_path = tmp_path / f'{table_name}.csv'
+        csv_path = os.path.join(tmp_path, f'{table_name}.csv')
         dataframe.to_csv(csv_path, index=False)
 
     # Run
@@ -184,11 +184,11 @@ def test_detect_table_from_csv(tmp_path):
     metadata = Metadata()
 
     for table_name, dataframe in real_data.items():
-        csv_path = tmp_path / f'{table_name}.csv'
+        csv_path = os.path.join(tmp_path, f'{table_name}.csv')
         dataframe.to_csv(csv_path, index=False)
 
     # Run
-    metadata.detect_table_from_csv('hotels', tmp_path / 'hotels.csv')
+    metadata.detect_table_from_csv('hotels', os.path.join(tmp_path, 'hotels.csv'))
 
     # Assert
     metadata.update_column(
@@ -257,7 +257,7 @@ def test_single_table_compatibility(tmp_path):
     with pytest.warns(FutureWarning, match=warn_msg):
         synthesizer = GaussianCopulaSynthesizer(metadata)
     synthesizer.fit(data)
-    model_path = tmp_path / 'synthesizer.pkl'
+    model_path = os.path.join(tmp_path, 'synthesizer.pkl')
     synthesizer.save(model_path)
 
     # Assert
@@ -333,7 +333,7 @@ def test_multi_table_compatibility(tmp_path):
     with pytest.warns(FutureWarning, match=warn_msg):
         synthesizer = HMASynthesizer(metadata)
     synthesizer.fit(data)
-    model_path = tmp_path / 'synthesizer.pkl'
+    model_path = os.path.join(tmp_path, 'synthesizer.pkl')
     synthesizer.save(model_path)
 
     # Assert

--- a/tests/integration/metadata/test_metadata.py
+++ b/tests/integration/metadata/test_metadata.py
@@ -272,6 +272,7 @@ def test_multi_table_compatibility(tmp_path):
     )
 
     # Run
+    assert type(metadata) is MultiTableMetadata
     with pytest.warns(FutureWarning, match=warn_msg):
         synthesizer = HMASynthesizer(metadata)
     synthesizer.fit(data)

--- a/tests/integration/metadata/test_metadata.py
+++ b/tests/integration/metadata/test_metadata.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 import pytest

--- a/tests/integration/metadata/test_metadata.py
+++ b/tests/integration/metadata/test_metadata.py
@@ -262,8 +262,8 @@ def test_single_table_compatibility(tmp_path):
     synthesizer.save(model_path)
 
     # Assert
-    assert model_path.exists()
-    assert model_path.is_file()
+    assert os.path.exists(model_path)
+    assert os.path.isfile(model_path)
     loaded_synthesizer = GaussianCopulaSynthesizer.load(model_path)
     assert isinstance(synthesizer, GaussianCopulaSynthesizer)
     assert loaded_synthesizer.get_info() == synthesizer.get_info()
@@ -338,8 +338,8 @@ def test_multi_table_compatibility(tmp_path):
     synthesizer.save(model_path)
 
     # Assert
-    assert model_path.exists()
-    assert model_path.is_file()
+    assert os.path.exists(model_path)
+    assert os.path.isfile(model_path)
     loaded_synthesizer = HMASynthesizer.load(model_path)
     assert isinstance(synthesizer, HMASynthesizer)
     assert loaded_synthesizer.get_info() == synthesizer.get_info()

--- a/tests/unit/io/local/test_local.py
+++ b/tests/unit/io/local/test_local.py
@@ -36,7 +36,7 @@ class TestBaseLocalHandler:
         # Assert
         assert isinstance(metadata, MultiTableMetadata)
         assert metadata.to_dict() == {
-            'METADATA_SPEC_VERSION': 'MULTI_TABLE_V1',
+            'METADATA_SPEC_VERSION': 'V1',
             'relationships': [],
             'tables': {
                 'guests': {

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -3163,7 +3163,7 @@ class TestSingleTableMetadata:
         # Run
         message = (
             'There are multiple tables specified in the JSON. '
-            'Try using the MultiTableMetadata class to upgrade this file.'
+            'Try using the Metadata class to upgrade this file.'
         )
         with pytest.raises(InvalidMetadataError, match=message):
             SingleTableMetadata.upgrade_metadata('old')

--- a/tests/unit/multi_table/test_hma.py
+++ b/tests/unit/multi_table/test_hma.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from sdv.errors import SynthesizerInputError
+from sdv.metadata.metadata import Metadata
 from sdv.metadata.multi_table import MultiTableMetadata
 from sdv.multi_table.hma import HMASynthesizer
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
@@ -17,6 +18,7 @@ class TestHMASynthesizer:
         """Test the default initialization of the ``HMASynthesizer``."""
         # Run
         metadata = get_multi_table_metadata()
+        metadata = Metadata.load_from_dict(metadata.to_dict())
         metadata.validate = Mock()
         instance = HMASynthesizer(metadata)
 


### PR DESCRIPTION
resolves #2129 
CU-86b19awxk

Replace `MultiTableMetadata` with `Metadata` and warn the user of deprecation. Since `Metadata` is a derived class of `MultiTableMetadata`, almost all instances can be swapped easily. Tests have to change because new instances are created for `Metadata` conversion and it contains the spec version `V1` instead of `MULTI_TABLE_V1`