### PR TITLE
Add version parameter to SingleTableSynthesizer

### DIFF
--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -200,13 +200,10 @@ class BaseMultiTableSynthesizer:
             error_msg = f"Unrecognized version '{version}', please use 'original' or 'modified'."
             raise ValueError(error_msg)
 
-        if version == 'original':
-            original = (
-                self._original_metadata if hasattr(self, '_original_metadata') else self.metadata
-            )
-            return original
-        else:
-            return self.metadata
+        if version == 'original' and hasattr(self, '_original_metadata'):
+            return Metadata.load_from_dict(self._original_metadata.to_dict())
+
+        return Metadata.load_from_dict(self.metadata.to_dict())
 
     def _transform_helper(self, data):
         """Validate and transform all CAG patterns during preprocessing.

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -103,7 +103,11 @@ class BaseSynthesizer:
 
     def _check_input_metadata_updated(self):
         if not hasattr(self, '_input_metadata'):
-            unified_metadata = Metadata.load_from_dict(self._original_metadata.to_dict())
+            if hasattr(self, '_original_metadata'):
+                unified_metadata = Metadata.load_from_dict(self._original_metadata.to_dict())
+            else:
+                unified_metadata = Metadata.load_from_dict(self.metadata.to_dict())
+
             setattr(self, '_input_metadata', unified_metadata)
 
         if isinstance(self._input_metadata, Metadata):

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -152,7 +152,7 @@ class BaseSynthesizer:
         # Points to the input metadata object and allows us to check if user has changed it
         self._input_metadata = metadata
 
-        # Points to a dynamic metadata object that could be re-created by CAG's
+        # Points to a dynamic metadata object that could be modified by constraints
         self.metadata = metadata
 
         self._table_name = Metadata.DEFAULT_SINGLE_TABLE_NAME

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -158,7 +158,7 @@ class BaseSynthesizer:
         self.metadata.validate()
 
         # Points to a metadata object that conserves the initialized status of the synthesizer
-        self._original_metadata = deepcopy(metadata)
+        self._original_metadata = deepcopy(self.metadata)
         self._check_metadata_updated()
         self.enforce_min_max_values = enforce_min_max_values
         self.enforce_rounding = enforce_rounding

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -101,16 +101,16 @@ class BaseSynthesizer:
             for sdtype, transformer in self._model_sdtype_transformers.items():
                 self._data_processor._update_transformers_by_sdtypes(sdtype, transformer)
 
-    def _check_original_metadata_updated(self):
-        if not hasattr(self, '_original_metadata'):
+    def _check_input_metadata_updated(self):
+        if not hasattr(self, '_input_metadata'):
             unified_metadata = Metadata.load_from_dict(self.metadata.to_dict())
-            setattr(self, '_original_metadata', unified_metadata)
+            setattr(self, '_input_metadata', unified_metadata)
 
-        if isinstance(self._original_metadata, Metadata):
-            metadata = self._original_metadata._convert_to_single_table()
+        if isinstance(self._input_metadata, Metadata):
+            metadata = self._input_metadata._convert_to_single_table()
 
         else:
-            metadata = self._original_metadata
+            metadata = self._input_metadata
 
         if metadata._updated:
             warnings.warn(
@@ -139,7 +139,13 @@ class BaseSynthesizer:
         self, metadata, enforce_min_max_values=True, enforce_rounding=True, locales=['en_US']
     ):
         self._validate_inputs(enforce_min_max_values, enforce_rounding)
-        self._original_metadata = self.metadata = metadata
+
+        # Points to the input metadata object and allows us to check if user has changed it
+        self._input_metadata = metadata
+
+        # Points to a dynamic metadata object that could be re-created by CAG's
+        self.metadata = metadata
+
         self._table_name = Metadata.DEFAULT_SINGLE_TABLE_NAME
         if isinstance(metadata, Metadata):
             self._table_name = metadata._get_single_table_name()
@@ -150,6 +156,9 @@ class BaseSynthesizer:
             self.metadata.tables[self._table_name]._updated = metadata._updated
 
         self.metadata.validate()
+
+        # Points to a metadata object that conserves the initialized status of the synthesizer
+        self._original_metadata = deepcopy(metadata)
         self._check_metadata_updated()
         self.enforce_min_max_values = enforce_min_max_values
         self.enforce_rounding = enforce_rounding
@@ -343,12 +352,26 @@ class BaseSynthesizer:
 
         return instantiated_parameters
 
-    def get_metadata(self):
-        """Return the ``Metadata`` for this synthesizer."""
-        if isinstance(self.metadata, SingleTableMetadata):
-            table_name = getattr(self, '_table_name', None)
-            return Metadata.load_from_dict(self.metadata.to_dict(), table_name)
-        return self.metadata
+    def get_metadata(self, version='original'):
+        """Get the metadata, either original or modified after applying CAG patterns.
+
+        Args:
+            version (str, optional):
+                The version of metadata to return, must be one of 'original' or 'modified'. If
+                'original', will return the original metadata used to instantiate the
+                synthesizer. If 'modified', will return the modified metadata after applying this
+                synthesizer's CAG patterns. Defaults to 'original'.
+        """
+        if version not in ('original', 'modified'):
+            raise ValueError(
+                f"Unrecognized version '{version}', please use 'original' or 'modified'."
+            )
+
+        table_name = getattr(self, '_table_name', None)
+        if hasattr(self, '_original_metadata') and version == 'original':
+            return Metadata.load_from_dict(self._original_metadata.to_dict(), table_name)
+
+        return Metadata.load_from_dict(self.metadata.to_dict(), table_name)
 
     def load_custom_constraint_classes(self, filepath, class_names):
         """Load a custom constraint class for the current synthesizer.
@@ -558,7 +581,7 @@ class BaseSynthesizer:
         })
 
         check_synthesizer_version(self, is_fit_method=True, compare_operator=operator.lt)
-        self._check_original_metadata_updated()
+        self._check_input_metadata_updated()
         self._fitted = False
         self._data_processor.reset_sampling()
         self._random_state_set = False
@@ -688,26 +711,6 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
     def get_cag(self):
         """Get a list of constraint-augmented generation patterns applied to the synthesizer."""
         return deepcopy(self._chained_patterns + self._reject_sampling_patterns)
-
-    def get_metadata(self, version='original'):
-        """Get the metadata, either original or modified after applying CAG patterns.
-
-        Args:
-            version (str, optional):
-                The version of metadata to return, must be one of 'original' or 'modified'. If
-                'original', will return the original metadata used to instantiate the
-                synthesizer. If 'modified', will return the modified metadata after applying this
-                synthesizer's CAG patterns. Defaults to 'original'.
-        """
-        if version not in ('original', 'modified'):
-            raise ValueError(
-                f"Unrecognized version '{version}', please use 'original' or 'modified'."
-            )
-
-        if hasattr(self, '_original_metadata') and version == 'original':
-            return self._original_metadata
-
-        return super().get_metadata()
 
     def _transform_helper(self, data):
         """Validate and transform all CAG patterns during preprocessing.
@@ -1158,7 +1161,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                 ' sampling synthetic data.'
             )
 
-        self._check_original_metadata_updated()
+        self._check_input_metadata_updated()
         sample_timestamp = datetime.datetime.now()
         has_constraints = bool(self._data_processor._constraints)
         has_batches = batch_size is not None and batch_size != num_rows

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -103,7 +103,7 @@ class BaseSynthesizer:
 
     def _check_input_metadata_updated(self):
         if not hasattr(self, '_input_metadata'):
-            unified_metadata = Metadata.load_from_dict(self.metadata.to_dict())
+            unified_metadata = Metadata.load_from_dict(self._original_metadata.to_dict())
             setattr(self, '_input_metadata', unified_metadata)
 
         if isinstance(self._input_metadata, Metadata):
@@ -125,6 +125,11 @@ class BaseSynthesizer:
                 "We strongly recommend saving the metadata using 'save_to_json' for replicability"
                 ' in future SDV versions.'
             )
+            if hasattr(self, '_input_metadata'):
+                if hasattr(self._input_metadata, '_reset_updated_flag'):
+                    self._input_metadata._reset_updated_flag()
+                else:
+                    self._input_metadata._updated = False
 
     def _validate_regex_format(self):
         if self.metadata.tables:
@@ -156,10 +161,11 @@ class BaseSynthesizer:
             self.metadata.tables[self._table_name]._updated = metadata._updated
 
         self.metadata.validate()
+        self._check_metadata_updated()
 
         # Points to a metadata object that conserves the initialized status of the synthesizer
         self._original_metadata = deepcopy(self.metadata)
-        self._check_metadata_updated()
+
         self.enforce_min_max_values = enforce_min_max_values
         self.enforce_rounding = enforce_rounding
         self.locales = locales

--- a/tests/integration/single_table/test_base.py
+++ b/tests/integration/single_table/test_base.py
@@ -653,10 +653,6 @@ def test_metadata_updated_warning_detect(mock__fit):
         "The 'SingleTableMetadata' is deprecated. "
         "Please use the new 'Metadata' class for synthesizers."
     )
-    expected_input_metadata_updated_message = (
-        'Your metadata has been modified. Metadata modifications cannot be applied to an '
-        'existing synthesizer. Please create a new synthesizer with the modified metadata.'
-    )
 
     # Run
     with warnings.catch_warnings(record=True) as record:
@@ -664,13 +660,11 @@ def test_metadata_updated_warning_detect(mock__fit):
         instance.fit(data)
 
     # Assert
-    assert len(record) == 3
+    assert len(record) == 2
     assert record[0].category is FutureWarning
     assert str(record[0].message) == expected_deprecation_message
     assert record[1].category is UserWarning
     assert str(record[1].message) == expected_user_message
-    assert record[2].category is UserWarning
-    assert str(record[2].message) == expected_input_metadata_updated_message
 
 
 parametrization = [

--- a/tests/integration/single_table/test_base.py
+++ b/tests/integration/single_table/test_base.py
@@ -653,6 +653,10 @@ def test_metadata_updated_warning_detect(mock__fit):
         "The 'SingleTableMetadata' is deprecated. "
         "Please use the new 'Metadata' class for synthesizers."
     )
+    expected_input_metadata_updated_message = (
+        'Your metadata has been modified. Metadata modifications cannot be applied to an '
+        'existing synthesizer. Please create a new synthesizer with the modified metadata.'
+    )
 
     # Run
     with warnings.catch_warnings(record=True) as record:
@@ -660,11 +664,13 @@ def test_metadata_updated_warning_detect(mock__fit):
         instance.fit(data)
 
     # Assert
-    assert len(record) == 2
+    assert len(record) == 3
     assert record[0].category is FutureWarning
     assert str(record[0].message) == expected_deprecation_message
     assert record[1].category is UserWarning
     assert str(record[1].message) == expected_user_message
+    assert record[2].category is UserWarning
+    assert str(record[2].message) == expected_input_metadata_updated_message
 
 
 parametrization = [

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -1523,8 +1523,8 @@ class TestBaseMultiTableSynthesizer:
         patterns_metadata = BaseMultiTableSynthesizer.get_metadata(instance)
 
         # Assert
-        assert no_patterns_metadata == metadata
-        assert patterns_metadata == metadata
+        assert no_patterns_metadata.to_dict() == metadata.to_dict()
+        assert patterns_metadata.to_dict() == metadata.to_dict()
 
     def test_get_metadata_modified(self):
         """Test getting the modified metadata from the synthesizer."""
@@ -1537,7 +1537,7 @@ class TestBaseMultiTableSynthesizer:
         returned_metadata = BaseMultiTableSynthesizer.get_metadata(instance, 'modified')
 
         # Assert
-        assert returned_metadata == metadata
+        assert returned_metadata.to_dict() == metadata.to_dict()
 
     def test_get_metadata_bad_keyword(self):
         """Test passing a bad keyword to ``get_metadata``."""

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -76,8 +76,8 @@ class TestBaseSingleTableSynthesizer:
         # Assert
         instance.metadata._updated = False
 
-    def test__check_original_metadata_updated_warns_when_updated(self):
-        """Test the `_check_original_metadata_updated` method raises a warning."""
+    def test__check_input_metadata_updated_warns_when_updated(self):
+        """Test the `_check_input_metadata_updated` method raises a warning."""
         # Setup
         instance = Mock()
         metadata_instance = Mock()
@@ -94,10 +94,10 @@ class TestBaseSingleTableSynthesizer:
 
         # Run and Assert
         with pytest.warns(UserWarning, match=expected_message):
-            BaseSynthesizer._check_original_metadata_updated(instance)
+            BaseSynthesizer._check_input_metadata_updated(instance)
 
-    def test__check_original_metadata_updated_does_not_warn_if_not_updated(self):
-        """Test `_check_original_metadata_updated` does not warn if metadata is not updated."""
+    def test__check_input_metadata_updated_does_not_warn_if_not_updated(self):
+        """Test `_check_input_metadata_updated` does not warn if metadata is not updated."""
         # Setup
         instance = Mock()
         metadata_instance = Mock()
@@ -105,22 +105,22 @@ class TestBaseSingleTableSynthesizer:
         metadata_instance._updated = False
 
         instance.metadata.to_dict.return_value = {'some': 'data'}
-        instance._original_metadata = metadata_instance
+        instance._input_metadata = metadata_instance
 
         # Run and Assert
         with warnings.catch_warnings(record=True) as raised_warnings:
-            BaseSynthesizer._check_original_metadata_updated(instance)
+            BaseSynthesizer._check_input_metadata_updated(instance)
             assert not raised_warnings
 
     @patch('sdv.metadata.Metadata.load_from_dict')
-    def test__check_original_metadata_updated_sets_original_metadata_if_missing(
+    def test__check_input_metadata_updated_sets_original_metadata_if_missing(
         self, mock_load_from_dict
     ):
-        """Test `_check_original_metadata_updated` sets _original_metadata if not present."""
+        """Test `_check_input_metadata_updated` sets _original_metadata if not present."""
         # Setup
         instance = Mock()
         instance.metadata.to_dict.return_value = {'some': 'data'}
-        del instance._original_metadata
+        del instance._input_metadata
 
         loaded_metadata = Mock()
         loaded_metadata._convert_to_single_table.return_value = loaded_metadata
@@ -128,10 +128,10 @@ class TestBaseSingleTableSynthesizer:
         mock_load_from_dict.return_value = loaded_metadata
 
         # Run
-        BaseSynthesizer._check_original_metadata_updated(instance)
+        BaseSynthesizer._check_input_metadata_updated(instance)
 
         # Assert
-        assert instance._original_metadata == loaded_metadata
+        assert instance._input_metadata == loaded_metadata
 
     @patch('sdv.single_table.base._check_regex_format')
     def test__validate_regex_format(self, mock_check_regex_format):
@@ -620,7 +620,7 @@ class TestBaseSingleTableSynthesizer:
         instance._data_processor.reset_sampling.assert_called_once_with()
         instance.preprocess.assert_called_once_with(data)
         instance.fit_processed_data.assert_called_once_with(instance.preprocess.return_value)
-        instance._check_original_metadata_updated.assert_called_once()
+        instance._check_input_metadata_updated.assert_called_once()
         assert caplog.messages[0] == str({
             'EVENT': 'Fit',
             'TIMESTAMP': '2024-04-19 16:20:10.037183',
@@ -1709,7 +1709,7 @@ class TestBaseSingleTableSynthesizer:
         instance._sample_with_progress_bar.assert_called_once_with(
             10, 50, 5, 'temp.csv', show_progress_bar=True
         )
-        instance._check_original_metadata_updated.assert_called_once_with()
+        instance._check_input_metadata_updated.assert_called_once_with()
         pd.testing.assert_frame_equal(result, pd.DataFrame({'col': [1, 2, 3]}))
         assert caplog.messages[0] == str({
             'EVENT': 'Sample',


### PR DESCRIPTION
Resolves #2484 
CU-86b4tehv8

This pull request adds a new private attribute to the `BaseSynthesizer`, the `_input_metadata`. This attribute holds reference to the input metadata of the user. This allows us to determine wether or not they have updated the metadata after some steps and they forgot to re-create a synthesizer.

This conserves the current `self.metadata` and `self._original_metadata` as two different objects. The `_original_metadata` being the unmodified metadata of the original input, while `self.metadata` is the mutable version that could be altered by CAG's or other processes.

