### PR TITLE
Allow default transformers to have custom arguments

### DIFF
--- a/sdv/_utils.py
+++ b/sdv/_utils.py
@@ -1,5 +1,6 @@
 """Miscellaneous utility functions."""
 
+import inspect
 import operator
 import uuid
 import warnings
@@ -450,3 +451,13 @@ def _is_numerical(value):
         return is_integer(value) or is_float(value)
     except Exception:
         return False
+
+
+def _get_transformer_init_kwargs(transformer):
+    """Get the dict of arguments used to instantiate the given transformer."""
+    args = inspect.getfullargspec(transformer.__init__).args[1:]
+    return {
+        key: getattr(transformer, key)
+        for key in args
+        if key != 'model_missing_values' and hasattr(transformer, key)
+    }

--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -1,6 +1,5 @@
 """Single table data processing."""
 
-import inspect
 import json
 import logging
 import warnings
@@ -14,6 +13,7 @@ from pandas.errors import IntCastingNaNError
 from rdt.transformers import AnonymizedFaker, get_default_transformers
 from rdt.transformers.pii.anonymization import get_anonymized_transformer
 
+from sdv._utils import _get_transformer_init_kwargs
 from sdv.constraints import Constraint
 from sdv.constraints.base import get_subclasses
 from sdv.constraints.errors import (
@@ -495,15 +495,6 @@ class DataProcessor:
 
         return transformer
 
-    @staticmethod
-    def _get_transformer_kwargs(transformer):
-        args = inspect.getfullargspec(transformer.__init__).args[1:]
-        return {
-            key: getattr(transformer, key)
-            for key in args
-            if key != 'model_missing_values' and hasattr(transformer, key)
-        }
-
     def _get_transformer_instance(self, sdtype, column_metadata):
         transformer = self._transformers_by_sdtype[sdtype]
         if isinstance(transformer, AnonymizedFaker):
@@ -522,7 +513,7 @@ class DataProcessor:
 
         if kwargs and transformer is not None:
             transformer_class = transformer.__class__
-            default_transformer_kwargs = self._get_transformer_kwargs(transformer)
+            default_transformer_kwargs = _get_transformer_init_kwargs(transformer)
             return transformer_class(**{**default_transformer_kwargs, **kwargs})
 
         return deepcopy(transformer)

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -1033,6 +1033,30 @@ class TestDataProcessor:
         assert isinstance(result, FloatFormatter)
         assert result.computer_representation == 'Int32'
 
+    def test__get_transformer_instance_passes_kwargs_from_default(self):
+        """Test the ``_get_transformer_instance`` uses the default transformers kwargs.
+
+        Test than when the default transformer has custom kwargs, they are also used
+        when creating a new instance of a transformer.
+        """
+        # Setup
+        dp = DataProcessor(SingleTableMetadata())
+        dp._transformers_by_sdtype['numerical'] = FloatFormatter(
+            missing_value_replacement='random',
+            missing_value_generation='from_column',
+            learn_rounding_scheme=False
+        )
+
+        # Run
+        result = dp._get_transformer_instance(
+            'numerical', {'computer_representation': 'Int32'})
+
+        # Assert
+        assert isinstance(result, FloatFormatter)
+        assert result.missing_value_replacement == 'random'
+        assert result.missing_value_generation == 'from_column'
+        assert result.learn_rounding_scheme is False
+
     @patch('sdv.data_processing.data_processor.LOGGER')
     @patch('sdv.data_processing.data_processor.rdt')
     def test__update_constraint_transformers(self, mock_rdt, mock_log):

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -1044,12 +1044,11 @@ class TestDataProcessor:
         dp._transformers_by_sdtype['numerical'] = FloatFormatter(
             missing_value_replacement='random',
             missing_value_generation='from_column',
-            learn_rounding_scheme=False
+            learn_rounding_scheme=False,
         )
 
         # Run
-        result = dp._get_transformer_instance(
-            'numerical', {'computer_representation': 'Int32'})
+        result = dp._get_transformer_instance('numerical', {'computer_representation': 'Int32'})
 
         # Assert
         assert isinstance(result, FloatFormatter)

--- a/tests/unit/test__utils.py
+++ b/tests/unit/test__utils.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pandas as pd
 import pytest
+from rdt.transformers.numerical import FloatFormatter
 
 from sdv import version
 from sdv._utils import (
@@ -16,6 +17,7 @@ from sdv._utils import (
     _get_chars_for_option,
     _get_datetime_format,
     _get_root_tables,
+    _get_transformer_init_kwargs,
     _is_datetime_type,
     _is_numerical,
     _validate_foreign_keys_not_null,
@@ -788,3 +790,23 @@ def test__is_numerical_string():
     # Assert
     assert str_result is False
     assert datetime_result is False
+
+
+def test__get_transformer_init_kwargs():
+    # Setup
+    transformer = FloatFormatter(
+        missing_value_replacement=None,
+        learn_rounding_scheme=True,
+        computer_representation='Float64',
+        enforce_min_max_values=False,
+    )
+
+    # Run
+    transformer_kwarg_dict = _get_transformer_init_kwargs(transformer)
+
+    # Assert
+    transformer_kwarg_dict == {
+        'missing_value_replacement': None,
+        'learn_rounding_scheme': True,
+        'computer_representation': 'Float64',
+    }


### PR DESCRIPTION
This PR updates the data processor so that parameters used to instantiate the default transformer for an sdtype are used to create additional instances of the transformer.