### PR TITLE
Make single table CAGs backwards compatible

### DIFF
--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -674,7 +674,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
 
         if hasattr(self, '_original_metadata') and version == 'original':
             return self._original_metadata
-        return self.metadata
+        return super().get_metadata()
 
     def _transform_helper(self, data):
         """Validate and transform all CAG patterns during preprocessing.

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -191,6 +191,7 @@ class BaseSynthesizer:
     def _get_table_metadata(self):
         if isinstance(self.metadata, Metadata):
             return self.metadata.tables.get(self._table_name, SingleTableMetadata())
+
         return self.metadata
 
     def _validate_primary_key(self, data):
@@ -679,6 +680,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
 
         if hasattr(self, '_original_metadata') and version == 'original':
             return self._original_metadata
+
         return super().get_metadata()
 
     def _transform_helper(self, data):

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -834,14 +834,15 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                 )
                 sampled = pd.concat([sampled, raw_sampled[missing_cols]], axis=1)
 
-            for pattern in reversed(self._chained_patterns):
-                sampled = pattern.reverse_transform(sampled)
-                valid_rows = pattern.is_valid(sampled)
-                sampled = sampled[valid_rows]
+            if hasattr(self, '_chained_patterns') and hasattr(self, '_reject_sampling_patterns'):
+                for pattern in reversed(self._chained_patterns):
+                    sampled = pattern.reverse_transform(sampled)
+                    valid_rows = pattern.is_valid(sampled)
+                    sampled = sampled[valid_rows]
 
-            for pattern in reversed(self._reject_sampling_patterns):
-                valid_rows = pattern.is_valid(sampled)
-                sampled = sampled[valid_rows]
+                for pattern in reversed(self._reject_sampling_patterns):
+                    valid_rows = pattern.is_valid(sampled)
+                    sampled = sampled[valid_rows]
 
             if previous_rows is not None:
                 sampled = pd.concat([previous_rows, sampled], ignore_index=True)

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -672,7 +672,9 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                 f"Unrecognized version '{version}', please use 'original' or 'modified'."
             )
 
-        return self._original_metadata if version == 'original' else self.metadata
+        if hasattr(self, '_original_metadata') and version == 'original':
+            return self._original_metadata
+        return self.metadata
 
     def _transform_helper(self, data):
         """Validate and transform all CAG patterns during preprocessing.

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -160,7 +160,10 @@ class BaseSynthesizer:
         """Validate that the data follows the metadata."""
         errors = []
         try:
-            self.metadata.validate_data({self._table_name: data})
+            if isinstance(self.metadata, Metadata):
+                self.metadata.validate_data({self._table_name: data})
+            else:
+                self.metadata.validate_data(data)
         except InvalidDataError as error:
             errors += error.errors
 
@@ -186,7 +189,9 @@ class BaseSynthesizer:
         return []
 
     def _get_table_metadata(self):
-        return self.metadata.tables.get(self._table_name, SingleTableMetadata())
+        if isinstance(self.metadata, Metadata):
+            return self.metadata.tables.get(self._table_name, SingleTableMetadata())
+        return self.metadata
 
     def _validate_primary_key(self, data):
         primary_key = self._get_table_metadata().primary_key
@@ -622,7 +627,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
         super().__init__(metadata, enforce_min_max_values, enforce_rounding, locales)
         self._chained_patterns = []  # chain of patterns used to preprocess the data
         self._reject_sampling_patterns = []  # patterns used only for reject sampling
-        self._original_metadata = self.metadata
+        self._original_metadata = deepcopy(self.metadata)
 
     def add_cag(self, patterns):
         """Add the list of constraint-augmented generation patterns to the synthesizer.

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -264,7 +264,7 @@ class TestBaseSingleTableSynthesizer:
         result = instance.get_metadata()
 
         # Assert
-        assert result == metadata
+        assert result.to_dict() == metadata.to_dict()
 
     def test_auto_assign_transformers(self):
         """Test that the ``DataProcessor.prepare_for_fitting`` is being called."""


### PR DESCRIPTION
CU-86b4exee1.

This PR makes the usage of CAGs backwards compatible.

The feature branch `feature/single-table-CAG` adds two new attributes to `BaseSingleTableSynthesizer`: `_chained_patterns` and `_reject_sampling_patterns`. If a synthesizer from an older version is fitted, it won't have these two attributes and will crash during the `reverse_transform`, when the attributes are called.

This PR fixes the issue by skipping the part of the code which uses these attributes if they are not present. This works because that part of the code is only responsible for handling CAGs, which were not supported for the older versions of the synthesizer.

It also fixes the `get_metadata` method for a similar problem when the `_original_metadata` attribute doesn't exist.