### PR TITLE
Hide warnings when using Metadata in PARSynthesizer

### DIFF
--- a/sdv/metadata/metadata.py
+++ b/sdv/metadata/metadata.py
@@ -110,8 +110,6 @@ class Metadata(MultiTableMetadata):
                 Name of the sequence index column.
         """
         self._validate_table_exists(table_name)
-        if len(self.tables) > 1:
-            warnings.warn('Sequential modeling is not yet supported on SDV Multi Table models.')
         self.tables[table_name].set_sequence_index(column_name)
 
     def set_sequence_key(self, table_name, column_name):
@@ -124,6 +122,4 @@ class Metadata(MultiTableMetadata):
                 Name (or tuple of names) of the sequence key column(s).
         """
         self._validate_table_exists(table_name)
-        if len(self.tables) > 1:
-            warnings.warn('Sequential modeling is not yet supported on SDV Multi Table models.')
         self.tables[table_name].set_sequence_key(column_name)

--- a/sdv/metadata/metadata.py
+++ b/sdv/metadata/metadata.py
@@ -110,6 +110,10 @@ class Metadata(MultiTableMetadata):
                 Name of the sequence index column.
         """
         self._validate_table_exists(table_name)
+        if len(self.tables) > 1:
+            warnings.warn(
+                'Sequential modeling will not support multi table models.'
+                ' This metadata contains multiple tables.')
         self.tables[table_name].set_sequence_index(column_name)
 
     def set_sequence_key(self, table_name, column_name):
@@ -122,4 +126,8 @@ class Metadata(MultiTableMetadata):
                 Name (or tuple of names) of the sequence key column(s).
         """
         self._validate_table_exists(table_name)
+        if len(self.tables) > 1:
+            warnings.warn(
+                'Sequential modeling will not support multi table models.'
+                ' This metadata contains multiple tables.')
         self.tables[table_name].set_sequence_key(column_name)

--- a/sdv/metadata/metadata.py
+++ b/sdv/metadata/metadata.py
@@ -110,10 +110,6 @@ class Metadata(MultiTableMetadata):
                 Name of the sequence index column.
         """
         self._validate_table_exists(table_name)
-        if len(self.tables) > 1:
-            warnings.warn(
-                'Sequential modeling will not support multi table models.'
-                ' This metadata contains multiple tables.')
         self.tables[table_name].set_sequence_index(column_name)
 
     def set_sequence_key(self, table_name, column_name):
@@ -126,8 +122,4 @@ class Metadata(MultiTableMetadata):
                 Name (or tuple of names) of the sequence key column(s).
         """
         self._validate_table_exists(table_name)
-        if len(self.tables) > 1:
-            warnings.warn(
-                'Sequential modeling will not support multi table models.'
-                ' This metadata contains multiple tables.')
         self.tables[table_name].set_sequence_key(column_name)

--- a/sdv/metadata/metadata.py
+++ b/sdv/metadata/metadata.py
@@ -99,3 +99,31 @@ class Metadata(MultiTableMetadata):
             )
 
         return next(iter(self.tables.values()), SingleTableMetadata())
+
+    def set_sequence_index(self, table_name, column_name):
+        """Set the sequence index of a table.
+
+        Args:
+            table_name (str):
+                Name of the table to set the sequence index.
+            column_name (str):
+                Name of the sequence index column.
+        """
+        self._validate_table_exists(table_name)
+        if len(self.tables) > 1:
+            warnings.warn('Sequential modeling is not yet supported on SDV Multi Table models.')
+        self.tables[table_name].set_sequence_index(column_name)
+
+    def set_sequence_key(self, table_name, column_name):
+        """Set the sequence key of a table.
+
+        Args:
+            table_name (str):
+                Name of the table to set the sequence key.
+            column_name (str, tulple[str]):
+                Name (or tuple of names) of the sequence key column(s).
+        """
+        self._validate_table_exists(table_name)
+        if len(self.tables) > 1:
+            warnings.warn('Sequential modeling is not yet supported on SDV Multi Table models.')
+        self.tables[table_name].set_sequence_key(column_name)

--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -14,6 +14,8 @@ from rdt.transformers import FloatFormatter
 
 from sdv._utils import _cast_to_iterable, _groupby_list
 from sdv.errors import SamplingError, SynthesizerInputError
+from sdv.metadata.errors import InvalidMetadataError
+from sdv.metadata.metadata import Metadata
 from sdv.metadata.single_table import SingleTableMetadata
 from sdv.sampling import Condition
 from sdv.single_table import GaussianCopulaSynthesizer
@@ -94,6 +96,9 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         cuda=True,
         verbose=False,
     ):
+        if type(metadata) is Metadata and len(metadata.tables) > 1:
+            raise InvalidMetadataError('PARSynthesizer can only be used with a single table.')
+
         super().__init__(
             metadata=metadata,
             enforce_min_max_values=enforce_min_max_values,
@@ -123,7 +128,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         }
         context_metadata = self._get_context_metadata()
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=".*The 'SingleTableMetadata' is deprecated.*")
+            warnings.filterwarnings(
+                'ignore', message=".*The 'SingleTableMetadata' is deprecated.*")
             self._context_synthesizer = GaussianCopulaSynthesizer(
                 metadata=context_metadata,
                 enforce_min_max_values=enforce_min_max_values,
@@ -337,7 +343,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         context_metadata: SingleTableMetadata = self._get_context_metadata()
         if self.context_columns or self._extra_context_columns:
             context_cols = (
-                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns +
+                list(self._extra_context_columns.keys())
             )
             context = transformed[context_cols]
         else:
@@ -354,7 +361,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
                     context_metadata.update_column(column, sdtype='numerical')
 
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=".*The 'SingleTableMetadata' is deprecated.*")
+            warnings.filterwarnings(
+                'ignore', message=".*The 'SingleTableMetadata' is deprecated.*")
             self._context_synthesizer = GaussianCopulaSynthesizer(
                 context_metadata,
                 enforce_min_max_values=self._context_synthesizer.enforce_min_max_values,
@@ -372,7 +380,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             for column in timeseries_data.columns
             if column
             not in (
-                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns +
+                list(self._extra_context_columns.keys())
             )
         ]
 

--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -128,8 +128,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         }
         context_metadata = self._get_context_metadata()
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', message=".*The 'SingleTableMetadata' is deprecated.*")
+            warnings.filterwarnings('ignore', message=".*The 'SingleTableMetadata' is deprecated.*")
             self._context_synthesizer = GaussianCopulaSynthesizer(
                 metadata=context_metadata,
                 enforce_min_max_values=enforce_min_max_values,
@@ -343,8 +342,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         context_metadata: SingleTableMetadata = self._get_context_metadata()
         if self.context_columns or self._extra_context_columns:
             context_cols = (
-                self._sequence_key + self.context_columns +
-                list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
             )
             context = transformed[context_cols]
         else:
@@ -361,8 +359,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
                     context_metadata.update_column(column, sdtype='numerical')
 
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', message=".*The 'SingleTableMetadata' is deprecated.*")
+            warnings.filterwarnings('ignore', message=".*The 'SingleTableMetadata' is deprecated.*")
             self._context_synthesizer = GaussianCopulaSynthesizer(
                 context_metadata,
                 enforce_min_max_values=self._context_synthesizer.enforce_min_max_values,
@@ -380,8 +377,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             for column in timeseries_data.columns
             if column
             not in (
-                self._sequence_key + self.context_columns +
-                list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
             )
         ]
 

--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -123,8 +123,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         }
         context_metadata = self._get_context_metadata()
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', message=".*The 'SingleTableMetadata' is deprecated.*")
+            warnings.filterwarnings('ignore', message=".*The 'SingleTableMetadata' is deprecated.*")
             self._context_synthesizer = GaussianCopulaSynthesizer(
                 metadata=context_metadata,
                 enforce_min_max_values=enforce_min_max_values,
@@ -338,8 +337,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         context_metadata: SingleTableMetadata = self._get_context_metadata()
         if self.context_columns or self._extra_context_columns:
             context_cols = (
-                self._sequence_key + self.context_columns +
-                list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
             )
             context = transformed[context_cols]
         else:
@@ -356,8 +354,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
                     context_metadata.update_column(column, sdtype='numerical')
 
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', message=".*The 'SingleTableMetadata' is deprecated.*")
+            warnings.filterwarnings('ignore', message=".*The 'SingleTableMetadata' is deprecated.*")
             self._context_synthesizer = GaussianCopulaSynthesizer(
                 context_metadata,
                 enforce_min_max_values=self._context_synthesizer.enforce_min_max_values,
@@ -375,8 +372,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
             for column in timeseries_data.columns
             if column
             not in (
-                self._sequence_key + self.context_columns +
-                list(self._extra_context_columns.keys())
+                self._sequence_key + self.context_columns + list(self._extra_context_columns.keys())
             )
         ]
 

--- a/tests/unit/sequential/test_par.py
+++ b/tests/unit/sequential/test_par.py
@@ -1075,9 +1075,7 @@ class TestPARSynthesizer:
 
         # Run and Assert
         PARSynthesizer(metadata)
-        error_msg = re.escape(
-            'Metadata contains more than one table, use a MultiTableSynthesizer instead.'
-        )
+        error_msg = re.escape('PARSynthesizer can only be used with a single table.')
 
         with pytest.raises(InvalidMetadataError, match=error_msg):
             PARSynthesizer(multi_metadata)


### PR DESCRIPTION
Fixing issue from bug bash:

- Hide `SingleTableMetadata` future warnings when using PARSynthesizer.
- Hide `Sequential modeling is not yet supported on SDV Multi Table models.` warnings coming from `MultiTableMetadata` unless there is more than one table in `Metadata`