### PR TITLE
Raise a proper `ValueError` message when the `Metadata` is empty

### DIFF
--- a/sdv/metadata/metadata.py
+++ b/sdv/metadata/metadata.py
@@ -163,6 +163,11 @@ class Metadata(MultiTableMetadata):
         return next(iter(self.tables.values()), SingleTableMetadata())
 
     def _handle_table_name(self, table_name):
+        if len(self.tables) == 0:
+            raise ValueError(
+                'The metadata object is currently empty. To populate it, please use either '
+                "'detect_from_dataframe' or 'detect_from_dataframes'."
+            )
         if table_name is None:
             if len(self.tables) == 1:
                 table_name = next(iter(self.tables))

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -707,3 +707,16 @@ class TestMetadataClass:
 
         # Assert
         assert isinstance(single_table_metadata, SingleTableMetadata)
+
+    def test__handle_table_name_with_empty_tables(self):
+        """Test that the proper `ValueError` is raised when there are no `tables`."""
+        # Setup
+        instance = Metadata()
+
+        # Run and Assert
+        error_msg = (
+            'The metadata object is currently empty. To populate it, please use either '
+            "'detect_from_dataframe' or 'detect_from_dataframes'."
+        )
+        with pytest.raises(ValueError, match=error_msg):
+            instance._handle_table_name(None)


### PR DESCRIPTION
Resolves #2252 
CU-86b2d6au4
