### PR TITLE
Fixing release notes by fixing splitting index

### DIFF
--- a/scripts/release_notes_generator.py
+++ b/scripts/release_notes_generator.py
@@ -132,7 +132,7 @@ def update_release_notes(release_notes):
         history = history_file.read()
 
     token = '# Release Notes\n\n'
-    split_index = history.find(token) + len(token) + 1
+    split_index = history.find(token) + len(token)
     header = history[:split_index]
     new_notes = f'{header}{release_notes}{history[split_index:]}'
 


### PR DESCRIPTION
resolves #2348 
The PR #2351 was created using this update. As you can see, the correct amount of '#' characters is being added before the new notes
<img width="718" alt="Screenshot 2025-01-16 at 3 37 26 PM" src="https://github.com/user-attachments/assets/1b567285-1a62-43a9-9241-9ea5a830feaa" />
