### PR TITLE
Metadata: Add sequence key and sequence index

### DIFF
--- a/tests/integration/metadata/test_visualization.py
+++ b/tests/integration/metadata/test_visualization.py
@@ -1,8 +1,25 @@
 import pandas as pd
 
+from sdv.datasets.demo import download_demo
 from sdv.metadata.metadata import Metadata
 from sdv.multi_table.hma import HMASynthesizer
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
+
+
+def test_visualize_graph_for_sequential_data():
+    """Test visualization has sequence key and index with sequential data."""
+    # Setup
+    _, metadata = download_demo(modality='sequential', dataset_name='nasdaq100_2019')
+
+    # Run
+    graph = metadata.visualize()
+
+    # Assert
+    assert 'Sequence index' in graph.source
+    assert 'Sequence key' in graph.source
+    assert 'Primary key' in graph.source
+    assert 'nasdaq100_2019' in graph.source
+    assert 'relationships' not in graph.source
 
 
 def test_visualize_graph_for_single_table():

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -826,3 +826,36 @@ class TestMetadataClass:
         # Assert
         metadata._get_anonymized_dict.assert_called_once()
         mock_load_from_dict.assert_called_once_with({})
+
+    @patch('sdv.metadata.multi_table.visualize_graph')
+    def test_visualize_with_sequence_key_and_index(self, visualize_graph_mock):
+        """Test the ``visualize`` method with sequence key and index"""
+        # Setup
+        metadata_dict = {
+            'tables': {
+                'nasdaq100_2019': {
+                    'columns': {
+                        'Symbol': {'sdtype': 'id', 'regex_format': '[A-Z]{4}'},
+                        'Date': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+                    },
+                    'sequence_index': 'Date',
+                    'sequence_key': 'Symbol',
+                }
+            },
+            'relationships': [],
+            'METADATA_SPEC_VERSION': 'V1',
+        }
+        metadata = Metadata.load_from_dict(metadata_dict)
+
+        # Run
+        metadata.visualize('full', True)
+
+        # Assert
+        expected_label = (
+            '{nasdaq100_2019|Symbol : id\\lDate : datetime\\l|Primary key: None\\l'
+            'Sequence key: Symbol\\lSequence index: Date\\l}'
+        )
+        expected_nodes = {
+            'nasdaq100_2019': expected_label,
+        }
+        visualize_graph_mock.assert_called_once_with(expected_nodes, [], None)


### PR DESCRIPTION
resolves #2411 
CU-86b46ytr4


Since all visualization code is still in `MultiTableMetadata`, decided to fix the visualization here. `Metadata` inherits all of  `MultiTableMetadata` so it gets these changes as well.

Multi Table Visualization
![multi](https://github.com/user-attachments/assets/0839157f-ca7e-4070-8894-47ee51604b91)
Single Table with Seq Key and Index
![seq](https://github.com/user-attachments/assets/28e6fbee-d17f-437c-88bf-e263a433b3f8)
Single Table with only Primary Key
![single](https://github.com/user-attachments/assets/488b1a19-54c8-4216-a2b7-114f2c61a7bf)
