### PR TITLE
Fix: Error message for reused foreign key in relationships was showing the valid relationship too

### DIFF
--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -190,8 +190,12 @@ class MultiTableMetadata:
                 )
 
     def _validate_foreign_key_uniqueness_across_relationships(
-        self, parent_table_name, parent_primary_key, child_table_name,
-        child_foreign_key, seen_foreign_keys
+        self,
+        parent_table_name,
+        parent_primary_key,
+        child_table_name,
+        child_foreign_key,
+        seen_foreign_keys,
     ):
         key = (child_table_name, child_foreign_key)
         current_relationship = (parent_table_name, parent_primary_key)
@@ -804,7 +808,9 @@ class MultiTableMetadata:
         for relation in self.relationships:
             self._append_relationships_errors(errors, self._validate_relationship, **relation)
             self._append_relationships_errors(
-                errors, self._validate_foreign_key_uniqueness_across_relationships, **relation,
+                errors,
+                self._validate_foreign_key_uniqueness_across_relationships,
+                **relation,
                 seen_foreign_keys=seen_foreign_keys,
             )
 

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -37,6 +37,7 @@ class MultiTableMetadata:
         self.tables = {}
         self.relationships = []
         self._multi_table_updated = False
+        self._seen_foreign_keys = {}
 
     def _check_updated_flag(self):
         is_single_table_updated = any(table._updated for table in self.tables.values())
@@ -170,7 +171,7 @@ class MultiTableMetadata:
                 'with a non-primary key.'
             )
 
-    def _validate_foreign_key_is_not_reused(
+    def _validate_new_foreign_key_is_not_reused(
         self, parent_table_name, parent_primary_key, child_table_name, child_foreign_key
     ):
         for relationship in self.relationships:
@@ -188,6 +189,23 @@ class MultiTableMetadata:
                     f"a foreign key column ('{child_foreign_key}') that is already used in another "
                     'relationship.'
                 )
+
+    def _validate_foreign_key_uniqueness_across_relationships(
+        self, parent_table_name, parent_primary_key, child_table_name, child_foreign_key
+    ):
+        key = (child_table_name, child_foreign_key)
+        current_relationship = (parent_table_name, parent_primary_key)
+
+        if key in self._seen_foreign_keys:
+            existing_relationship = self._seen_foreign_keys[key]
+            if existing_relationship != current_relationship:
+                raise InvalidMetadataError(
+                    f'Relationship between tables ({parent_table_name}, {child_table_name}) uses '
+                    f"a foreign key column ('{child_foreign_key}') that is already used in another "
+                    'relationship.'
+                )
+        else:
+            self._seen_foreign_keys[key] = current_relationship
 
     def _validate_relationship_does_not_exist(
         self, parent_table_name, parent_primary_key, child_table_name, child_foreign_key
@@ -219,9 +237,6 @@ class MultiTableMetadata:
         self._validate_foreign_child_key(child_table_name, parent_table_name, child_foreign_key)
 
         self._validate_relationship_sdtypes(
-            parent_table_name, parent_primary_key, child_table_name, child_foreign_key
-        )
-        self._validate_foreign_key_is_not_reused(
             parent_table_name, parent_primary_key, child_table_name, child_foreign_key
         )
 
@@ -298,7 +313,9 @@ class MultiTableMetadata:
         self._validate_relationship(
             parent_table_name, child_table_name, parent_primary_key, child_foreign_key
         )
-
+        self._validate_new_foreign_key_is_not_reused(
+            parent_table_name, parent_primary_key, child_table_name, child_foreign_key
+        )
         child_map = self._get_child_map()
         child_map[parent_table_name].add(child_table_name)
         self._validate_relationship_does_not_exist(
@@ -783,8 +800,12 @@ class MultiTableMetadata:
         """
         errors = []
         self._validate_single_table(errors)
+        self._seen_foreign_keys = {}
         for relation in self.relationships:
             self._append_relationships_errors(errors, self._validate_relationship, **relation)
+            self._append_relationships_errors(
+                errors, self._validate_foreign_key_uniqueness_across_relationships, **relation
+            )
 
         child_map = self._get_child_map()
 

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -528,8 +528,6 @@ class TestMetadataClass:
         # Run and Assert
         error_msg = re.escape(
             'Relationships:\n'
-            "Relationship between tables (users, payments) uses a foreign key column ('user_id') "
-            'that is already used in another relationship.\n'
             'Relationship between tables (transactions, payments) uses a foreign key column '
             "('user_id') that is already used in another relationship."
         )

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -85,7 +85,6 @@ class TestMultiTableMetadata:
         assert instance.tables == {}
         assert instance.relationships == []
         assert instance._multi_table_updated is False
-        assert instance._seen_foreign_keys == {}
 
     def test__check_metadata_updated_single_metadata_updated(self):
         """Test ``_check_metadata_updated`` when a single table metadata has been updated."""
@@ -421,11 +420,13 @@ class TestMultiTableMetadata:
         """Test the method raises an error if a foreign key is reused with a different parent."""
         # Setup
         metadata = MultiTableMetadata()
+        seen_foreign_keys = {}
         metadata._validate_foreign_key_uniqueness_across_relationships(
             parent_table_name='sessions',
             parent_primary_key='id',
             child_table_name='transactions',
             child_foreign_key='session_id',
+            seen_foreign_keys=seen_foreign_keys,
         )
 
         # Run and Assert
@@ -439,6 +440,7 @@ class TestMultiTableMetadata:
                 parent_primary_key='id',
                 child_table_name='transactions',
                 child_foreign_key='session_id',
+                seen_foreign_keys=seen_foreign_keys,
             )
 
     def test__validate_circular_relationships(self):


### PR DESCRIPTION
As part of #2454 and #2453 we've updated the behavior of the validate command when handling reused foreign keys in relationships.

### Previous behavior:
When multiple relationships used the same foreign key, the validation output would display all of them, even if the first one was valid. For example:
```python
Relationships:
Relationship between tables (A1, A3) uses a foreign key column ('fk3_A1_A2') that is already used in another relationship.
Relationship between tables (A2, A3) uses a foreign key column ('fk3_A1_A2') that is already used in another relationship.
```

### New behavior:
With the latest implementation, the validation will now retain the first valid relationship and only raise errors for subsequent conflicting relationships using the same foreign key. Example output:

```
Relationships:
Relationship between tables (A2, A3) uses a foreign key column ('fk3_A1_A2') that is already used in another relationship.
```