### PR TITLE
Inequality CAG does not respect datetime format

### DIFF
--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -184,8 +184,8 @@ class BaseSynthesizer:
             enforce_min_max_values=self.enforce_min_max_values,
             locales=self.locales,
         )
-        self._dtypes = {}
-        self._formatters = {}  # Data formatters for columns not handled by the data processor
+        self._constraint_col_dtypes = {}
+        self._constraint_col_formatters = {}  # Formatters for columns dropped by constraints
         self._validate_regex_format()
         self._original_columns = pd.Index([])
         self._fitted = False
@@ -508,38 +508,41 @@ class BaseSynthesizer:
 
     def _fit_constraint_column_formatters(self, data):
         """Fit formatters for columns that are dropped by constraints before data processing."""
-        self._formatters = {}
-        self._dtypes = {}
+        self._constraint_col_formatters = {}
+        self._constraint_col_dtypes = {}
         primary_key = self.metadata.tables[self._table_name].primary_key
-        input_columns = self._input_metadata.get_column_names()
+        input_columns = self._original_metadata.get_column_names()
         columns_to_format = set(input_columns) - set(self.metadata.get_column_names())
         for column_name in columns_to_format:
-            self._dtypes[column_name] = data[column_name].dtype
-            column_metadata = self._input_metadata.tables[self._table_name].columns.get(column_name)
+            self._constraint_col_dtypes[column_name] = data[column_name].dtype
+            column_metadata = self._original_metadata.tables[self._table_name].columns.get(
+                column_name
+            )
             sdtype = column_metadata.get('sdtype')
             if sdtype == 'numerical' and column_name != primary_key:
                 representation = column_metadata.get('computer_representation', 'Float')
-                self._formatters[column_name] = NumericalFormatter(
+                self._constraint_col_formatters[column_name] = NumericalFormatter(
                     enforce_rounding=self.enforce_rounding,
                     enforce_min_max_values=self.enforce_min_max_values,
                     computer_representation=representation,
                 )
-                self._formatters[column_name].learn_format(data[column_name])
+                self._constraint_col_formatters[column_name].learn_format(data[column_name])
 
             elif sdtype == 'datetime' and column_name != primary_key:
                 datetime_format = column_metadata.get('datetime_format')
-                self._formatters[column_name] = DatetimeFormatter(datetime_format=datetime_format)
-                self._formatters[column_name].learn_format(data[column_name])
+                self._constraint_col_formatters[column_name] = DatetimeFormatter(
+                    datetime_format=datetime_format
+                )
+                self._constraint_col_formatters[column_name].learn_format(data[column_name])
 
     def _format_constraint_columns(self, data):
         """Format columns skipped by the data processor due to being dropped by constraints."""
         column_order = [
-            column for column in self._input_metadata.get_column_names() if column in data
+            column for column in self._original_metadata.get_column_names() if column in data
         ]
-        for column_name in self._dtypes:
+        for column_name, dtype in self._constraint_col_dtypes.items():
             column_data = data[column_name]
 
-            dtype = self._dtypes[column_name]
             if is_integer_dtype(dtype) and is_float_dtype(column_data.dtype):
                 column_data = column_data.round()
 
@@ -564,9 +567,11 @@ class BaseSynthesizer:
                     'and metadata settings.'
                 )
 
-            if column_name in self._formatters:
+            if column_name in self._constraint_col_formatters:
                 data_to_format = data[column_name]
-                data[column_name] = self._formatters[column_name].format_data(data_to_format)
+                data[column_name] = self._constraint_col_formatters[column_name].format_data(
+                    data_to_format
+                )
 
         return data[column_order]
 
@@ -664,11 +669,14 @@ class BaseSynthesizer:
         check_synthesizer_version(self, is_fit_method=True, compare_operator=operator.lt)
         self._check_input_metadata_updated()
         self._fitted = False
-        self._fit_constraint_column_formatters(data)
         self._data_processor.reset_sampling()
         self._random_state_set = False
+        is_converted = self._store_and_convert_original_cols(data)
+        self._fit_constraint_column_formatters(data)
         processed_data = self.preprocess(data)
         self.fit_processed_data(processed_data)
+        if is_converted:
+            data.columns = self._original_columns
 
     def _validate_fit_before_save(self):
         """Validate that the synthesizer has been fitted before saving."""
@@ -975,12 +983,6 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                 except NotImplementedError:
                     raw_sampled = self._sample(num_rows)
             sampled = self._data_processor.reverse_transform(raw_sampled)
-            if keep_extra_columns:
-                input_columns = self._data_processor._hyper_transformer._input_columns
-                missing_cols = list(
-                    set(raw_sampled.columns) - set(input_columns) - set(sampled.columns)
-                )
-                sampled = pd.concat([sampled, raw_sampled[missing_cols]], axis=1)
 
             if hasattr(self, '_chained_patterns') and hasattr(self, '_reject_sampling_patterns'):
                 for pattern in reversed(self._chained_patterns):
@@ -992,8 +994,15 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                     valid_rows = pattern.is_valid(sampled)
                     sampled = sampled[valid_rows]
 
-            if hasattr(self, '_formatters'):
+            if getattr(self, '_constraint_col_dtypes'):
                 sampled = self._format_constraint_columns(sampled)
+
+            if keep_extra_columns:
+                input_columns = self._data_processor._hyper_transformer._input_columns
+                missing_cols = list(
+                    set(raw_sampled.columns) - set(input_columns) - set(sampled.columns)
+                )
+                sampled = pd.concat([sampled, raw_sampled[missing_cols]], axis=1)
 
             if previous_rows is not None:
                 sampled = pd.concat([previous_rows, sampled], ignore_index=True)

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -18,6 +18,8 @@ import numpy as np
 import pandas as pd
 import tqdm
 from copulas.multivariate import GaussianMultivariate
+from pandas.api.types import is_float_dtype, is_integer_dtype
+from pandas.errors import IntCastingNaNError
 
 from sdv import version
 from sdv._utils import (
@@ -32,6 +34,8 @@ from sdv.cag._errors import PatternNotMetError
 from sdv.cag._utils import _convert_to_snake_case, _get_invalid_rows
 from sdv.constraints.errors import AggregateConstraintsError
 from sdv.data_processing.data_processor import DataProcessor
+from sdv.data_processing.datetime_formatter import DatetimeFormatter
+from sdv.data_processing.numerical_formatter import NumericalFormatter
 from sdv.errors import (
     ConstraintsNotMetError,
     InvalidDataError,
@@ -180,6 +184,8 @@ class BaseSynthesizer:
             enforce_min_max_values=self.enforce_min_max_values,
             locales=self.locales,
         )
+        self._dtypes = {}
+        self._formatters = {}  # Data formatters for columns not handled by the data processor
         self._validate_regex_format()
         self._original_columns = pd.Index([])
         self._fitted = False
@@ -500,6 +506,70 @@ class BaseSynthesizer:
 
         return info
 
+    def _fit_constraint_column_formatters(self, data):
+        """Fit formatters for columns that are dropped by constraints before data processing."""
+        self._formatters = {}
+        self._dtypes = {}
+        primary_key = self.metadata.tables[self._table_name].primary_key
+        input_columns = self._input_metadata.get_column_names()
+        columns_to_format = set(input_columns) - set(self.metadata.get_column_names())
+        for column_name in columns_to_format:
+            self._dtypes[column_name] = data[column_name].dtype
+            column_metadata = self._input_metadata.tables[self._table_name].columns.get(column_name)
+            sdtype = column_metadata.get('sdtype')
+            if sdtype == 'numerical' and column_name != primary_key:
+                representation = column_metadata.get('computer_representation', 'Float')
+                self._formatters[column_name] = NumericalFormatter(
+                    enforce_rounding=self.enforce_rounding,
+                    enforce_min_max_values=self.enforce_min_max_values,
+                    computer_representation=representation,
+                )
+                self._formatters[column_name].learn_format(data[column_name])
+
+            elif sdtype == 'datetime' and column_name != primary_key:
+                datetime_format = column_metadata.get('datetime_format')
+                self._formatters[column_name] = DatetimeFormatter(datetime_format=datetime_format)
+                self._formatters[column_name].learn_format(data[column_name])
+
+    def _format_constraint_columns(self, data):
+        """Format columns skipped by the data processor due to being dropped by constraints."""
+        column_order = [
+            column for column in self._input_metadata.get_column_names() if column in data
+        ]
+        for column_name in self._dtypes:
+            column_data = data[column_name]
+
+            dtype = self._dtypes[column_name]
+            if is_integer_dtype(dtype) and is_float_dtype(column_data.dtype):
+                column_data = column_data.round()
+
+            data[column_name] = column_data[column_data.notna()]
+            try:
+                data[column_name] = data[column_name].astype(dtype)
+            except (IntCastingNaNError, ValueError) as e:
+                message = (
+                    f"The real data in '{column_name}' was stored as '{dtype}' but the "
+                    'synthetic data could not be cast back to this type. If this is a '
+                    'problem, please check your input data and metadata settings.'
+                )
+                LOGGER.debug(message)
+                if isinstance(e, IntCastingNaNError):
+                    continue  # Skip numerical formatting if we can't cast to int
+
+            except OverflowError:
+                LOGGER.debug(
+                    f"The real data in '{self._table_name}' and column '{column_name}' was "
+                    f"stored as '{dtype}' but the synthetic data overflowed when casting back "
+                    'to this type. If this is a problem, please check your input data '
+                    'and metadata settings.'
+                )
+
+            if column_name in self._formatters:
+                data_to_format = data[column_name]
+                data[column_name] = self._formatters[column_name].format_data(data_to_format)
+
+        return data[column_order]
+
     def _preprocess(self, data):
         self.validate(data)
         self._data_processor.fit(data)
@@ -594,6 +664,7 @@ class BaseSynthesizer:
         check_synthesizer_version(self, is_fit_method=True, compare_operator=operator.lt)
         self._check_input_metadata_updated()
         self._fitted = False
+        self._fit_constraint_column_formatters(data)
         self._data_processor.reset_sampling()
         self._random_state_set = False
         processed_data = self.preprocess(data)
@@ -920,6 +991,9 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                 for pattern in reversed(self._reject_sampling_patterns):
                     valid_rows = pattern.is_valid(sampled)
                     sampled = sampled[valid_rows]
+
+            if hasattr(self, '_formatters'):
+                sampled = self._format_constraint_columns(sampled)
 
             if previous_rows is not None:
                 sampled = pd.concat([previous_rows, sampled], ignore_index=True)

--- a/tests/integration/cag/test_inequality.py
+++ b/tests/integration/cag/test_inequality.py
@@ -3,6 +3,7 @@ import re
 import numpy as np
 import pandas as pd
 import pytest
+from pandas.api.types import is_object_dtype
 
 from sdv.cag import Inequality
 from sdv.cag._errors import PatternNotMetError
@@ -314,11 +315,11 @@ def test_inequality_with_timestamp_and_date():
     synthetic_data = synthesizer.sample(num_rows=10)
 
     # Assert
-    assert synthetic_data['SUBMISSION_TIMESTAMP'].dtype == 'O'
+    assert is_object_dtype(synthetic_data['SUBMISSION_TIMESTAMP'].dtype)
     synthetic_data['SUBMISSION_TIMESTAMP'] = pd.to_datetime(
         synthetic_data['SUBMISSION_TIMESTAMP'], format='%Y-%m-%d %H:%M:%S'
     )
-    assert synthetic_data['DUE_DATE'].dtype == 'O'
+    assert is_object_dtype(synthetic_data['DUE_DATE'].dtype)
     synthetic_data['DUE_DATE'] = pd.to_datetime(synthetic_data['DUE_DATE'], format='%Y-%m-%d')
     invalid_rows = synthetic_data[
         synthetic_data['SUBMISSION_TIMESTAMP'].dt.date > synthetic_data['DUE_DATE'].dt.date
@@ -533,11 +534,11 @@ def test_inequality_pattern_date_less_than_timestamp_no_strict_boundaries():
     synthetic_data = synthesizer.sample(10)
 
     # Assert
-    assert synthetic_data['SUBMISSION_TIMESTAMP'].dtype == 'O'
+    assert is_object_dtype(synthetic_data['SUBMISSION_TIMESTAMP'].dtype)
     synthetic_data['SUBMISSION_TIMESTAMP'] = pd.to_datetime(
         synthetic_data['SUBMISSION_TIMESTAMP'], format='%Y-%m-%d %H:%M:%S'
     )
-    assert synthetic_data['DUE_DATE'].dtype == 'O'
+    assert is_object_dtype(synthetic_data['DUE_DATE'].dtype)
     synthetic_data['DUE_DATE'] = pd.to_datetime(synthetic_data['DUE_DATE'], format='%Y-%m-%d')
     invalid_rows = synthetic_data[
         synthetic_data['SUBMISSION_TIMESTAMP'].dt.date > synthetic_data['DUE_DATE'].dt.date
@@ -595,11 +596,11 @@ def test_inequality_pattern_timestamp_less_than_date_no_strict_boundaries():
     synthetic_data = synthesizer.sample(10)
 
     # Assert
-    assert synthetic_data['SUBMISSION_TIMESTAMP'].dtype == 'O'
+    assert is_object_dtype(synthetic_data['SUBMISSION_TIMESTAMP'].dtype)
     synthetic_data['SUBMISSION_TIMESTAMP'] = pd.to_datetime(
         synthetic_data['SUBMISSION_TIMESTAMP'], format='%Y-%m-%d %H:%M:%S'
     )
-    assert synthetic_data['DUE_DATE'].dtype == 'O'
+    assert is_object_dtype(synthetic_data['DUE_DATE'].dtype)
     synthetic_data['DUE_DATE'] = pd.to_datetime(synthetic_data['DUE_DATE'], format='%Y-%m-%d')
     invalid_rows = synthetic_data[
         synthetic_data['SUBMISSION_TIMESTAMP'].dt.date > synthetic_data['DUE_DATE'].dt.date

--- a/tests/integration/cag/test_inequality.py
+++ b/tests/integration/cag/test_inequality.py
@@ -314,10 +314,12 @@ def test_inequality_with_timestamp_and_date():
     synthetic_data = synthesizer.sample(num_rows=10)
 
     # Assert
+    assert synthetic_data['SUBMISSION_TIMESTAMP'].dtype == 'O'
     synthetic_data['SUBMISSION_TIMESTAMP'] = pd.to_datetime(
-        synthetic_data['SUBMISSION_TIMESTAMP'], errors='coerce'
+        synthetic_data['SUBMISSION_TIMESTAMP'], format='%Y-%m-%d %H:%M:%S'
     )
-    synthetic_data['DUE_DATE'] = pd.to_datetime(synthetic_data['DUE_DATE'], errors='coerce')
+    assert synthetic_data['DUE_DATE'].dtype == 'O'
+    synthetic_data['DUE_DATE'] = pd.to_datetime(synthetic_data['DUE_DATE'], format='%Y-%m-%d')
     invalid_rows = synthetic_data[
         synthetic_data['SUBMISSION_TIMESTAMP'].dt.date > synthetic_data['DUE_DATE'].dt.date
     ]
@@ -531,10 +533,12 @@ def test_inequality_pattern_date_less_than_timestamp_no_strict_boundaries():
     synthetic_data = synthesizer.sample(10)
 
     # Assert
+    assert synthetic_data['SUBMISSION_TIMESTAMP'].dtype == 'O'
     synthetic_data['SUBMISSION_TIMESTAMP'] = pd.to_datetime(
-        synthetic_data['SUBMISSION_TIMESTAMP'], errors='coerce'
+        synthetic_data['SUBMISSION_TIMESTAMP'], format='%Y-%m-%d %H:%M:%S'
     )
-    synthetic_data['DUE_DATE'] = pd.to_datetime(synthetic_data['DUE_DATE'], errors='coerce')
+    assert synthetic_data['DUE_DATE'].dtype == 'O'
+    synthetic_data['DUE_DATE'] = pd.to_datetime(synthetic_data['DUE_DATE'], format='%Y-%m-%d')
     invalid_rows = synthetic_data[
         synthetic_data['SUBMISSION_TIMESTAMP'].dt.date > synthetic_data['DUE_DATE'].dt.date
     ]
@@ -591,10 +595,12 @@ def test_inequality_pattern_timestamp_less_than_date_no_strict_boundaries():
     synthetic_data = synthesizer.sample(10)
 
     # Assert
+    assert synthetic_data['SUBMISSION_TIMESTAMP'].dtype == 'O'
     synthetic_data['SUBMISSION_TIMESTAMP'] = pd.to_datetime(
-        synthetic_data['SUBMISSION_TIMESTAMP'], errors='coerce'
+        synthetic_data['SUBMISSION_TIMESTAMP'], format='%Y-%m-%d %H:%M:%S'
     )
-    synthetic_data['DUE_DATE'] = pd.to_datetime(synthetic_data['DUE_DATE'], errors='coerce')
+    assert synthetic_data['DUE_DATE'].dtype == 'O'
+    synthetic_data['DUE_DATE'] = pd.to_datetime(synthetic_data['DUE_DATE'], format='%Y-%m-%d')
     invalid_rows = synthetic_data[
         synthetic_data['SUBMISSION_TIMESTAMP'].dt.date > synthetic_data['DUE_DATE'].dt.date
     ]

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -20,6 +20,8 @@ from rdt.transformers import (
 from sdv import version
 from sdv.cag._errors import PatternNotMetError
 from sdv.constraints.errors import AggregateConstraintsError
+from sdv.data_processing.datetime_formatter import DatetimeFormatter
+from sdv.data_processing.numerical_formatter import NumericalFormatter
 from sdv.errors import (
     ConstraintsNotMetError,
     InvalidDataError,
@@ -663,6 +665,7 @@ class TestBaseSingleTableSynthesizer:
 
         # Assert
         assert instance._random_state_set is False
+        instance._fit_constraint_column_formatters.assert_called_once_with(data)
         instance._data_processor.reset_sampling.assert_called_once_with()
         instance.preprocess.assert_called_once_with(data)
         instance.fit_processed_data.assert_called_once_with(instance.preprocess.return_value)
@@ -2470,3 +2473,149 @@ class TestBaseSingleTableSynthesizer:
         # Run and Assert
         with pytest.raises(PatternNotMetError, match=msg):
             instance.validate_cag(synthetic_data)
+
+    def test__fit_constraint_column_formatters(self):
+        """Test the `_fit_constraint_column_formatters` fits formatters for dropped columns."""
+        # Setup
+        instance = Mock()
+        instance.enforce_rounding = False
+        instance.enforce_min_max_values = False
+        instance._table_name = 'table'
+        instance._input_metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'col1': {'sdtype': 'categorical'},
+                        'col2': {'sdtype': 'numerical', 'computer_representation': 'Int8'},
+                        'col3': {'sdtype': 'numerical'},
+                        'date_col1': {'sdtype': 'datetime'},
+                        'date_col2': {'sdtype': 'datetime'},
+                    }
+                }
+            }
+        })
+        instance.metadata = Metadata.load_from_dict({
+            'tables': {'table': {'columns': {'col1#col2': {'sdtype': 'numerical'}}}}
+        })
+        data = pd.DataFrame({
+            'col1': ['abc', 'def'],
+            'col2': [1, 2],
+            'col3': [3, 4],
+            'date_col1': ['16-05-2023', '14-04-2022'],
+            'date_col2': pd.to_datetime(['2021-02-15', '2022-05-16']),
+        })
+
+        # Run
+        BaseSingleTableSynthesizer._fit_constraint_column_formatters(instance, data)
+
+        # Assert
+        assert instance._dtypes == {
+            'col1': 'O',
+            'col2': 'int64',
+            'col3': 'int64',
+            'date_col1': 'O',
+            'date_col2': '<M8[ns]',
+        }
+
+        assert set(instance._formatters.keys()) == {'col2', 'col3', 'date_col1', 'date_col2'}
+
+        assert isinstance(instance._formatters['col2'], NumericalFormatter)
+        assert instance._formatters['col2'].enforce_rounding is False
+        assert instance._formatters['col2'].enforce_min_max_values is False
+        assert instance._formatters['col2'].computer_representation == 'Int8'
+
+        assert isinstance(instance._formatters['col3'], NumericalFormatter)
+        assert instance._formatters['col3'].enforce_rounding is False
+        assert instance._formatters['col3'].enforce_min_max_values is False
+        assert instance._formatters['col3'].computer_representation == 'Float'
+
+        assert isinstance(instance._formatters['date_col1'], DatetimeFormatter)
+        assert isinstance(instance._formatters['date_col2'], DatetimeFormatter)
+        assert instance._formatters['date_col1']._dtype == 'O'
+        assert instance._formatters['date_col1'].datetime_format == '%d-%m-%Y'
+        assert instance._formatters['date_col2']._dtype == '<M8[ns]'
+        assert instance._formatters['date_col2'].datetime_format == '%Y-%m-%d'
+
+    @patch('sdv.single_table.base.LOGGER')
+    def test__format_constraint_columns(sel, log_mock):
+        """Test formatting all columns that were dropped by constraints."""
+        # Setup
+        instance = Mock()
+        instance._table_name = 'table'
+        instance._input_metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'datetime_col': {'sdtype': 'datetime'},
+                        'overflow_int': {'sdtype': 'numerical'},
+                        'int': {'sdtype': 'numerical'},
+                        'nan_int': {'sdtype': 'numerical'},
+                        'float': {'sdtype': 'numerical'},
+                    }
+                }
+            }
+        })
+        instance._dtypes = {
+            'overflow_int': 'int64',
+            'nan_int': 'int64',
+            'int': 'int64',
+            'float': 'float64',
+            'datetime_col': 'O',
+        }
+
+        instance._formatters = {
+            'overflow_int': Mock(),
+            'nan_int': Mock(),
+            'int': Mock(return_value=[0, 1, 2]),
+            'float': Mock(return_value=[0.1, 1.2, 2.3]),
+            'datetime_col': Mock(return_value=['2021-02-15', '2022-05-16', '2023-07-18']),
+        }
+        instance._formatters['overflow_int'].format_data.return_value = [
+            99999999999999999990,
+            99999999999999999991,
+            99999999999999999992,
+        ]
+        instance._formatters['int'].format_data.return_value = [0, 1, 2]
+        instance._formatters['float'].format_data.return_value = [0.1, 1.2, 2.3]
+        instance._formatters['datetime_col'].format_data.return_value = [
+            '2021-02-15',
+            '2022-05-16',
+            '2023-07-18',
+        ]
+
+        data = pd.DataFrame({
+            'overflow_int': [99999999999999999990, 99999999999999999991, 99999999999999999992],
+            'nan_int': [0, 1, np.nan],
+            'int': [0.0, 1.0, 2.0],
+            'float': [0.11, 1.21, 2.33],
+            'datetime_col': pd.to_datetime(['2021-02-15', '2022-05-16', '2023-07-18']),
+        })
+
+        # Run
+        formatted_data = BaseSingleTableSynthesizer._format_constraint_columns(instance, data)
+
+        # Assert
+        instance._formatters['nan_int'].format_data.assert_not_called()
+
+        expected_data = pd.DataFrame({
+            'datetime_col': ['2021-02-15', '2022-05-16', '2023-07-18'],
+            'overflow_int': [99999999999999999990, 99999999999999999991, 99999999999999999992],
+            'int': [0, 1, 2],
+            'nan_int': [0, 1, np.nan],
+            'float': [0.1, 1.2, 2.3],
+        })
+        pd.testing.assert_frame_equal(expected_data, formatted_data)
+
+        expected_log_calls = [
+            call(
+                "The real data in 'table' and column 'overflow_int' was stored as 'int64' "
+                'but the synthetic data overflowed when casting back to this type. If this is a '
+                'problem, please check your input data and metadata settings.'
+            ),
+            call(
+                "The real data in 'nan_int' was stored as 'int64' but the synthetic data "
+                'could not be cast back to this type. If this is a problem, please check your '
+                'input data and metadata settings.'
+            ),
+        ]
+        log_mock.debug.assert_has_calls(expected_log_calls)


### PR DESCRIPTION
Resolve #2495 

Since columns dropped by constraints are no longer being processed by the data processor, the synthesizer needs to handle formatting these columns. 