### PR TITLE
Remove outdated docs dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ dev = [
 
     # docs
     'docutils>=0.12,<1',
-    'm2r2>=0.2.5,<1',
     'nbsphinx>=0.5.0,<1',
     'sphinx_toolbox>=2.5,<4',
     'Sphinx>=3,<8',


### PR DESCRIPTION
Fixes #2148

CU-86b1e5y2p

Current docs is unused for now.  A dependency (`m2r2`) used to include the markdown file "HISTORY.MD" in the docs isn't being updated and I'm removing it to avoid conflicts.

Possible replacement libraries should we need this functionality in the future include `sphinx-mdinclude` or `myst-parser
`