### PR TITLE
Enabling sdv logging causes tests to fail locally

### DIFF
--- a/sdv/logging/logger.py
+++ b/sdv/logging/logger.py
@@ -33,7 +33,7 @@ class CSVFormatter(logging.Formatter):
 
     def format(self, record):  # noqa: A003
         """Format the record and write to CSV."""
-        row = record.msg
+        row = record.msg.copy()
         row['LEVEL'] = record.levelname
         self.writer.writerow(row)
         data = self.output.getvalue()


### PR DESCRIPTION
resolves #2162 
By making a copy of the log message, it makes sure that other handlers don't get a modified record