### PR TITLE
Add version parameter to the `get_metadata` function for `SingleTableSynthesizers`

### DIFF
--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -328,9 +328,28 @@ class BaseSynthesizer:
 
         return instantiated_parameters
 
-    def get_metadata(self):
-        """Return the ``Metadata`` for this synthesizer."""
+    def get_metadata(self, version='original'):
+        """Return the ``Metadata`` for this synthesizer.
+
+        Args:
+            version (str): The version of metadata to retrieve.
+                Must be either 'original' or 'modified'. Defaults to 'original'.
+
+        Returns:
+            Metadata:
+                The corresponding Metadata object for the requested version.
+
+        Raises:
+            ValueError:
+                If the specified version is not 'original' or 'modified'.
+        """
+        if version not in ('original', 'modified'):
+            raise ValueError("Version can only be 'original' or 'modified'.")
+
         table_name = getattr(self, '_table_name', None)
+        if version == 'original':
+            return Metadata.load_from_dict(self._original_metadata.to_dict(), table_name)
+
         return Metadata.load_from_dict(self.metadata.to_dict(), table_name)
 
     def load_custom_constraint_classes(self, filepath, class_names):

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -342,8 +342,8 @@ class TestBaseSingleTableSynthesizer:
 
     @patch('sdv.single_table.base.DataProcessor')
     @patch('sdv.single_table.base.Metadata.load_from_dict')
-    def test_get_metadata(self, mock_load_from_dict, _):
-        """Test that it returns the ``metadata`` object."""
+    def test_get_metadata_default(self, mock_load_from_dict, _):
+        """Test that get_metadata returns the 'original' metadata by default."""
         # Setup
         metadata = Metadata()
         metadata.get_column_names = Mock(return_value=[])
@@ -358,6 +358,63 @@ class TestBaseSingleTableSynthesizer:
 
         # Assert
         assert result == mock_converted_metadata
+        mock_load_from_dict.assert_called_once()
+
+    @patch('sdv.single_table.base.DataProcessor')
+    @patch('sdv.single_table.base.Metadata.load_from_dict')
+    def test_get_metadata_original(self, mock_load_from_dict, _):
+        """Test get_metadata with version='original'."""
+        # Setup
+        metadata = Metadata()
+        metadata.get_column_names = Mock(return_value=[])
+        instance = BaseSingleTableSynthesizer(
+            metadata, enforce_min_max_values=False, enforce_rounding=False
+        )
+        mock_converted_metadata = Mock()
+        mock_load_from_dict.return_value = mock_converted_metadata
+
+        # Run
+        result = instance.get_metadata(version='original')
+
+        # Assert
+        assert result == mock_converted_metadata
+        mock_load_from_dict.assert_called_once()
+
+    @patch('sdv.single_table.base.DataProcessor')
+    @patch('sdv.single_table.base.Metadata.load_from_dict')
+    def test_get_metadata_modified(self, mock_load_from_dict, _):
+        """Test get_metadata with version='modified'."""
+        # Setup
+        metadata = Metadata()
+        metadata.get_column_names = Mock(return_value=[])
+        instance = BaseSingleTableSynthesizer(
+            metadata, enforce_min_max_values=False, enforce_rounding=False
+        )
+        instance.metadata = metadata
+
+        mock_converted_metadata = Mock()
+        mock_load_from_dict.return_value = mock_converted_metadata
+
+        # Run
+        result = instance.get_metadata(version='modified')
+
+        # Assert
+        assert result == mock_converted_metadata
+        mock_load_from_dict.assert_called_once()
+
+    @patch('sdv.single_table.base.DataProcessor')
+    def test_get_metadata_invalid_version(self, _):
+        """Test get_metadata raises ValueError on invalid version."""
+        # Setup
+        metadata = Metadata()
+        metadata.get_column_names = Mock(return_value=[])
+        instance = BaseSingleTableSynthesizer(
+            metadata, enforce_min_max_values=False, enforce_rounding=False
+        )
+
+        # Run and assert
+        with pytest.raises(ValueError, match="Version can only be 'original' or 'modified'."):
+            instance.get_metadata(version='invalid')
 
     def test_auto_assign_transformers(self):
         """Test that the ``DataProcessor.prepare_for_fitting`` is being called."""


### PR DESCRIPTION
Resolves #2484 
CU-86b4tehv8