### PR TITLE
Changing conditions in ScalarRange for is_datetime

### DIFF
--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -1136,7 +1136,7 @@ class ScalarRange(Constraint):
         is_high_datetime = _is_datetime_type(self._high_value)
         is_datetime = is_low_datetime and is_high_datetime and is_column_datetime
 
-        if not is_datetime and any([is_low_datetime, is_column_datetime, is_high_datetime]):
+        if is_column_datetime and not(all([is_low_datetime, is_column_datetime, is_high_datetime])):
             raise ValueError('The constraint column and bounds must all be datetime.')
 
         return is_datetime


### PR DESCRIPTION
I suggest updating the condition that checks for `datetime` types in ScalarRange.

This resulted in an exception when the range values could be interpreted as dates (e.g., 1900, 2000) even though the column type is `int`.

Therefore I suggest raisin the exception only when the column is a `datetime` and not both low/high values of the range are datetime.
