### PR TITLE
Add mode to save_to_json to allow for overwrites

### DIFF
--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -16,7 +16,7 @@ from sdv.logging import get_sdv_logger
 from sdv.metadata.errors import InvalidMetadataError
 from sdv.metadata.metadata_upgrader import convert_metadata
 from sdv.metadata.single_table import SingleTableMetadata
-from sdv.metadata.utils import read_json, validate_file_does_not_exist
+from sdv.metadata.utils import _validate_file_mode, read_json, validate_file_does_not_exist
 from sdv.metadata.visualization import (
     create_columns_node,
     create_summarized_columns_node,
@@ -1110,17 +1110,23 @@ class MultiTableMetadata:
         instance._set_metadata_dict(metadata_dict)
         return instance
 
-    def save_to_json(self, filepath):
+    def save_to_json(self, filepath, mode='write'):
         """Save the current ``MultiTableMetadata`` in to a ``json`` file.
 
         Args:
             filepath (str):
                 String that represent the ``path`` to the ``json`` file to be written.
+            mode (str):
+                String that determines the mode of the function.
+                'write' mode will create and write a file if it does not exist.
+                'overwrite' mode will overwrite a file if that file does exist.
 
         Raises:
-            Raises a ``ValueError`` if the path already exists.
+            Raises a ``ValueError`` if the path already exists and the mode is 'write'.
         """
-        validate_file_does_not_exist(filepath)
+        _validate_file_mode(mode)
+        if mode == 'write':
+            validate_file_does_not_exist(filepath)
         metadata = self.to_dict()
         total_columns = 0
         for table in self.tables.values():

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -1117,7 +1117,7 @@ class MultiTableMetadata:
             filepath (str):
                 String that represent the ``path`` to the ``json`` file to be written.
             mode (str):
-                String that determines the mode of the function.
+                String that determines the mode of the function. Defaults to ``write``.
                 'write' mode will create and write a file if it does not exist.
                 'overwrite' mode will overwrite a file if that file does exist.
 

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -1339,7 +1339,7 @@ class SingleTableMetadata:
             filepath (str):
                 String that represents the ``path`` to the ``json`` file to be written.
             mode (str):
-                String that determines the mode of the function.
+                String that determines the mode of the function. Defaults to ``write``.
                 'write' mode will create and write a file if it does not exist.
                 'overwrite' mode will overwrite a file if that file does exist.
 

--- a/sdv/metadata/single_table.py
+++ b/sdv/metadata/single_table.py
@@ -26,7 +26,7 @@ from sdv.errors import InvalidDataError
 from sdv.logging import get_sdv_logger
 from sdv.metadata.errors import InvalidMetadataError
 from sdv.metadata.metadata_upgrader import convert_metadata
-from sdv.metadata.utils import read_json, validate_file_does_not_exist
+from sdv.metadata.utils import _validate_file_mode, read_json, validate_file_does_not_exist
 from sdv.metadata.visualization import (
     create_columns_node,
     create_summarized_columns_node,
@@ -1332,17 +1332,23 @@ class SingleTableMetadata:
         node = {'': f'{{{node}}}'}
         return visualize_graph(node, [], output_filepath)
 
-    def save_to_json(self, filepath):
+    def save_to_json(self, filepath, mode='write'):
         """Save the current ``SingleTableMetadata`` in to a ``json`` file.
 
         Args:
             filepath (str):
                 String that represents the ``path`` to the ``json`` file to be written.
+            mode (str):
+                String that determines the mode of the function.
+                'write' mode will create and write a file if it does not exist.
+                'overwrite' mode will overwrite a file if that file does exist.
 
         Raises:
-            Raises an ``Error`` if the path already exists.
+            Raises an ``Error`` if the path already exists and the mode is 'write'.
         """
-        validate_file_does_not_exist(filepath)
+        _validate_file_mode(mode)
+        if mode == 'write':
+            validate_file_does_not_exist(filepath)
         metadata = self.to_dict()
         metadata['METADATA_SPEC_VERSION'] = self.METADATA_SPEC_VERSION
         SINGLETABLEMETADATA_LOGGER.info(

--- a/sdv/metadata/utils.py
+++ b/sdv/metadata/utils.py
@@ -24,3 +24,9 @@ def validate_file_does_not_exist(filepath):
             f"A file named '{filepath.name}' already exists in this folder. Please specify "
             'a different filename.'
         )
+
+
+def _validate_file_mode(mode):
+    possible_modes = ['write', 'overwrite']
+    if mode not in possible_modes:
+        raise ValueError(f"Mode '{mode}' must be in {possible_modes}.")

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -2843,11 +2843,11 @@ class TestMultiTableMetadata:
         assert instance.tables['table1']._version == 'SINGLE_TABLE_V1'
 
     @patch('sdv.metadata.utils.Path')
-    def test_save_to_json_file_exists(self, mock_path):
+    def test_save_to_json_file_exists_write(self, mock_path):
         """Test the ``save_to_json`` method.
 
         Test that when attempting to write over a file that already exists, the method
-        raises a ``ValueError``.
+        raises a ``ValueError`` when using the mode 'write'.
 
         Setup:
             - instance of ``MultiTableMetadata``.
@@ -2868,7 +2868,64 @@ class TestMultiTableMetadata:
             'a different filename.'
         )
         with pytest.raises(ValueError, match=error_msg):
-            instance.save_to_json('filepath.json')
+            instance.save_to_json('filepath.json', 'write')
+
+    def test_save_to_json_file_exists_overwrite(self, tmp_path):
+        """Test the ``save_to_json`` method using 'overwrite' mode.
+
+        Test that when attempting to write over a file that already exists, the method
+        works as expected with the mode 'overwrite'`.
+
+        Setup:
+            - instance of ``MultiTableMetadata``.
+            - save file to tmp path
+
+        Assert:
+            - Running save_to_json to the same path does not raise a ValueError
+            - The data in the value matches the second run of save_to_json
+        """
+        # Setup
+        instance = MultiTableMetadata()
+        file_name = tmp_path / 'multitable.json'
+        instance.save_to_json(file_name, 'write')
+        with open(file_name, 'rb') as multi_table_file:
+            saved_metadata = json.load(multi_table_file)
+            assert saved_metadata == instance.to_dict()
+
+        # Run
+        new_table = 'table'
+        new_col = 'col1'
+        instance.add_table(new_table)
+        instance.add_column(new_table, new_col, sdtype='id')
+        instance.save_to_json(file_name, 'overwrite')
+
+        # Assert
+        with open(file_name, 'rb') as multi_table_file:
+            new_saved_metadata = json.load(multi_table_file)
+            assert new_table in new_saved_metadata['tables']
+            assert new_col in new_saved_metadata['tables'][new_table]['columns']
+            assert new_saved_metadata == instance.to_dict()
+
+    def test_save_to_json_file_check_mode(self, tmp_path):
+        """Test the ``save_to_json`` method with invalid modes.
+
+        Test that invalid modes raise an error.
+
+        Setup:
+            - instance of ``MultiTableMetadata``.
+
+        Side Effects:
+            - Raise ``ValueError``saying mode is invalid.
+        """
+        # Setup
+        instance = MultiTableMetadata()
+        bad_mode = 'bad_mode'
+        file_name = tmp_path / 'multitable.json'
+        error_msg = re.escape(f"Mode '{bad_mode}' must be in ['write', 'overwrite'].")
+
+        # Assert
+        with pytest.raises(ValueError, match=error_msg):
+            instance.save_to_json(file_name, bad_mode)
 
     @patch('sdv.metadata.multi_table.datetime')
     def test_save_to_json(self, mock_datetime, tmp_path, caplog):


### PR DESCRIPTION
resolves #2392 
CU-86b42am23


Added a mode to `save_to_json`
- (default) 'write': The status quo. AKA write the metadata into a new file, and raise an error if the file already exists.
- 'overwite': Write the metadata into the file. If it already exists, re-write the file

Added tests to check for modes and overwrites are working properly