### PR TITLE
Non-key ID columns should use default categorical transformer instead of `UniformEncoder`

### DIFF
--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -600,7 +600,9 @@ class DataProcessor:
 
                     sdtypes[column] = 'pii' if column_metadata.get('pii') else 'text'
                 else:
-                    transformers[column] = rdt.transformers.categorical.UniformEncoder()
+                    transformers[column] = self._get_transformer_instance(
+                        'categorical', column_metadata
+                    )
                     sdtypes[column] = 'id'
 
             elif sdtype == 'unknown':

--- a/tests/unit/data_processing/test_data_processor.py
+++ b/tests/unit/data_processing/test_data_processor.py
@@ -1487,6 +1487,26 @@ class TestDataProcessor:
         # Assert
         assert config['transformers']['numerical_column'].function_kwargs['text'] == '!!%##'
 
+    def test__create_config_with_categorical_id_column(self):
+        """Test the ``_create_config`` method with a non-key, non-regex ID column."""
+        # Setup
+        data = pd.DataFrame({
+            'id_column': ['id1', 'id2', 'id3'],
+        })
+        metadata = SingleTableMetadata().load_from_dict({
+            'METADATA_SPEC_VERSION': 'SINGLE_TABLE_V1',
+            'columns': {'id_column': {'sdtype': 'id'}},
+        })
+        dp = DataProcessor(metadata)
+        dp._get_transformer_instance = Mock()
+
+        # Run
+        config = DataProcessor._create_config(dp, data, set())
+
+        # Assert
+        dp._get_transformer_instance.assert_called_once_with('categorical', {'sdtype': 'id'})
+        assert config['transformers']['id_column'] == dp._get_transformer_instance.return_value
+
     def test_update_transformers_not_fitted(self):
         """Test when ``self._hyper_transformer`` is ``None`` raises a ``NotFittedError``."""
         # Setup


### PR DESCRIPTION
Currently, any column with the `'id'` sdtype that is (1) not a key and (2) does not have a `'regex_format'` defined is always assigned the `UniformEncoder` transformer. However, this can cause problems in cases where we do not want to use the `UniformEncoder` to transform categorical values. For example, CTGAN does not apply transformations to categorical columns.

Instead, ID columns should fall back to whatever the default transformer is for categorical columns.