### PR TITLE
Suppress warning when using GANs that suggests that CUDA isn't being used

### DIFF
--- a/sdv/single_table/ctgan.py
+++ b/sdv/single_table/ctgan.py
@@ -290,7 +290,7 @@ class CTGANSynthesizer(LossValuesMixin, BaseSingleTableSynthesizer):
         )
         self._model = CTGAN(**self._model_kwargs)
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=UserWarning)
+            warnings.filterwarnings('ignore', message='.*Attempting to run cuBLAS.*')
             self._model.fit(processed_data, discrete_columns=discrete_columns)
 
     def _sample(self, num_rows, conditions=None):

--- a/sdv/single_table/ctgan.py
+++ b/sdv/single_table/ctgan.py
@@ -1,5 +1,7 @@
 """Wrapper around CTGAN model."""
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import plotly.express as px
@@ -287,7 +289,9 @@ class CTGANSynthesizer(LossValuesMixin, BaseSingleTableSynthesizer):
             self.get_metadata(), processed_data, transformers
         )
         self._model = CTGAN(**self._model_kwargs)
-        self._model.fit(processed_data, discrete_columns=discrete_columns)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=UserWarning)
+            self._model.fit(processed_data, discrete_columns=discrete_columns)
 
     def _sample(self, num_rows, conditions=None):
         """Sample the indicated number of rows from the model.


### PR DESCRIPTION
CU-86b0vehd0, Resolve #2052.

This PR suppresses the warning generated in CTGAN: https://github.com/sdv-dev/CTGAN/blob/d132c23a7bf5883cba0d1cb09f6d54aa400c39fb/ctgan/synthesizers/ctgan.py#L43

The warning originates from torch: https://github.com/pytorch/pytorch/blob/f72266eceaf833cd1a44d8e4ac611bc36102539c/aten/src/ATen/cuda/CublasHandlePool.cpp#L135C5-L135C20