### PR TITLE
Consolidate names of CAG/data patterns to `constraints`

### DIFF
--- a/sdv/cag/__init__.py
+++ b/sdv/cag/__init__.py
@@ -2,5 +2,6 @@
 
 from sdv.cag.fixed_combinations import FixedCombinations
 from sdv.cag.fixed_increments import FixedIncrements
+from sdv.cag.inequality import Inequality
 
-__all__ = ('FixedCombinations', 'FixedIncrements')
+__all__ = ('FixedCombinations', 'FixedIncrements', 'Inequality')

--- a/sdv/cag/__init__.py
+++ b/sdv/cag/__init__.py
@@ -3,5 +3,6 @@
 from sdv.cag.fixed_combinations import FixedCombinations
 from sdv.cag.fixed_increments import FixedIncrements
 from sdv.cag.inequality import Inequality
+from sdv.cag.range import Range
 
-__all__ = ('FixedCombinations', 'FixedIncrements', 'Inequality')
+__all__ = ('FixedCombinations', 'FixedIncrements', 'Inequality', 'Range')

--- a/sdv/cag/__init__.py
+++ b/sdv/cag/__init__.py
@@ -1,5 +1,6 @@
 """SDV CAG module."""
 
 from sdv.cag.fixed_combinations import FixedCombinations
+from sdv.cag.fixed_increments import FixedIncrements
 
-__all__ = ('FixedCombinations',)
+__all__ = ('FixedCombinations', 'FixedIncrements')

--- a/sdv/cag/__init__.py
+++ b/sdv/cag/__init__.py
@@ -1,0 +1,5 @@
+"""SDV CAG module."""
+
+from sdv.cag.fixed_combinations import FixedCombinations
+
+__all__ = ('FixedCombinations',)

--- a/sdv/cag/__init__.py
+++ b/sdv/cag/__init__.py
@@ -4,5 +4,12 @@ from sdv.cag.fixed_combinations import FixedCombinations
 from sdv.cag.fixed_increments import FixedIncrements
 from sdv.cag.inequality import Inequality
 from sdv.cag.range import Range
+from sdv.cag.one_hot_encoding import OneHotEncoding
 
-__all__ = ('FixedCombinations', 'FixedIncrements', 'Inequality', 'Range')
+__all__ = (
+    'FixedCombinations',
+    'FixedIncrements',
+    'Inequality',
+    'Range',
+    'OneHotEncoding',
+)

--- a/sdv/cag/_errors.py
+++ b/sdv/cag/_errors.py
@@ -1,0 +1,5 @@
+"""CAG Pattern Exceptions."""
+
+
+class PatternNotMetError(Exception):
+    """Error to raise when a CAG pattern is not met."""

--- a/sdv/cag/_errors.py
+++ b/sdv/cag/_errors.py
@@ -1,5 +1,5 @@
 """CAG Pattern Exceptions."""
 
 
-class PatternNotMetError(Exception):
+class ConstraintNotMetError(Exception):
     """Error to raise when a CAG pattern is not met."""

--- a/sdv/cag/_errors.py
+++ b/sdv/cag/_errors.py
@@ -2,4 +2,4 @@
 
 
 class ConstraintNotMetError(Exception):
-    """Error to raise when a CAG pattern is not met."""
+    """Error to raise when a constraint is not met."""

--- a/sdv/cag/_errors.py
+++ b/sdv/cag/_errors.py
@@ -1,4 +1,4 @@
-"""CAG Pattern Exceptions."""
+"""Constraint Exceptions."""
 
 
 class ConstraintNotMetError(Exception):

--- a/sdv/cag/_utils.py
+++ b/sdv/cag/_utils.py
@@ -1,9 +1,12 @@
 import re
 
+import warnings
+
 import numpy as np
 import pandas as pd
 
 from sdv.cag._errors import PatternNotMetError
+from sdv.cag.base import BasePattern
 from sdv.metadata import Metadata
 
 
@@ -147,3 +150,44 @@ def _remove_columns_from_metadata(metadata, table_name, columns_to_drop):
         if set(rel['column_names']).isdisjoint(column_set)
     ]
     return Metadata.load_from_dict(metadata)
+
+
+def _filter_old_style_constraints(constraints):
+    """Filter out old-style constraints."""
+    result = [constraint for constraint in constraints if isinstance(constraint, BasePattern)]
+    old_style_constraint = [
+        constraint for constraint in constraints if isinstance(constraint, dict)
+    ]
+    if old_style_constraint:
+        warnings.warn(
+            'The `add_constraints` function no longer supports constraints using the older '
+            'dictionary-style definition. Such constraints will be ignored. Please supply '
+            'objects from `sdv.cag` instead.',
+            DeprecationWarning,
+        )
+
+    return result
+
+
+def _validate_constraints(constraints, synthesizer_fitted):
+    """Validate the constraints.
+
+    Args:
+        constraints (list[sdv.cag.BasePattern]):
+            The list of constraints to validate.
+
+        synthesizer_fitted (bool):
+            Whether the synthesizer has been fitted or not.
+
+    Raises:
+        ValueError: If the constraints are not valid.
+    """
+    if not isinstance(constraints, list):
+        raise ValueError('Constraints must be a list of sdv.cag.BasePattern objects.')
+
+    if synthesizer_fitted:
+        warnings.warn(
+            "For these constraints to take effect, please refit the synthesizer using 'fit'."
+        )
+
+    return _filter_old_style_constraints(constraints)

--- a/sdv/cag/_utils.py
+++ b/sdv/cag/_utils.py
@@ -1,0 +1,18 @@
+from sdv.cag._errors import PatternNotMetError
+
+
+def _validate_table_and_column_names(table_name, columns, metadata):
+    """Validate the table and column names for the pattern."""
+    if table_name is None and len(metadata.tables) > 1:
+        raise PatternNotMetError(
+            'Metadata contains more than 1 table but no ``table_name`` provided.'
+        )
+    if table_name is None:
+        table_name = metadata._get_single_table_name()
+    elif table_name not in metadata.tables:
+        raise PatternNotMetError(f"Table '{table_name}' missing from metadata.")
+
+    if not set(columns).issubset(set(metadata.tables[table_name].columns)):
+        missing_columns = columns - set(metadata.tables[table_name].columns)
+        missing_columns = "', '".join(sorted(missing_columns))
+        raise PatternNotMetError(f"Table '{table_name}' is missing columns '{missing_columns}'.")

--- a/sdv/cag/_utils.py
+++ b/sdv/cag/_utils.py
@@ -1,5 +1,4 @@
 import re
-
 import warnings
 
 import numpy as np

--- a/sdv/cag/_utils.py
+++ b/sdv/cag/_utils.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 from sdv.cag._errors import ConstraintNotMetError
-from sdv.cag.base import BasePattern
+from sdv.cag.base import BaseConstraint
 from sdv.metadata import Metadata
 
 
@@ -154,7 +154,7 @@ def _remove_columns_from_metadata(metadata, table_name, columns_to_drop):
 
 def _filter_old_style_constraints(constraints):
     """Filter out old-style constraints."""
-    result = [constraint for constraint in constraints if isinstance(constraint, BasePattern)]
+    result = [constraint for constraint in constraints if isinstance(constraint, BaseConstraint)]
     old_style_constraint = [
         constraint for constraint in constraints if isinstance(constraint, dict)
     ]
@@ -173,7 +173,7 @@ def _validate_constraints(constraints, synthesizer_fitted):
     """Validate the constraints.
 
     Args:
-        constraints (list[sdv.cag.BasePattern]):
+        constraints (list[sdv.cag.BaseConstraint]):
             The list of constraints to validate.
 
         synthesizer_fitted (bool):
@@ -183,7 +183,7 @@ def _validate_constraints(constraints, synthesizer_fitted):
         ValueError: If the constraints are not valid.
     """
     if not isinstance(constraints, list):
-        raise ValueError('Constraints must be a list of sdv.cag.BasePattern objects.')
+        raise ValueError('Constraints must be a list of sdv.cag objects.')
 
     if synthesizer_fitted:
         warnings.warn(

--- a/sdv/cag/_utils.py
+++ b/sdv/cag/_utils.py
@@ -1,8 +1,46 @@
+import numpy as np
+
 from sdv.cag._errors import PatternNotMetError
+from sdv.metadata import Metadata
+
+
+def _validate_columns_in_metadata(table_name, columns, metadata):
+    """Validates that the columns are in the metadata.
+
+    Args:
+        table_name (str):
+            The name of the table in the metadata.
+
+        columns (list[str])
+            The column names to check.
+
+        metadata (sdv.metadata.Metadata):
+            The Metadata to check.
+    """
+    if not set(columns).issubset(set(metadata.tables[table_name].columns)):
+        missing_columns = set(columns) - set(metadata.tables[table_name].columns)
+        missing_columns = "', '".join(sorted(missing_columns))
+        raise PatternNotMetError(f"Table '{table_name}' is missing columns '{missing_columns}'.")
 
 
 def _validate_table_and_column_names(table_name, columns, metadata):
-    """Validate the table and column names for the pattern."""
+    """Validate the table name and columns against the metadata.
+
+    It checks the following:
+        - If the table name is None, the metadata should only contain a single table.
+        - The table name is in the metadata.
+        - The columns are in the metadata.
+
+    Args:
+        table_name (str):
+            The name of the table in the metadata to validate.
+
+        columns (list[str])
+            The column names to check.
+
+        metadata (sdv.metadata.Metadata):
+            The Metadata to check.
+    """
     if table_name is None and len(metadata.tables) > 1:
         raise PatternNotMetError(
             'Metadata contains more than 1 table but no ``table_name`` provided.'
@@ -12,7 +50,70 @@ def _validate_table_and_column_names(table_name, columns, metadata):
     elif table_name not in metadata.tables:
         raise PatternNotMetError(f"Table '{table_name}' missing from metadata.")
 
-    if not set(columns).issubset(set(metadata.tables[table_name].columns)):
-        missing_columns = columns - set(metadata.tables[table_name].columns)
-        missing_columns = "', '".join(sorted(missing_columns))
-        raise PatternNotMetError(f"Table '{table_name}' is missing columns '{missing_columns}'.")
+    _validate_columns_in_metadata(table_name, columns, metadata)
+
+
+def _validate_table_name_if_defined(table_name):
+    """Validate if the table name is defined, it is a string."""
+    if table_name and not isinstance(table_name, str):
+        raise ValueError('`table_name` must be a string or None.')
+
+
+def _remove_columns_from_metadata(metadata, table_name, columns_to_drop):
+    """Remove columns from metadata, including column relationships.
+
+        Will raise an error if the primary key is being dropped.
+
+    Args:
+        metadata (dict, sdv.metadata.Metadata): The Metadata which contains
+            the columns to drop.
+
+        table_name (str): Name of the table in the metadata, where the column(s)
+            are located.
+
+        columns_to_drop (list[str]): The list of column names to drop from the
+            Metadata.
+
+    Returns:
+        (sdv.metadata.Metadata): The new Metadata, with the columns removed.
+    """
+    if isinstance(metadata, Metadata):
+        metadata = metadata.to_dict()
+    for column in columns_to_drop:
+        primary_key = metadata['tables'][table_name].get('primary_key')
+        if primary_key and primary_key == column:
+            raise ValueError('Cannot remove primary key from Metadata')
+        del metadata['tables'][table_name]['columns'][column]
+
+    metadata['tables'][table_name]['column_relationships'] = [
+        rel
+        for rel in metadata['tables'][table_name].get('column_relationships', [])
+        if set(rel['column_names']).isdisjoint(columns_to_drop)
+    ]
+    return Metadata.load_from_dict(metadata)
+
+
+def _is_list_of_strings(values):
+    """Checks that a list contains all strings."""
+    return isinstance(values, list) and all(isinstance(value, str) for value in values)
+
+
+def _get_invalid_rows(valid):
+    """Determine the indices of the rows where value is False.
+
+    Args:
+        valid (pd.Series):
+            The input data to check for False values.
+
+    Returns:
+        (str): A string that describes the indices where the value is False.
+            If there are more than 5 indices, the rest are described as 'more'.
+    """
+    invalid_rows = np.where(~valid)[0]
+    if len(invalid_rows) <= 5:
+        invalid_rows_str = ', '.join(str(i) for i in invalid_rows)
+    else:
+        first_five = ', '.join(str(i) for i in invalid_rows[:5])
+        remaining = len(invalid_rows) - 5
+        invalid_rows_str = f'{first_five}, +{remaining} more'
+    return invalid_rows_str

--- a/sdv/cag/_utils.py
+++ b/sdv/cag/_utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 
 from sdv.cag._errors import PatternNotMetError
 from sdv.metadata import Metadata
@@ -93,9 +94,9 @@ def _remove_columns_from_metadata(metadata, table_name, columns_to_drop):
     return Metadata.load_from_dict(metadata)
 
 
-def _is_list_of_strings(values):
-    """Checks that a list contains all strings."""
-    return isinstance(values, list) and all(isinstance(value, str) for value in values)
+def _is_list_of_type(values, type_to_check=str):
+    """Checks that 'values' is a list and all elements are of type 'type_to_check'."""
+    return isinstance(values, list) and all(isinstance(value, type_to_check) for value in values)
 
 
 def _get_invalid_rows(valid):
@@ -117,3 +118,26 @@ def _get_invalid_rows(valid):
         remaining = len(invalid_rows) - 5
         invalid_rows_str = f'{first_five}, +{remaining} more'
     return invalid_rows_str
+
+
+def _get_is_valid_dict(data, table_name):
+    """Create a dictionary of True values for each table besides table_name.
+
+    Besides table_name, all rows of every other table are considered valid,
+    so the boolean Series will be True for all rows of every other table.
+
+    Args:
+        data (dict):
+            The data.
+        table_name (str):
+            The name of the table to exclude from the dictionary.
+
+    Returns:
+        dict:
+            Dictionary of table names to boolean Series of True values.
+    """
+    return {
+        table: pd.Series(True, index=table_data.index)
+        for table, table_data in data.items()
+        if table != table_name
+    }

--- a/sdv/cag/_utils.py
+++ b/sdv/cag/_utils.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pandas as pd
 
@@ -60,40 +62,6 @@ def _validate_table_name_if_defined(table_name):
         raise ValueError('`table_name` must be a string or None.')
 
 
-def _remove_columns_from_metadata(metadata, table_name, columns_to_drop):
-    """Remove columns from metadata, including column relationships.
-
-        Will raise an error if the primary key is being dropped.
-
-    Args:
-        metadata (dict, sdv.metadata.Metadata): The Metadata which contains
-            the columns to drop.
-
-        table_name (str): Name of the table in the metadata, where the column(s)
-            are located.
-
-        columns_to_drop (list[str]): The list of column names to drop from the
-            Metadata.
-
-    Returns:
-        (sdv.metadata.Metadata): The new Metadata, with the columns removed.
-    """
-    if isinstance(metadata, Metadata):
-        metadata = metadata.to_dict()
-    for column in columns_to_drop:
-        primary_key = metadata['tables'][table_name].get('primary_key')
-        if primary_key and primary_key == column:
-            raise ValueError('Cannot remove primary key from Metadata')
-        del metadata['tables'][table_name]['columns'][column]
-
-    metadata['tables'][table_name]['column_relationships'] = [
-        rel
-        for rel in metadata['tables'][table_name].get('column_relationships', [])
-        if set(rel['column_names']).isdisjoint(columns_to_drop)
-    ]
-    return Metadata.load_from_dict(metadata)
-
-
 def _is_list_of_type(values, type_to_check=str):
     """Checks that 'values' is a list and all elements are of type 'type_to_check'."""
     return isinstance(values, list) and all(isinstance(value, type_to_check) for value in values)
@@ -141,3 +109,41 @@ def _get_is_valid_dict(data, table_name):
         for table, table_data in data.items()
         if table != table_name
     }
+
+
+def _convert_to_snake_case(string):
+    """Convert a string to snake case (words separated by underscores, all lowercase)."""
+    return re.sub(r'([a-z])([A-Z])', r'\1_\2', string).lower()
+
+
+def _remove_columns_from_metadata(metadata, table_name, columns_to_drop):
+    """Remove columns from metadata, including column relationships.
+
+        Will raise an error if the primary key is being dropped.
+
+    Args:
+        metadata (dict, sdv.metadata.Metadata): The Metadata which contains
+            the columns to drop.
+        table_name (str): Name of the table in the metadata, where the column(s)
+            are located.
+        columns_to_drop (list[str]): The list of column names to drop from the
+            Metadata.
+
+    Returns:
+        (sdv.metadata.Metadata): The new Metadata, with the columns removed.
+    """
+    if isinstance(metadata, Metadata):
+        metadata = metadata.to_dict()
+    column_set = set(columns_to_drop)
+    primary_key = metadata['tables'][table_name].get('primary_key')
+    for column in column_set:
+        if primary_key and primary_key == column:
+            raise ValueError('Cannot remove primary key from Metadata')
+        del metadata['tables'][table_name]['columns'][column]
+
+    metadata['tables'][table_name]['column_relationships'] = [
+        rel
+        for rel in metadata['tables'][table_name].get('column_relationships', [])
+        if set(rel['column_names']).isdisjoint(column_set)
+    ]
+    return Metadata.load_from_dict(metadata)

--- a/sdv/cag/_utils.py
+++ b/sdv/cag/_utils.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.cag.base import BasePattern
 from sdv.metadata import Metadata
 
@@ -26,7 +26,7 @@ def _validate_columns_in_metadata(table_name, columns, metadata):
     if not set(columns).issubset(set(metadata.tables[table_name].columns)):
         missing_columns = set(columns) - set(metadata.tables[table_name].columns)
         missing_columns = "', '".join(sorted(missing_columns))
-        raise PatternNotMetError(f"Table '{table_name}' is missing columns '{missing_columns}'.")
+        raise ConstraintNotMetError(f"Table '{table_name}' is missing columns '{missing_columns}'.")
 
 
 def _validate_table_and_column_names(table_name, columns, metadata):
@@ -48,13 +48,13 @@ def _validate_table_and_column_names(table_name, columns, metadata):
             The Metadata to check.
     """
     if table_name is None and len(metadata.tables) > 1:
-        raise PatternNotMetError(
+        raise ConstraintNotMetError(
             'Metadata contains more than 1 table but no ``table_name`` provided.'
         )
     if table_name is None:
         table_name = metadata._get_single_table_name()
     elif table_name not in metadata.tables:
-        raise PatternNotMetError(f"Table '{table_name}' missing from metadata.")
+        raise ConstraintNotMetError(f"Table '{table_name}' missing from metadata.")
 
     _validate_columns_in_metadata(table_name, columns, metadata)
 

--- a/sdv/cag/base.py
+++ b/sdv/cag/base.py
@@ -46,6 +46,10 @@ class BasePattern:
             if self._single_table:
                 data = {self._table_name: data}
 
+            elif isinstance(data, pd.DataFrame):
+                table_name = self._get_single_table_name(metadata)
+                data = {table_name: data}
+
             self._validate_pattern_with_data(data, metadata)
 
     def _get_updated_metadata(self, metadata):

--- a/sdv/cag/base.py
+++ b/sdv/cag/base.py
@@ -19,10 +19,10 @@ class BasePattern:
 
         return metadata._get_single_table_name() if self.table_name is None else self.table_name
 
-    def _validate_pattern_with_metadata(self, metadata):
+    def _validate_constraint_with_metadata(self, metadata):
         raise NotImplementedError()
 
-    def _validate_pattern_with_data(self, data, metadata):
+    def _validate_constraint_with_data(self, data, metadata):
         raise NotImplementedError()
 
     def validate(self, data=None, metadata=None):
@@ -41,7 +41,7 @@ class BasePattern:
 
             metadata = self.metadata
 
-        self._validate_pattern_with_metadata(metadata)
+        self._validate_constraint_with_metadata(metadata)
 
         if isinstance(data, pd.DataFrame):
             if self._single_table:
@@ -51,7 +51,7 @@ class BasePattern:
                 data = {table_name: data}
 
         if data is not None:
-            self._validate_pattern_with_data(data, metadata)
+            self._validate_constraint_with_data(data, metadata)
 
     def _get_updated_metadata(self, metadata):
         return metadata
@@ -78,13 +78,13 @@ class BasePattern:
             metadata (sdv.Metadata):
                 The metadata to fit the constraint on.
         """
-        self._validate_pattern_with_metadata(metadata)
+        self._validate_constraint_with_metadata(metadata)
         if isinstance(data, pd.DataFrame):
             self._single_table = True
             self._table_name = self._get_single_table_name(metadata)
             data = {self._table_name: data}
 
-        self._validate_pattern_with_data(data, metadata)
+        self._validate_constraint_with_data(data, metadata)
         self._fit(data, metadata)
         self.metadata = metadata
 

--- a/sdv/cag/base.py
+++ b/sdv/cag/base.py
@@ -1,12 +1,12 @@
-"""Base Multi-Table Pattern."""
+"""Base Multi-Table Constraint."""
 
 import pandas as pd
 
 from sdv.errors import NotFittedError
 
 
-class BasePattern:
-    """Base CAG Pattern Class."""
+class BaseConstraint:
+    """Base Constraint Class."""
 
     def __init__(self):
         self.metadata = None
@@ -37,7 +37,7 @@ class BasePattern:
         """
         if metadata is None:
             if self.metadata is None:
-                raise NotFittedError('Pattern must be fit before validating without metadata.')
+                raise NotFittedError('Constraint must be fit before validating without metadata.')
 
             metadata = self.metadata
 
@@ -105,7 +105,7 @@ class BasePattern:
                 The input data dictionary to be transformed.
         """
         if not self._fitted:
-            raise NotFittedError('Pattern must be fit using ``fit`` before transforming.')
+            raise NotFittedError('Constraint must be fit using ``fit`` before transforming.')
 
         self.validate(data)
         if self._single_table:
@@ -158,7 +158,7 @@ class BasePattern:
         """
         if not self._fitted:
             raise NotFittedError(
-                'Pattern must be fit using ``fit`` before determining if data is valid.'
+                'Constraint must be fit using ``fit`` before determining if data is valid.'
             )
 
         if self._single_table:

--- a/sdv/cag/base.py
+++ b/sdv/cag/base.py
@@ -42,14 +42,15 @@ class BasePattern:
             metadata = self.metadata
 
         self._validate_pattern_with_metadata(metadata)
-        if data is not None:
+
+        if isinstance(data, pd.DataFrame):
             if self._single_table:
                 data = {self._table_name: data}
-
-            elif isinstance(data, pd.DataFrame):
+            else:
                 table_name = self._get_single_table_name(metadata)
                 data = {table_name: data}
 
+        if data is not None:
             self._validate_pattern_with_data(data, metadata)
 
     def _get_updated_metadata(self, metadata):

--- a/sdv/cag/base.py
+++ b/sdv/cag/base.py
@@ -26,13 +26,13 @@ class BasePattern:
         raise NotImplementedError()
 
     def validate(self, data=None, metadata=None):
-        """Validate the data/metadata meets the pattern requirements.
+        """Validate the data/metadata meets the constraint requirements.
 
         Args:
             data (dict[str, pd.DataFrame], optional)
                 The data dictionary. If `None`, ``validate`` will skip data validation.
             metadata (sdv.Metadata, optional)
-                The input metadata. If `None`, pattern must have been fitted and ``validate``
+                The input metadata. If `None`, constraint must have been fitted and ``validate``
                 will use the metadata saved during fitting.
         """
         if metadata is None:
@@ -57,11 +57,11 @@ class BasePattern:
         return metadata
 
     def get_updated_metadata(self, metadata):
-        """Get the updated metadata after applying the pattern to the input metadata.
+        """Get the updated metadata after applying the constraint to the input metadata.
 
         Args:
             metadata (sdv.Metadata):
-                The input metadata to apply the pattern to.
+                The input metadata to apply the constraint to.
         """
         self.validate(metadata=metadata)
         return self._get_updated_metadata(metadata)
@@ -70,13 +70,13 @@ class BasePattern:
         raise NotImplementedError
 
     def fit(self, data, metadata):
-        """Fit the pattern with data and metadata.
+        """Fit the constraint with data and metadata.
 
         Args:
             data (dict[pd.DataFrame]):
-                The data dictionary to fit the pattern on.
+                The data dictionary to fit the constraint on.
             metadata (sdv.Metadata):
-                The metadata to fit the pattern on.
+                The metadata to fit the constraint on.
         """
         self._validate_pattern_with_metadata(metadata)
         if isinstance(data, pd.DataFrame):
@@ -154,7 +154,7 @@ class BasePattern:
 
         Returns:
             pd.Series or dict[pd.Series]:
-                Series of boolean values indicating if the row is valid for the pattern or not.
+                Series of boolean values indicating if the row is valid for the constraint or not.
         """
         if not self._fitted:
             raise NotFittedError(

--- a/sdv/cag/base.py
+++ b/sdv/cag/base.py
@@ -1,4 +1,4 @@
-"""Base Multi-Table Constraint."""
+"""Base Constraint."""
 
 import pandas as pd
 

--- a/sdv/cag/base.py
+++ b/sdv/cag/base.py
@@ -1,0 +1,166 @@
+"""Base Multi-Table Pattern."""
+
+import pandas as pd
+
+from sdv.errors import NotFittedError
+
+
+class BasePattern:
+    """Base CAG Pattern Class."""
+
+    def __init__(self):
+        self.metadata = None
+        self._fitted = False
+        self._single_table = False
+
+    def _get_single_table_name(self, metadata):
+        if not hasattr(self, 'table_name'):
+            raise ValueError('No ``table_name`` attribute has been set.')
+
+        return metadata._get_single_table_name() if self.table_name is None else self.table_name
+
+    def _validate_pattern_with_metadata(self, metadata):
+        raise NotImplementedError()
+
+    def _validate_pattern_with_data(self, data, metadata):
+        raise NotImplementedError()
+
+    def validate(self, data=None, metadata=None):
+        """Validate the data/metadata meets the pattern requirements.
+
+        Args:
+            data (dict[str, pd.DataFrame], optional)
+                The data dictionary. If `None`, ``validate`` will skip data validation.
+            metadata (sdv.Metadata, optional)
+                The input metadata. If `None`, pattern must have been fitted and ``validate``
+                will use the metadata saved during fitting.
+        """
+        if metadata is None:
+            if self.metadata is None:
+                raise NotFittedError('Pattern must be fit before validating without metadata.')
+
+            metadata = self.metadata
+
+        self._validate_pattern_with_metadata(metadata)
+        if data is not None:
+            if self._single_table:
+                data = {self._table_name: data}
+
+            self._validate_pattern_with_data(data, metadata)
+
+    def _get_updated_metadata(self, metadata):
+        return metadata
+
+    def get_updated_metadata(self, metadata):
+        """Get the updated metadata after applying the pattern to the input metadata.
+
+        Args:
+            metadata (sdv.Metadata):
+                The input metadata to apply the pattern to.
+        """
+        self.validate(metadata=metadata)
+        return self._get_updated_metadata(metadata)
+
+    def _fit(self, data, metadata):
+        raise NotImplementedError
+
+    def fit(self, data, metadata):
+        """Fit the pattern with data and metadata.
+
+        Args:
+            data (dict[pd.DataFrame]):
+                The data dictionary to fit the pattern on.
+            metadata (sdv.Metadata):
+                The metadata to fit the pattern on.
+        """
+        self._validate_pattern_with_metadata(metadata)
+        if isinstance(data, pd.DataFrame):
+            self._single_table = True
+            self._table_name = self._get_single_table_name(metadata)
+            data = {self._table_name: data}
+
+        self._validate_pattern_with_data(data, metadata)
+        self._fit(data, metadata)
+        self.metadata = metadata
+
+        self._dtypes = {table: data[table].dtypes.to_dict() for table in metadata.tables}
+        self._original_data_columns = {
+            table: metadata.tables[table].get_column_names() for table in metadata.tables
+        }
+        self._fitted = True
+
+    def _transform(self, data):
+        raise NotImplementedError
+
+    def transform(self, data):
+        """Transform the data.
+
+        Args:
+            data (dict[str, pd.DataFrame])
+                The input data dictionary to be transformed.
+        """
+        if not self._fitted:
+            raise NotFittedError('Pattern must be fit using ``fit`` before transforming.')
+
+        self.validate(data)
+        if self._single_table:
+            data = {self._table_name: data}
+
+        data = {table: table_data.copy() for table, table_data in data.items()}
+        transformed_data = self._transform(data)
+        if self._single_table:
+            return transformed_data[self._table_name]
+
+        return transformed_data
+
+    def _reverse_transform(self, data):
+        raise NotImplementedError
+
+    def reverse_transform(self, data):
+        """Reverse transform the data back into the original space.
+
+        Args:
+            data (dict[str, pd.DataFrame])
+                The transformed data dictionary to be reverse transformed.
+        """
+        if self._single_table:
+            data = {self._table_name: data}
+
+        data = {table: table_data.copy() for table, table_data in data.items()}
+        reverse_transformed = self._reverse_transform(data)
+        for table_name, table in reverse_transformed.items():
+            table = table[self._original_data_columns[table_name]]
+            reverse_transformed[table_name] = table.astype(self._dtypes[table_name])
+
+        if self._single_table:
+            return reverse_transformed[self._table_name]
+
+        return reverse_transformed
+
+    def _is_valid(self, data):
+        raise NotImplementedError
+
+    def is_valid(self, data):
+        """Say whether the given table rows are valid.
+
+        Args:
+            data (pd.DataFrame or dict[pd.DataFrame]):
+                Table data.
+
+        Returns:
+            pd.Series or dict[pd.Series]:
+                Series of boolean values indicating if the row is valid for the pattern or not.
+        """
+        if not self._fitted:
+            raise NotFittedError(
+                'Pattern must be fit using ``fit`` before determining if data is valid.'
+            )
+
+        if self._single_table:
+            data = {self._table_name: data}
+
+        is_valid_data = self._is_valid(data)
+        if self._single_table:
+            return is_valid_data[self._table_name]
+
+        return is_valid_data

--- a/sdv/cag/fixed_combinations.py
+++ b/sdv/cag/fixed_combinations.py
@@ -1,0 +1,203 @@
+"""FixedCombinations CAG pattern."""
+
+import uuid
+
+import numpy as np
+import pandas as pd
+
+from sdv._utils import _create_unique_name
+from sdv.cag._errors import PatternNotMetError
+from sdv.cag._utils import _validate_table_and_column_names
+from sdv.cag.base import BasePattern
+from sdv.constraints.utils import get_mappable_combination
+from sdv.metadata import Metadata
+
+
+class FixedCombinations(BasePattern):
+    """Pattern to ensure that the combinations across multiple columns are fixed.
+
+    One simple example of this pattern can be found in a table that
+    contains the columns `country` and `city`, where each country can
+    have multiple cities and the same city name can even be found in
+    multiple countries, but some combinations of country/city would
+    produce invalid results.
+
+    This pattern would ensure that the combinations of country/city
+    found in the sampled data always stay within the combinations previously
+    seen during training.
+
+    Args:
+        column_names (list[str]):
+            Names of the columns that need to produce fixed combinations. Must
+            contain at least two columns.
+        table_name (str, optional):
+            The name of the table that contains the columns. Optional if the
+            data is only a single table. Defaults to None.
+    """
+
+    def __init__(self, column_names, table_name=None):
+        super().__init__()
+        if not isinstance(column_names, list) or not all(
+            isinstance(column_name, str) for column_name in column_names
+        ):
+            raise ValueError('`column_names` must be a list of strings.')
+
+        if len(column_names) < 2:
+            raise ValueError('FixedCombinations pattern requires at least two columns.')
+
+        if table_name and not isinstance(table_name, str):
+            raise ValueError('`table_name` must be a string or None.')
+
+        self.column_names = column_names
+        self.table_name = table_name
+        self._joint_column = '#'.join(self.column_names)
+        self._combinations = None
+
+    def _validate_pattern_with_metadata(self, metadata):
+        """Validate the pattern is compatible with the provided metadata.
+
+        Validates that:
+        - If `table_name` is None then the metadata contains only a single table
+        - If `table_name` is not None, then the metadata contains a table with the same name.
+        - All columns in `column_names` are present in the target table.
+        - All columns in `column_names` have either 'categorical' or 'boolean' as their sdtype.
+        - Columns relationships do not partially contain columns in `column_names`.
+        """
+        _validate_table_and_column_names(self.table_name, self.column_names, metadata)
+        table_name = self._get_single_table_name(metadata)
+        for column in self.column_names:
+            col_sdtype = metadata.tables[table_name].columns[column]['sdtype']
+            if col_sdtype not in ['boolean', 'categorical']:
+                raise PatternNotMetError(
+                    f"Column '{column}' has an incompatible sdtype ('{col_sdtype}'). The column "
+                    "sdtype must be either 'boolean' or 'categorical'."
+                )
+
+        column_set = set(self.column_names)
+        for column_relationship in metadata.tables[table_name].column_relationships:
+            relationship_columns = set(column_relationship['column_names'])
+            if not (
+                column_set.issuperset(relationship_columns)
+                or relationship_columns.isdisjoint(column_set)
+            ):
+                bad_columns = "', '".join(list(relationship_columns.intersection(column_set)))
+                raise PatternNotMetError(
+                    f"Cannot apply pattern because columns ['{bad_columns}'] are part of a "
+                    'column relationship.'
+                )
+
+    def _validate_pattern_with_data(self, data, metadata):
+        """Validate the data is compatible with the pattern.
+
+        For FixedCombinations, this is a NOP.
+        """
+        return
+
+    def _get_updated_metadata(self, metadata):
+        """Get the new output metadata after applying the pattern to the input metadata."""
+        table_name = self._get_single_table_name(metadata)
+        combination_column = _create_unique_name(
+            self._joint_column, metadata.tables[table_name].columns.keys()
+        )
+
+        metadata = metadata.to_dict()
+        metadata['tables'][table_name]['columns'][combination_column] = {'sdtype': 'categorical'}
+        for column in self.column_names:
+            del metadata['tables'][table_name]['columns'][column]
+
+        column_set = set(self.column_names)
+        metadata['tables'][table_name]['column_relationships'] = [
+            rel
+            for rel in metadata['tables'][table_name].get('column_relationships', [])
+            if set(rel['column_names']).isdisjoint(column_set)
+        ]
+
+        return Metadata.load_from_dict(metadata)
+
+    def _fit(self, data, metadata):
+        """Fit the pattern."""
+        table_name = self._get_single_table_name(metadata)
+        table_data = data[table_name]
+        self._joint_column = _create_unique_name(
+            self._joint_column, metadata.tables[table_name].columns.keys()
+        )
+        self._combinations = table_data[self.column_names].drop_duplicates().copy()
+        self._combinations_to_uuids = {}
+        self._uuids_to_combinations = {}
+        for combination in self._combinations.itertuples(index=False, name=None):
+            mappable_combination = get_mappable_combination(combination)
+            uuid_str = str(uuid.uuid5(uuid.NAMESPACE_DNS, str(mappable_combination)))
+            self._combinations_to_uuids[mappable_combination] = uuid_str
+            self._uuids_to_combinations[uuid_str] = mappable_combination
+
+    def _transform(self, data):
+        """Transform the data.
+
+        The transformation consist on removing all the ``self.column_names`` from
+        the table, and replacing them with a unique identifier that maps to
+        that unique combination of column values under the previously computed
+        combined column name.
+
+        Args:
+            data (dict[pd.DataFrame]):
+                Table data.
+
+        Returns:
+            dict[pd].DataFrame:
+                Transformed data.
+        """
+        table_name = self._get_single_table_name(self.metadata)
+        table_data = data[table_name]
+        # To make the NaN to None mapping work for pd.Categorical data, we need to convert
+        # the columns to object before replacing NaNs with None.
+        table_data[self.column_names] = table_data[self.column_names].astype({
+            col: object
+            for col in self.column_names
+            if isinstance(table_data[col].dtype, pd.CategoricalDtype)
+        })
+
+        table_data[self.column_names] = table_data[self.column_names].replace({np.nan: None})
+        combinations = table_data[self.column_names].itertuples(index=False, name=None)
+        uuids = map(self._combinations_to_uuids.get, combinations)
+        table_data[self._joint_column] = list(uuids)
+        data[table_name] = table_data.drop(self.column_names, axis=1)
+        return data
+
+    def _reverse_transform(self, data):
+        """Reverse transform the data.
+
+        The transformation is reversed by popping the joint column from
+        the table, mapping it back to the original combination of column values,
+        and then setting all the columns back to the table with the original
+        names.
+
+        Args:
+            table_data (dict[pd.DataFrame)]:
+                Transformed data.
+
+        Returns:
+            dict[pd.DataFrame]:
+                Reverse transformed data.
+        """
+        table_name = self._get_single_table_name(self.metadata)
+        table_data = data[table_name]
+        columns = table_data.pop(self._joint_column).map(self._uuids_to_combinations)
+
+        for index, column in enumerate(self.column_names):
+            table_data[column] = columns.str[index]
+
+        return data
+
+    def _is_valid(self, data):
+        """Determine whether the data matches the pattern."""
+        table_name = self._get_single_table_name(self.metadata)
+        is_valid = {
+            table: pd.Series(True, index=table_data.index)
+            for table, table_data in data.items()
+            if table != table_name
+        }
+        merged = data[table_name].merge(
+            self._combinations, how='left', on=self.column_names, indicator=self._joint_column
+        )
+        is_valid[table_name] = merged[self._joint_column] == 'both'
+        return is_valid

--- a/sdv/cag/fixed_combinations.py
+++ b/sdv/cag/fixed_combinations.py
@@ -7,7 +7,11 @@ import pandas as pd
 
 from sdv._utils import _create_unique_name
 from sdv.cag._errors import PatternNotMetError
-from sdv.cag._utils import _validate_table_and_column_names
+from sdv.cag._utils import (
+    _is_list_of_strings,
+    _validate_table_and_column_names,
+    _validate_table_name_if_defined,
+)
 from sdv.cag.base import BasePattern
 from sdv.constraints.utils import get_mappable_combination
 from sdv.metadata import Metadata
@@ -37,16 +41,13 @@ class FixedCombinations(BasePattern):
 
     def __init__(self, column_names, table_name=None):
         super().__init__()
-        if not isinstance(column_names, list) or not all(
-            isinstance(column_name, str) for column_name in column_names
-        ):
+        if not _is_list_of_strings(column_names):
             raise ValueError('`column_names` must be a list of strings.')
 
         if len(column_names) < 2:
             raise ValueError('FixedCombinations pattern requires at least two columns.')
 
-        if table_name and not isinstance(table_name, str):
-            raise ValueError('`table_name` must be a string or None.')
+        _validate_table_name_if_defined(table_name)
 
         self.column_names = column_names
         self.table_name = table_name
@@ -143,7 +144,7 @@ class FixedCombinations(BasePattern):
                 Table data.
 
         Returns:
-            dict[pd].DataFrame:
+            (dict[pd.DataFrame]):
                 Transformed data.
         """
         table_name = self._get_single_table_name(self.metadata)
@@ -172,7 +173,7 @@ class FixedCombinations(BasePattern):
         names.
 
         Args:
-            table_data (dict[pd.DataFrame)]:
+            data (dict[pd.DataFrame)]:
                 Transformed data.
 
         Returns:

--- a/sdv/cag/fixed_combinations.py
+++ b/sdv/cag/fixed_combinations.py
@@ -10,12 +10,12 @@ from sdv.cag._errors import PatternNotMetError
 from sdv.cag._utils import (
     _get_is_valid_dict,
     _is_list_of_type,
+    _remove_columns_from_metadata,
     _validate_table_and_column_names,
     _validate_table_name_if_defined,
 )
 from sdv.cag.base import BasePattern
 from sdv.constraints.utils import get_mappable_combination
-from sdv.metadata import Metadata
 
 
 class FixedCombinations(BasePattern):
@@ -104,17 +104,9 @@ class FixedCombinations(BasePattern):
 
         metadata = metadata.to_dict()
         metadata['tables'][table_name]['columns'][combination_column] = {'sdtype': 'categorical'}
-        for column in self.column_names:
-            del metadata['tables'][table_name]['columns'][column]
-
-        column_set = set(self.column_names)
-        metadata['tables'][table_name]['column_relationships'] = [
-            rel
-            for rel in metadata['tables'][table_name].get('column_relationships', [])
-            if set(rel['column_names']).isdisjoint(column_set)
-        ]
-
-        return Metadata.load_from_dict(metadata)
+        return _remove_columns_from_metadata(
+            metadata, table_name, columns_to_drop=self.column_names
+        )
 
     def _fit(self, data, metadata):
         """Fit the pattern."""

--- a/sdv/cag/fixed_combinations.py
+++ b/sdv/cag/fixed_combinations.py
@@ -1,4 +1,4 @@
-"""FixedCombinations CAG constraint."""
+"""FixedCombinations constraint."""
 
 import uuid
 
@@ -55,7 +55,7 @@ class FixedCombinations(BasePattern):
         self._joint_column = '#'.join(self.column_names)
         self._combinations = None
 
-    def _validate_pattern_with_metadata(self, metadata):
+    def _validate_constraint_with_metadata(self, metadata):
         """Validate the constraint is compatible with the provided metadata.
 
         Validates that:
@@ -88,7 +88,7 @@ class FixedCombinations(BasePattern):
                     'column relationship.'
                 )
 
-    def _validate_pattern_with_data(self, data, metadata):
+    def _validate_constraint_with_data(self, data, metadata):
         """Validate the data is compatible with the constraint.
 
         For FixedCombinations, this is a NOP.

--- a/sdv/cag/fixed_combinations.py
+++ b/sdv/cag/fixed_combinations.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 from sdv._utils import _create_unique_name
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.cag._utils import (
     _get_is_valid_dict,
     _is_list_of_type,
@@ -70,7 +70,7 @@ class FixedCombinations(BasePattern):
         for column in self.column_names:
             col_sdtype = metadata.tables[table_name].columns[column]['sdtype']
             if col_sdtype not in ['boolean', 'categorical']:
-                raise PatternNotMetError(
+                raise ConstraintNotMetError(
                     f"Column '{column}' has an incompatible sdtype ('{col_sdtype}'). The column "
                     "sdtype must be either 'boolean' or 'categorical'."
                 )
@@ -83,7 +83,7 @@ class FixedCombinations(BasePattern):
                 or relationship_columns.isdisjoint(column_set)
             ):
                 bad_columns = "', '".join(list(relationship_columns.intersection(column_set)))
-                raise PatternNotMetError(
+                raise ConstraintNotMetError(
                     f"Cannot apply constraint because columns ['{bad_columns}'] are part of a "
                     'column relationship.'
                 )

--- a/sdv/cag/fixed_combinations.py
+++ b/sdv/cag/fixed_combinations.py
@@ -14,12 +14,12 @@ from sdv.cag._utils import (
     _validate_table_and_column_names,
     _validate_table_name_if_defined,
 )
-from sdv.cag.base import BasePattern
+from sdv.cag.base import BaseConstraint
 from sdv.constraints.utils import get_mappable_combination
 
 
-class FixedCombinations(BasePattern):
-    """Pattern to ensure that the combinations across multiple columns are fixed.
+class FixedCombinations(BaseConstraint):
+    """Constraint to ensure that the combinations across multiple columns are fixed.
 
     One simple example of this constraint can be found in a table that
     contains the columns `country` and `city`, where each country can

--- a/sdv/cag/fixed_combinations.py
+++ b/sdv/cag/fixed_combinations.py
@@ -1,4 +1,4 @@
-"""FixedCombinations CAG pattern."""
+"""FixedCombinations CAG constraint."""
 
 import uuid
 
@@ -21,13 +21,13 @@ from sdv.constraints.utils import get_mappable_combination
 class FixedCombinations(BasePattern):
     """Pattern to ensure that the combinations across multiple columns are fixed.
 
-    One simple example of this pattern can be found in a table that
+    One simple example of this constraint can be found in a table that
     contains the columns `country` and `city`, where each country can
     have multiple cities and the same city name can even be found in
     multiple countries, but some combinations of country/city would
     produce invalid results.
 
-    This pattern would ensure that the combinations of country/city
+    This constraint would ensure that the combinations of country/city
     found in the sampled data always stay within the combinations previously
     seen during training.
 
@@ -46,7 +46,7 @@ class FixedCombinations(BasePattern):
             raise ValueError('`column_names` must be a list of strings.')
 
         if len(column_names) < 2:
-            raise ValueError('FixedCombinations pattern requires at least two columns.')
+            raise ValueError('FixedCombinations constraint requires at least two columns.')
 
         _validate_table_name_if_defined(table_name)
 
@@ -56,7 +56,7 @@ class FixedCombinations(BasePattern):
         self._combinations = None
 
     def _validate_pattern_with_metadata(self, metadata):
-        """Validate the pattern is compatible with the provided metadata.
+        """Validate the constraint is compatible with the provided metadata.
 
         Validates that:
         - If `table_name` is None then the metadata contains only a single table
@@ -84,19 +84,19 @@ class FixedCombinations(BasePattern):
             ):
                 bad_columns = "', '".join(list(relationship_columns.intersection(column_set)))
                 raise PatternNotMetError(
-                    f"Cannot apply pattern because columns ['{bad_columns}'] are part of a "
+                    f"Cannot apply constraint because columns ['{bad_columns}'] are part of a "
                     'column relationship.'
                 )
 
     def _validate_pattern_with_data(self, data, metadata):
-        """Validate the data is compatible with the pattern.
+        """Validate the data is compatible with the constraint.
 
         For FixedCombinations, this is a NOP.
         """
         return
 
     def _get_updated_metadata(self, metadata):
-        """Get the new output metadata after applying the pattern to the input metadata."""
+        """Get the new output metadata after applying the constraint to the input metadata."""
         table_name = self._get_single_table_name(metadata)
         combination_column = _create_unique_name(
             self._joint_column, metadata.tables[table_name].columns.keys()
@@ -109,7 +109,7 @@ class FixedCombinations(BasePattern):
         )
 
     def _fit(self, data, metadata):
-        """Fit the pattern."""
+        """Fit the constraint."""
         table_name = self._get_single_table_name(metadata)
         table_data = data[table_name]
         self._joint_column = _create_unique_name(
@@ -183,7 +183,7 @@ class FixedCombinations(BasePattern):
         return data
 
     def _is_valid(self, data):
-        """Determine whether the data matches the pattern."""
+        """Determine whether the data matches the constraint."""
         table_name = self._get_single_table_name(self.metadata)
         is_valid = _get_is_valid_dict(data, table_name)
         merged = data[table_name].merge(

--- a/sdv/cag/fixed_combinations.py
+++ b/sdv/cag/fixed_combinations.py
@@ -8,7 +8,8 @@ import pandas as pd
 from sdv._utils import _create_unique_name
 from sdv.cag._errors import PatternNotMetError
 from sdv.cag._utils import (
-    _is_list_of_strings,
+    _get_is_valid_dict,
+    _is_list_of_type,
     _validate_table_and_column_names,
     _validate_table_name_if_defined,
 )
@@ -41,7 +42,7 @@ class FixedCombinations(BasePattern):
 
     def __init__(self, column_names, table_name=None):
         super().__init__()
-        if not _is_list_of_strings(column_names):
+        if not _is_list_of_type(column_names):
             raise ValueError('`column_names` must be a list of strings.')
 
         if len(column_names) < 2:
@@ -192,11 +193,7 @@ class FixedCombinations(BasePattern):
     def _is_valid(self, data):
         """Determine whether the data matches the pattern."""
         table_name = self._get_single_table_name(self.metadata)
-        is_valid = {
-            table: pd.Series(True, index=table_data.index)
-            for table, table_data in data.items()
-            if table != table_name
-        }
+        is_valid = _get_is_valid_dict(data, table_name)
         merged = data[table_name].merge(
             self._combinations, how='left', on=self.column_names, indicator=self._joint_column
         )

--- a/sdv/cag/fixed_increments.py
+++ b/sdv/cag/fixed_increments.py
@@ -11,10 +11,10 @@ from sdv.cag._utils import (
     _validate_table_and_column_names,
     _validate_table_name_if_defined,
 )
-from sdv.cag.base import BasePattern
+from sdv.cag.base import BaseConstraint
 
 
-class FixedIncrements(BasePattern):
+class FixedIncrements(BaseConstraint):
     """Ensure every value in a column is a multiple of the specified increment.
 
     Args:

--- a/sdv/cag/fixed_increments.py
+++ b/sdv/cag/fixed_increments.py
@@ -1,4 +1,4 @@
-"""FixedIncrements CAG pattern."""
+"""FixedIncrements CAG constraint."""
 
 import pandas as pd
 
@@ -54,7 +54,7 @@ class FixedIncrements(BasePattern):
         self._dtype = None
 
     def _validate_pattern_with_metadata(self, metadata):
-        """Validate the pattern is compatible with the provided Metadata.
+        """Validate the constraint is compatible with the provided Metadata.
 
         Validates that:
             - If no table_name is set, checks that the Metadata only contains a single table
@@ -76,7 +76,7 @@ class FixedIncrements(BasePattern):
             )
 
     def _validate_pattern_with_data(self, data, metadata):
-        """Validate the data is compatible with the pattern.
+        """Validate the data is compatible with the constraint.
 
         Args:
             data (dict[pd.DataFrame]):
@@ -100,14 +100,14 @@ class FixedIncrements(BasePattern):
             )
 
     def _get_updated_metadata(self, metadata):
-        """Get the updated metadata after applying the pattern to the metadata.
+        """Get the updated metadata after applying the constraint to the metadata.
 
         Args:
             metadata (sdv.metadata.Metadata):
-                The input Metadata to apply the pattern to.
+                The input Metadata to apply the constraint to.
 
         Returns:
-            (sdv.metadata.Metadata): The updated Metadata with the pattern applied.
+            (sdv.metadata.Metadata): The updated Metadata with the constraint applied.
         """
         table_name = self._get_single_table_name(metadata)
         increments_column = _create_unique_name(

--- a/sdv/cag/fixed_increments.py
+++ b/sdv/cag/fixed_increments.py
@@ -110,18 +110,14 @@ class FixedIncrements(BasePattern):
             (sdv.metadata.Metadata): The updated Metadata with the pattern applied.
         """
         table_name = self._get_single_table_name(metadata)
-        original_columns = list(metadata.tables[table_name].columns)
         increments_column = _create_unique_name(
             self._fixed_increments_column_name, metadata.tables[table_name].columns.keys()
         )
         metadata = metadata.to_dict()
         metadata['tables'][table_name]['columns'][increments_column] = {'sdtype': 'numerical'}
-        metadata = _remove_columns_from_metadata(
-            metadata,
-            table_name,
-            columns_to_drop=original_columns,
+        return _remove_columns_from_metadata(
+            metadata, table_name, columns_to_drop=[self.column_name]
         )
-        return metadata
 
     def _fit(self, data, metadata):
         """Learn the dtype of the column.

--- a/sdv/cag/fixed_increments.py
+++ b/sdv/cag/fixed_increments.py
@@ -1,4 +1,4 @@
-"""FixedIncrements CAG constraint."""
+"""FixedIncrements constraint."""
 
 import pandas as pd
 
@@ -53,7 +53,7 @@ class FixedIncrements(BasePattern):
         self.increment_value = increment_value
         self._dtype = None
 
-    def _validate_pattern_with_metadata(self, metadata):
+    def _validate_constraint_with_metadata(self, metadata):
         """Validate the constraint is compatible with the provided Metadata.
 
         Validates that:
@@ -75,7 +75,7 @@ class FixedIncrements(BasePattern):
                 "The column sdtype must be 'numerical'."
             )
 
-    def _validate_pattern_with_data(self, data, metadata):
+    def _validate_constraint_with_data(self, data, metadata):
         """Validate the data is compatible with the constraint.
 
         Args:

--- a/sdv/cag/fixed_increments.py
+++ b/sdv/cag/fixed_increments.py
@@ -1,0 +1,228 @@
+"""FixedIncrements CAG pattern."""
+
+import pandas as pd
+
+from sdv._utils import _create_unique_name
+from sdv.cag._errors import PatternNotMetError
+from sdv.cag._utils import (
+    _get_invalid_rows,
+    _remove_columns_from_metadata,
+    _validate_table_and_column_names,
+    _validate_table_name_if_defined,
+)
+from sdv.cag.base import BasePattern
+
+
+class FixedIncrements(BasePattern):
+    """Ensure every value in a column is a multiple of the specified increment.
+
+    Args:
+        column_name (str):
+            Name of the column.
+        increment_value (int):
+            The increment that each value in the column must be a multiple of. Must be greater
+            than 0 and a whole number.
+        table_name (str, optional):
+            The name of the table that contains the column. Optional if the
+            data is only a single table. Defaults to None.
+    """
+
+    @staticmethod
+    def _validate_init_inputs(column_name, increment_value, table_name):
+        if not isinstance(column_name, str):
+            raise ValueError('`column_name` must be a string.')
+        if not isinstance(increment_value, (int, float)):
+            raise ValueError('`increment_value` must be an integer or float.')
+        if table_name and not isinstance(table_name, str):
+            raise ValueError('`table_name` must be a string if not None.')
+
+        if increment_value <= 0:
+            raise ValueError('`increment_value` must be greater than 0.')
+        if increment_value % 1 != 0:
+            raise ValueError('`increment_value` must be a whole number.')
+
+        _validate_table_name_if_defined(table_name)
+
+    def __init__(self, column_name, increment_value, table_name=None):
+        super().__init__()
+        self._validate_init_inputs(column_name, increment_value, table_name)
+        self.column_name = column_name
+        self.table_name = table_name
+        self._fixed_increments_column_name = f'{self.column_name}#increment'
+        self.increment_value = increment_value
+        self._dtype = None
+
+    def _validate_pattern_with_metadata(self, metadata):
+        """Validate the pattern is compatible with the provided Metadata.
+
+        Validates that:
+            - If no table_name is set, checks that the Metadata only contains a single table
+            - The column_name exist in the table in the Metadata
+            - The column_name is a numerical sdtype
+        Args:
+            metadata (sdv.metadata.Metadata):
+                The input Metadata to validate.
+        """
+        _validate_table_and_column_names(
+            self.table_name, columns=[self.column_name], metadata=metadata
+        )
+        table_name = self._get_single_table_name(metadata)
+        col_sdtype = metadata.tables[table_name].columns[self.column_name]['sdtype']
+        if col_sdtype != 'numerical':
+            raise PatternNotMetError(
+                f"Column '{self.column_name}' has an incompatible sdtype ('{col_sdtype}')."
+                "The column sdtype must be 'numerical'."
+            )
+
+    def _validate_pattern_with_data(self, data, metadata):
+        """Validate the data is compatible with the pattern.
+
+        Args:
+            data (dict[pd.DataFrame]):
+                The data to validate
+
+            metadata (sdv.metadata.Metadata):
+                The input Metadata to use to validate the data.
+
+        Returns:
+            None
+        """
+        valid = self._check_if_divisible(
+            data, self._get_single_table_name(metadata), self.column_name, self.increment_value
+        )
+        if not valid.all():
+            invalid_rows_str = _get_invalid_rows(valid)
+            raise PatternNotMetError(
+                'The fixed increments requirement has not been met because the data is not '
+                f"evenly divisible by '{self.increment_value}' for row indices: "
+                f'[{invalid_rows_str}]'
+            )
+
+    def _get_updated_metadata(self, metadata):
+        """Get the updated metadata after applying the pattern to the metadata.
+
+        Args:
+            metadata (sdv.metadata.Metadata):
+                The input Metadata to apply the pattern to.
+
+        Returns:
+            (sdv.metadata.Metadata): The updated Metadata with the pattern applied.
+        """
+        table_name = self._get_single_table_name(metadata)
+        original_columns = list(metadata.tables[table_name].columns)
+        increments_column = _create_unique_name(
+            self._fixed_increments_column_name, metadata.tables[table_name].columns.keys()
+        )
+        metadata = metadata.to_dict()
+        metadata['tables'][table_name]['columns'][increments_column] = {'sdtype': 'numerical'}
+        metadata = _remove_columns_from_metadata(
+            metadata,
+            table_name,
+            columns_to_drop=original_columns,
+        )
+        return metadata
+
+    def _fit(self, data, metadata):
+        """Learn the dtype of the column.
+
+        Args:
+            data (dict[pd.DataFrame]):
+                The data.
+
+            metadata (sdv.metadata.Metadata):
+                The input Metadata.
+        """
+        table_name = self._get_single_table_name(metadata)
+        self._dtype = data[table_name][self.column_name].dtype
+
+    def _check_if_divisible(self, data, table_name, column_name, increment_value):
+        """Check if a column is divisible by a given increment value.
+
+        Args:
+            data (dict[pd.DataFrame]):
+                The data.
+
+            table_name (str):
+                Name of the table.
+
+            column_name (str):
+                Name of the table to check divisibility.
+
+            increment_value (int):
+                the number with which divisibility needs to be checked.
+        """
+        isnan = pd.isna(data[table_name][column_name])
+        is_divisible = data[table_name][column_name] % increment_value == 0
+        return isnan | is_divisible
+
+    def _is_valid(self, data):
+        """Determine if the data is evenly divisible by the increment.
+
+        Args:
+            data (dict[pd.DataFrame]):
+                The data.
+
+        Returns:
+            (dict[pd.DataFrame]):
+                For the specified table and column, returns a Series
+                which specifies if that row is evenly divisible or
+                not by the increment. The length of the Series
+                will be equal to the length of the input column.
+                The length of the dictionary will be equal to the
+                number of tables in the data and contain the same
+                table names.
+        """
+        table_name = self._get_single_table_name(self.metadata)
+        is_valid = {
+            table: pd.Series(True, index=table_data.index)
+            for table, table_data in data.items()
+            if table != table_name
+        }
+        valid = self._check_if_divisible(data, table_name, self.column_name, self.increment_value)
+        is_valid[table_name] = valid
+        return is_valid
+
+    def _transform(self, data):
+        """Transform the data.
+
+        The transformation works by dividing each value by the increment.
+
+        Args:
+            data (dict[pd.DataFrame]):
+                The data.
+
+        Returns:
+            (dict[pd.DataFrame]):
+                Transformed data.
+        """
+        table_name = self._get_single_table_name(self.metadata)
+        table_data = data[table_name]
+        self._fixed_increments_column_name = _create_unique_name(
+            self._fixed_increments_column_name, table_data.columns
+        )
+        table_data[self._fixed_increments_column_name] = (
+            table_data[self.column_name] / self.increment_value
+        ).astype(self._dtype)
+        data[table_name] = table_data.drop(columns=self.column_name)
+        return data
+
+    def _reverse_transform(self, data):
+        """Reverse transform the data.
+
+        Convert column to a multiple of the increment.
+
+        Args:
+            data (dict[pd.DataFrame)]:
+                Transformed data.
+
+        Returns:
+            dict[pd.DataFrame]:
+                Reverse transformed data.
+        """
+        table_name = self._get_single_table_name(self.metadata)
+        table_data = data[table_name]
+
+        column_data = table_data[self._fixed_increments_column_name].round()
+        table_data[self.column_name] = (column_data * self.increment_value).astype(self._dtype)
+        data[table_name] = table_data.drop(columns=[self._fixed_increments_column_name])
+        return data

--- a/sdv/cag/fixed_increments.py
+++ b/sdv/cag/fixed_increments.py
@@ -3,7 +3,7 @@
 import pandas as pd
 
 from sdv._utils import _create_unique_name
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.cag._utils import (
     _get_invalid_rows,
     _get_is_valid_dict,
@@ -70,7 +70,7 @@ class FixedIncrements(BasePattern):
         table_name = self._get_single_table_name(metadata)
         col_sdtype = metadata.tables[table_name].columns[self.column_name]['sdtype']
         if col_sdtype != 'numerical':
-            raise PatternNotMetError(
+            raise ConstraintNotMetError(
                 f"Column '{self.column_name}' has an incompatible sdtype ('{col_sdtype}')."
                 "The column sdtype must be 'numerical'."
             )
@@ -93,7 +93,7 @@ class FixedIncrements(BasePattern):
         )
         if not valid.all():
             invalid_rows_str = _get_invalid_rows(valid)
-            raise PatternNotMetError(
+            raise ConstraintNotMetError(
                 'The fixed increments requirement has not been met because the data is not '
                 f"evenly divisible by '{self.increment_value}' for row indices: "
                 f'[{invalid_rows_str}]'

--- a/sdv/cag/fixed_increments.py
+++ b/sdv/cag/fixed_increments.py
@@ -6,6 +6,7 @@ from sdv._utils import _create_unique_name
 from sdv.cag._errors import PatternNotMetError
 from sdv.cag._utils import (
     _get_invalid_rows,
+    _get_is_valid_dict,
     _remove_columns_from_metadata,
     _validate_table_and_column_names,
     _validate_table_name_if_defined,
@@ -173,11 +174,7 @@ class FixedIncrements(BasePattern):
                 table names.
         """
         table_name = self._get_single_table_name(self.metadata)
-        is_valid = {
-            table: pd.Series(True, index=table_data.index)
-            for table, table_data in data.items()
-            if table != table_name
-        }
+        is_valid = _get_is_valid_dict(data, table_name)
         valid = self._check_if_divisible(data, table_name, self.column_name, self.increment_value)
         is_valid[table_name] = valid
         return is_valid

--- a/sdv/cag/inequality.py
+++ b/sdv/cag/inequality.py
@@ -1,4 +1,4 @@
-"""Inequality CAG pattern."""
+"""Inequality CAG constraint."""
 
 import numpy as np
 import pandas as pd
@@ -72,7 +72,7 @@ class Inequality(BasePattern):
         self._nan_column_name = None
 
     def _validate_pattern_with_metadata(self, metadata):
-        """Validate the pattern is compatible with the provided metadata.
+        """Validate the constraint is compatible with the provided metadata.
 
         Validates that:
         - If no table_name is provided, the metadata contains a single table
@@ -119,7 +119,7 @@ class Inequality(BasePattern):
         return metadata.tables[table_name].columns[column_name].get('datetime_format')
 
     def _validate_pattern_with_data(self, data, metadata):
-        """Validate the data is compatible with the pattern.
+        """Validate the data is compatible with the constraint.
 
         Validate that the inequality requirement is met between the high and low columns.
         """
@@ -175,7 +175,7 @@ class Inequality(BasePattern):
         return diff_column, nan_diff_column
 
     def _get_updated_metadata(self, metadata):
-        """Get the new output metadata after applying the pattern to the input metadata."""
+        """Get the new output metadata after applying the constraint to the input metadata."""
         table_name = self._get_single_table_name(metadata)
         diff_column, nan_diff_column = self._get_diff_and_nan_column_names(
             metadata, self._diff_column_name, table_name
@@ -189,7 +189,7 @@ class Inequality(BasePattern):
         )
 
     def _fit(self, data, metadata):
-        """Fit the pattern.
+        """Fit the constraint.
 
         Args:
             data (dict[str, pd.DataFrame]):

--- a/sdv/cag/inequality.py
+++ b/sdv/cag/inequality.py
@@ -1,0 +1,320 @@
+"""Inequality CAG pattern."""
+
+import numpy as np
+import pandas as pd
+
+from sdv._utils import _convert_to_timedelta, _create_unique_name
+from sdv.cag._errors import PatternNotMetError
+from sdv.cag._utils import _validate_table_and_column_names
+from sdv.cag.base import BasePattern
+from sdv.constraints.utils import (
+    cast_to_datetime64,
+    compute_nans_column,
+    get_datetime_diff,
+    match_datetime_precision,
+    revert_nans_columns,
+)
+from sdv.metadata import Metadata
+
+
+class Inequality(BasePattern):
+    """Pattern that ensures `high_column_name` is greater than `low_column_name` .
+
+    The transformation works by creating a column with the difference between the
+    `high_column_name` and `low_column_name` columns and storing it in the
+    `high_column_name`'s place. The reverse transform adds the difference column
+    to the `low_column_name` to reconstruct the `high_column_name`.
+
+    Args:
+        low_column_name (str):
+            Name of the column that contains the low values.
+        high_column_name (str):
+            Name of the column that contains the high values.
+        strict_boundaries (bool):
+            Whether the comparison of the values should be strict ``>=`` or
+            not ``>``. Defaults to False.
+        table_name (str, optional):
+            The name of the table that contains the columns. Optional if the
+            data is only a single table. Defaults to None.
+    """
+
+    @staticmethod
+    def _validate_init_inputs(low_column_name, high_column_name, strict_boundaries, table_name):
+        if not (isinstance(low_column_name, str) and isinstance(high_column_name, str)):
+            raise ValueError('`low_column_name` and `high_column_name` must be strings.')
+
+        if not isinstance(strict_boundaries, bool):
+            raise ValueError('`strict_boundaries` must be a boolean.')
+
+        if table_name and not isinstance(table_name, str):
+            raise ValueError('`table_name` must be a string or None.')
+
+    def __init__(self, low_column_name, high_column_name, strict_boundaries=False, table_name=None):
+        super().__init__()
+        self._validate_init_inputs(low_column_name, high_column_name, strict_boundaries, table_name)
+        self._low_column_name = low_column_name
+        self._high_column_name = high_column_name
+        self._diff_column_name = f'{self._low_column_name}#{self._high_column_name}'
+        self._operator = np.greater if strict_boundaries else np.greater_equal
+        self.table_name = table_name
+
+        # Set during fit
+        self._is_datetime = None
+        self._dtype = None
+        self._low_datetime_format = None
+        self._high_datetime_format = None
+
+        # Set during transform
+        self._nan_column_name = None
+
+    def _validate_pattern_with_metadata(self, metadata):
+        """Validate the pattern is compatible with the provided metadata.
+
+        Validates that:
+        - If no table_name is provided, the metadata contains a single table
+        - Both the low_column_name and high_column_name columns exist in the table in the metadata
+        - Both the low_column_name and high_column_name columns have the same sdtype,
+        and that it is either numerical or datetime
+
+        Args:
+            metadata (Metadata):
+                The metadata to validate against.
+
+        Raises:
+            ValueError:
+                If any of the validations fail.
+        """
+        columns = [self._low_column_name, self._high_column_name]
+        _validate_table_and_column_names(self.table_name, columns, metadata)
+        table_name = self._get_single_table_name(metadata)
+        for column in columns:
+            col_sdtype = metadata.tables[table_name].columns[column]['sdtype']
+            if col_sdtype not in ['numerical', 'datetime']:
+                raise PatternNotMetError(
+                    f"Column '{column}' has an incompatible sdtype '{col_sdtype}'. The column "
+                    "sdtype must be either 'numerical' or 'datetime'."
+                )
+
+        low_column_sdtype = metadata.tables[table_name].columns[self._low_column_name]['sdtype']
+        high_column_sdtype = metadata.tables[table_name].columns[self._high_column_name]['sdtype']
+        if low_column_sdtype != high_column_sdtype:
+            raise PatternNotMetError(
+                f"Columns '{self._low_column_name}' and '{self._high_column_name}' must have the "
+                f"same sdtype. Found '{low_column_sdtype}' and '{high_column_sdtype}'."
+            )
+
+    def _get_data(self, data):
+        low = data[self._low_column_name].to_numpy()
+        high = data[self._high_column_name].to_numpy()
+        return low, high
+
+    def _get_is_datetime(self, metadata, table_name):
+        return metadata.tables[table_name].columns[self._low_column_name]['sdtype'] == 'datetime'
+
+    def _get_datetime_format(self, metadata, table_name, column_name):
+        return metadata.tables[table_name].columns[column_name].get('datetime_format')
+
+    def _validate_pattern_with_data(self, data, metadata):
+        """Validate the data is compatible with the pattern.
+
+        Validate that the inequality requirement is met between the high and low columns.
+        """
+        table_name = self._get_single_table_name(metadata)
+        data = data[table_name]
+        low, high = self._get_data(data)
+        is_datetime = self._get_is_datetime(metadata, table_name)
+        if is_datetime and data[self._high_column_name].dtypes == 'O':
+            low_format = self._get_datetime_format(metadata, table_name, self._low_column_name)
+            high_format = self._get_datetime_format(metadata, table_name, self._high_column_name)
+            low = cast_to_datetime64(low, low_format)
+            high = cast_to_datetime64(high, high_format)
+
+            format_matches = bool(low_format == high_format)
+            if not format_matches:
+                low, high = match_datetime_precision(
+                    low=low,
+                    high=high,
+                    low_datetime_format=low_format,
+                    high_datetime_format=high_format,
+                )
+
+        valid = pd.isna(low) | pd.isna(high) | self._operator(high, low)
+
+        if not valid.all():
+            invalid_rows = np.where(~valid)[0]
+            if len(invalid_rows) <= 5:
+                invalid_rows_str = ', '.join(str(i) for i in invalid_rows)
+            else:
+                first_five = ', '.join(str(i) for i in invalid_rows[:5])
+                remaining = len(invalid_rows) - 5
+                invalid_rows_str = f'{first_five}, +{remaining} more'
+
+            raise PatternNotMetError(
+                f'The inequality requirement is not met for row indices: [{invalid_rows_str}]'
+            )
+
+    def _get_updated_metadata(self, metadata):
+        """Get the new output metadata after applying the pattern to the input metadata."""
+        table_name = self._get_single_table_name(metadata)
+        diff_column = _create_unique_name(
+            self._diff_column_name, metadata.tables[table_name].columns.keys()
+        )
+
+        metadata = metadata.to_dict()
+        metadata['tables'][table_name]['columns'][diff_column] = {'sdtype': 'numerical'}
+        del metadata['tables'][table_name]['columns'][self._high_column_name]
+
+        metadata['tables'][table_name]['column_relationships'] = [
+            rel
+            for rel in metadata['tables'][table_name].get('column_relationships', [])
+            if self._high_column_name not in rel['column_names']
+        ]
+
+        return Metadata.load_from_dict(metadata)
+
+    def _fit(self, data, metadata):
+        """Fit the pattern.
+
+        Args:
+            data (dict[str, pd.DataFrame]):
+                Table data.
+            metadata (Metadata):
+                Metadata.
+        """
+        table_name = self._get_single_table_name(metadata)
+        table_data = data[table_name]
+        self._dtype = table_data[self._high_column_name].dtypes
+        self._is_datetime = self._get_is_datetime(metadata, table_name)
+        if self._is_datetime:
+            self._low_datetime_format = self._get_datetime_format(
+                metadata, table_name, self._low_column_name
+            )
+            self._high_datetime_format = self._get_datetime_format(
+                metadata, table_name, self._high_column_name
+            )
+
+    def _transform(self, data):
+        """Transform the data.
+
+        The transformation consists on replacing the `high_column_name` values with the
+        difference between it and the `low_column_name` values.
+
+        Afterwards, a logarithm is applied to the difference + 1 to ensure that the
+        value stays positive when reverted afterwards using an exponential.
+
+        Args:
+            data (dict[str, pd.DataFrame]):
+                Table data.
+
+        Returns:
+            dict[str, pd.DataFrame]:
+                Transformed data.
+        """
+        table_name = self._get_single_table_name(self.metadata)
+        table_data = data[table_name]
+        low, high = self._get_data(table_data)
+        if self._is_datetime:
+            diff_column = get_datetime_diff(
+                high=high,
+                low=low,
+                high_datetime_format=self._high_datetime_format,
+                low_datetime_format=self._low_datetime_format,
+            )
+        else:
+            diff_column = high - low
+
+        self._diff_column_name = _create_unique_name(self._diff_column_name, table_data.columns)
+        table_data[self._diff_column_name] = np.log(diff_column + 1)
+
+        nan_col = compute_nans_column(table_data, [self._low_column_name, self._high_column_name])
+        if nan_col is not None:
+            self._nan_column_name = _create_unique_name(nan_col.name, table_data.columns)
+            table_data[self._nan_column_name] = nan_col
+            if self._is_datetime:
+                mean_value_low = table_data[self._low_column_name].mode()[0]
+            else:
+                mean_value_low = table_data[self._low_column_name].mean()
+            table_data = table_data.fillna({
+                self._low_column_name: mean_value_low,
+                self._diff_column_name: table_data[self._diff_column_name].mean(),
+            })
+
+        data[table_name] = table_data.drop(self._high_column_name, axis=1)
+
+        return data
+
+    def _reverse_transform(self, data):
+        """Reverse transform the table data.
+
+        The transformation is reversed by computing an exponential of the difference value,
+        subtracting 1 and converting it to the original dtype. Finally, the obtained column
+        is added to the `low_column_name` column to get back the original `high_column_name`
+        value.
+
+        Args:
+            data (dict[str, pd.DataFrame]):
+                Table data.
+
+        Returns:
+            dict[str, pd.DataFrame]:
+                Transformed data.
+        """
+        table_name = self._get_single_table_name(self.metadata)
+        table_data = data[table_name]
+        diff_column = np.exp(table_data[self._diff_column_name]) - 1
+        if self._dtype != np.dtype('float'):
+            diff_column = diff_column.round()
+
+        if self._is_datetime:
+            diff_column = _convert_to_timedelta(diff_column)
+
+        low = table_data[self._low_column_name].to_numpy()
+        if self._is_datetime and self._dtype == 'O':
+            low = cast_to_datetime64(low)
+
+        table_data[self._high_column_name] = pd.Series(diff_column + low).astype(self._dtype)
+
+        if self._nan_column_name and self._nan_column_name in table_data.columns:
+            table_data = revert_nans_columns(table_data, self._nan_column_name)
+
+        data[table_name] = table_data.drop(self._diff_column_name, axis=1)
+
+        return data
+
+    def _is_valid(self, data):
+        """Check whether `high` is greater than `low` in each row.
+
+        Args:
+            data (dict[str, pd.DataFrame]):
+                Table data.
+
+        Returns:
+            dict[str, pd.Series]:
+                Whether each row is valid.
+        """
+        table_name = self._get_single_table_name(self.metadata)
+        is_valid = {
+            table: pd.Series(True, index=table_data.index)
+            for table, table_data in data.items()
+            if table != table_name
+        }
+
+        table_data = data[table_name]
+        low, high = self._get_data(table_data)
+        if self._is_datetime and self._dtype == 'O':
+            low = cast_to_datetime64(low, self._low_datetime_format)
+            high = cast_to_datetime64(high, self._high_datetime_format)
+
+            format_matches = bool(self._low_datetime_format == self._high_datetime_format)
+            if not format_matches:
+                low, high = match_datetime_precision(
+                    low=low,
+                    high=high,
+                    low_datetime_format=self._low_datetime_format,
+                    high_datetime_format=self._high_datetime_format,
+                )
+
+        valid = pd.isna(low) | pd.isna(high) | self._operator(high, low)
+        is_valid[table_name] = valid
+
+        return is_valid

--- a/sdv/cag/inequality.py
+++ b/sdv/cag/inequality.py
@@ -1,4 +1,4 @@
-"""Inequality CAG constraint."""
+"""Inequality constraint."""
 
 import numpy as np
 import pandas as pd
@@ -71,7 +71,7 @@ class Inequality(BasePattern):
         # Set during transform
         self._nan_column_name = None
 
-    def _validate_pattern_with_metadata(self, metadata):
+    def _validate_constraint_with_metadata(self, metadata):
         """Validate the constraint is compatible with the provided metadata.
 
         Validates that:
@@ -118,7 +118,7 @@ class Inequality(BasePattern):
     def _get_datetime_format(self, metadata, table_name, column_name):
         return metadata.tables[table_name].columns[column_name].get('datetime_format')
 
-    def _validate_pattern_with_data(self, data, metadata):
+    def _validate_constraint_with_data(self, data, metadata):
         """Validate the data is compatible with the constraint.
 
         Validate that the inequality requirement is met between the high and low columns.

--- a/sdv/cag/inequality.py
+++ b/sdv/cag/inequality.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 from sdv._utils import _convert_to_timedelta, _create_unique_name
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.cag._utils import (
     _get_is_valid_dict,
     _remove_columns_from_metadata,
@@ -94,7 +94,7 @@ class Inequality(BasePattern):
         for column in columns:
             col_sdtype = metadata.tables[table_name].columns[column]['sdtype']
             if col_sdtype not in ['numerical', 'datetime']:
-                raise PatternNotMetError(
+                raise ConstraintNotMetError(
                     f"Column '{column}' has an incompatible sdtype '{col_sdtype}'. The column "
                     "sdtype must be either 'numerical' or 'datetime'."
                 )
@@ -102,7 +102,7 @@ class Inequality(BasePattern):
         low_column_sdtype = metadata.tables[table_name].columns[self._low_column_name]['sdtype']
         high_column_sdtype = metadata.tables[table_name].columns[self._high_column_name]['sdtype']
         if low_column_sdtype != high_column_sdtype:
-            raise PatternNotMetError(
+            raise ConstraintNotMetError(
                 f"Columns '{self._low_column_name}' and '{self._high_column_name}' must have the "
                 f"same sdtype. Found '{low_column_sdtype}' and '{high_column_sdtype}'."
             )
@@ -153,7 +153,7 @@ class Inequality(BasePattern):
                 remaining = len(invalid_rows) - 5
                 invalid_rows_str = f'{first_five}, +{remaining} more'
 
-            raise PatternNotMetError(
+            raise ConstraintNotMetError(
                 f'The inequality requirement is not met for row indices: [{invalid_rows_str}]'
             )
 

--- a/sdv/cag/inequality.py
+++ b/sdv/cag/inequality.py
@@ -10,7 +10,7 @@ from sdv.cag._utils import (
     _remove_columns_from_metadata,
     _validate_table_and_column_names,
 )
-from sdv.cag.base import BasePattern
+from sdv.cag.base import BaseConstraint
 from sdv.constraints.utils import (
     cast_to_datetime64,
     compute_nans_column,
@@ -20,8 +20,8 @@ from sdv.constraints.utils import (
 )
 
 
-class Inequality(BasePattern):
-    """Pattern that ensures `high_column_name` is greater than `low_column_name` .
+class Inequality(BaseConstraint):
+    """Constraint that ensures `high_column_name` is greater than `low_column_name` .
 
     The transformation works by creating a column with the difference between the
     `high_column_name` and `low_column_name` columns and storing it in the

--- a/sdv/cag/inequality.py
+++ b/sdv/cag/inequality.py
@@ -7,6 +7,7 @@ from sdv._utils import _convert_to_timedelta, _create_unique_name
 from sdv.cag._errors import PatternNotMetError
 from sdv.cag._utils import (
     _get_is_valid_dict,
+    _remove_columns_from_metadata,
     _validate_table_and_column_names,
 )
 from sdv.cag.base import BasePattern
@@ -17,7 +18,6 @@ from sdv.constraints.utils import (
     match_datetime_precision,
     revert_nans_columns,
 )
-from sdv.metadata import Metadata
 
 
 class Inequality(BasePattern):
@@ -165,15 +165,9 @@ class Inequality(BasePattern):
 
         metadata = metadata.to_dict()
         metadata['tables'][table_name]['columns'][diff_column] = {'sdtype': 'numerical'}
-        del metadata['tables'][table_name]['columns'][self._high_column_name]
-
-        metadata['tables'][table_name]['column_relationships'] = [
-            rel
-            for rel in metadata['tables'][table_name].get('column_relationships', [])
-            if self._high_column_name not in rel['column_names']
-        ]
-
-        return Metadata.load_from_dict(metadata)
+        return _remove_columns_from_metadata(
+            metadata, table_name, columns_to_drop=[self._high_column_name]
+        )
 
     def _fit(self, data, metadata):
         """Fit the pattern.

--- a/sdv/cag/inequality.py
+++ b/sdv/cag/inequality.py
@@ -5,7 +5,10 @@ import pandas as pd
 
 from sdv._utils import _convert_to_timedelta, _create_unique_name
 from sdv.cag._errors import PatternNotMetError
-from sdv.cag._utils import _validate_table_and_column_names
+from sdv.cag._utils import (
+    _get_is_valid_dict,
+    _validate_table_and_column_names,
+)
 from sdv.cag.base import BasePattern
 from sdv.constraints.utils import (
     cast_to_datetime64,
@@ -293,12 +296,7 @@ class Inequality(BasePattern):
                 Whether each row is valid.
         """
         table_name = self._get_single_table_name(self.metadata)
-        is_valid = {
-            table: pd.Series(True, index=table_data.index)
-            for table, table_data in data.items()
-            if table != table_name
-        }
-
+        is_valid = _get_is_valid_dict(data, table_name)
         table_data = data[table_name]
         low, high = self._get_data(table_data)
         if self._is_datetime and self._dtype == 'O':

--- a/sdv/cag/one_hot_encoding.py
+++ b/sdv/cag/one_hot_encoding.py
@@ -9,10 +9,10 @@ from sdv.cag._utils import (
     _is_list_of_type,
     _validate_table_and_column_names,
 )
-from sdv.cag.base import BasePattern
+from sdv.cag.base import BaseConstraint
 
 
-class OneHotEncoding(BasePattern):
+class OneHotEncoding(BaseConstraint):
     """Ensure the appropriate columns are one hot encoded.
 
     This constraint allows the user to specify a list of columns where each row

--- a/sdv/cag/one_hot_encoding.py
+++ b/sdv/cag/one_hot_encoding.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.cag._utils import (
     _get_invalid_rows,
     _get_is_valid_dict,
@@ -54,7 +54,7 @@ class OneHotEncoding(BasePattern):
                 The metadata to validate against.
 
         Raises:
-            PatternNotMetError:
+            ConstraintNotMetError:
                 If any of the validations fail.
         """
         _validate_table_and_column_names(self.table_name, self._column_names, metadata)
@@ -75,7 +75,7 @@ class OneHotEncoding(BasePattern):
         valid = self._get_valid_table_data(data[table_name])
         if not valid.all():
             invalid_rows_str = _get_invalid_rows(valid)
-            raise PatternNotMetError(
+            raise ConstraintNotMetError(
                 f'The one hot encoding requirement is not met for row indices: [{invalid_rows_str}]'
             )
 

--- a/sdv/cag/one_hot_encoding.py
+++ b/sdv/cag/one_hot_encoding.py
@@ -1,4 +1,4 @@
-"""One Hot Encoding CAG constraint."""
+"""One Hot Encoding constraint."""
 
 import numpy as np
 
@@ -42,7 +42,7 @@ class OneHotEncoding(BasePattern):
         self._column_names = column_names
         self.table_name = table_name
 
-    def _validate_pattern_with_metadata(self, metadata):
+    def _validate_constraint_with_metadata(self, metadata):
         """Validate the constraint is compatible with the provided metadata.
 
         Validates that:
@@ -69,7 +69,7 @@ class OneHotEncoding(BasePattern):
 
         return sum_one & max_one & min_zero & no_nans
 
-    def _validate_pattern_with_data(self, data, metadata):
+    def _validate_constraint_with_data(self, data, metadata):
         """Validate the data is compatible with the constraint."""
         table_name = self._get_single_table_name(metadata)
         valid = self._get_valid_table_data(data[table_name])

--- a/sdv/cag/one_hot_encoding.py
+++ b/sdv/cag/one_hot_encoding.py
@@ -1,4 +1,4 @@
-"""One Hot Encoding CAG pattern."""
+"""One Hot Encoding CAG constraint."""
 
 import numpy as np
 
@@ -43,7 +43,7 @@ class OneHotEncoding(BasePattern):
         self.table_name = table_name
 
     def _validate_pattern_with_metadata(self, metadata):
-        """Validate the pattern is compatible with the provided metadata.
+        """Validate the constraint is compatible with the provided metadata.
 
         Validates that:
         - If no table_name is provided the metadata contains a single table
@@ -70,7 +70,7 @@ class OneHotEncoding(BasePattern):
         return sum_one & max_one & min_zero & no_nans
 
     def _validate_pattern_with_data(self, data, metadata):
-        """Validate the data is compatible with the pattern."""
+        """Validate the data is compatible with the constraint."""
         table_name = self._get_single_table_name(metadata)
         valid = self._get_valid_table_data(data[table_name])
         if not valid.all():
@@ -80,7 +80,7 @@ class OneHotEncoding(BasePattern):
             )
 
     def _fit(self, data, metadata):
-        """Fit the pattern.
+        """Fit the constraint.
 
         Args:
             data (dict[str, pd.DataFrame]):

--- a/sdv/cag/one_hot_encoding.py
+++ b/sdv/cag/one_hot_encoding.py
@@ -1,0 +1,145 @@
+"""One Hot Encoding CAG pattern."""
+
+import numpy as np
+
+from sdv.cag._errors import PatternNotMetError
+from sdv.cag._utils import (
+    _get_invalid_rows,
+    _get_is_valid_dict,
+    _is_list_of_type,
+    _validate_table_and_column_names,
+)
+from sdv.cag.base import BasePattern
+
+
+class OneHotEncoding(BasePattern):
+    """Ensure the appropriate columns are one hot encoded.
+
+    This constraint allows the user to specify a list of columns where each row
+    is a one hot vector. During the reverse transform, the output of the model
+    is transformed so that the column with the largest value is set to 1 while
+    all other columns are set to 0.
+
+    Args:
+        column_names (list[str]):
+            Names of the columns containing one hot rows.
+        table_name (str, optional):
+            The name of the table that contains the columns. Optional if the
+            data is only a single table. Defaults to None.
+    """
+
+    @staticmethod
+    def _validate_init_inputs(column_names, table_name):
+        if not _is_list_of_type(column_names):
+            raise ValueError('`column_names` must be a list of strings.')
+
+        if table_name and not isinstance(table_name, str):
+            raise ValueError('`table_name` must be a string or None.')
+
+    def __init__(self, column_names, table_name=None):
+        super().__init__()
+        self._validate_init_inputs(column_names, table_name)
+        self._column_names = column_names
+        self.table_name = table_name
+
+    def _validate_pattern_with_metadata(self, metadata):
+        """Validate the pattern is compatible with the provided metadata.
+
+        Validates that:
+        - If no table_name is provided the metadata contains a single table
+        - All input columns exist in the table in the metadata.
+
+        Args:
+            metadata (sdv.metadata.Metadata):
+                The metadata to validate against.
+
+        Raises:
+            PatternNotMetError:
+                If any of the validations fail.
+        """
+        _validate_table_and_column_names(self.table_name, self._column_names, metadata)
+
+    def _get_valid_table_data(self, table_data):
+        one_hot_data = table_data[self._column_names]
+
+        sum_one = one_hot_data.sum(axis=1) == 1.0
+        max_one = one_hot_data.max(axis=1) == 1.0
+        min_zero = one_hot_data.min(axis=1) == 0.0
+        no_nans = ~one_hot_data.isna().any(axis=1)
+
+        return sum_one & max_one & min_zero & no_nans
+
+    def _validate_pattern_with_data(self, data, metadata):
+        """Validate the data is compatible with the pattern."""
+        table_name = self._get_single_table_name(metadata)
+        valid = self._get_valid_table_data(data[table_name])
+        if not valid.all():
+            invalid_rows_str = _get_invalid_rows(valid)
+            raise PatternNotMetError(
+                f'The one hot encoding requirement is not met for row indices: [{invalid_rows_str}]'
+            )
+
+    def _fit(self, data, metadata):
+        """Fit the pattern.
+
+        Args:
+            data (dict[str, pd.DataFrame]):
+                Table data.
+            metadata (sdv.metadata.Metadata):
+                Metadata.
+        """
+        pass
+
+    def _transform(self, data):
+        """Transform the data.
+
+        Args:
+            data (dict[str, pd.DataFrame]):
+                Table data.
+
+        Returns:
+            dict[str, pd.DataFrame]:
+                Transformed data.
+        """
+        return data
+
+    def _reverse_transform(self, data):
+        """Reverse transform the table data.
+
+        Set the column with the largest value to one, set all other columns to zero.
+
+        Args:
+            data (dict[str, pd.DataFrame]):
+                Table data.
+
+        Returns:
+            dict[str, pd.DataFrame]:
+                Transformed data.
+        """
+        table_name = self._get_single_table_name(self.metadata)
+        table_data = data[table_name]
+        one_hot_data = table_data[self._column_names]
+        transformed_data = np.zeros_like(one_hot_data.to_numpy())
+        max_category_indices = np.argmax(one_hot_data.to_numpy(), axis=1)
+        transformed_data[np.arange(len(one_hot_data)), max_category_indices] = 1
+        table_data[self._column_names] = transformed_data
+        data[table_name] = table_data
+
+        return data
+
+    def _is_valid(self, data):
+        """Check whether the data satisfies the one-hot constraint.
+
+        Args:
+            data (dict[str, pd.DataFrame]):
+                Table data.
+
+        Returns:
+            dict[str, pd.Series]:
+                Whether each row is valid.
+        """
+        table_name = self._get_single_table_name(self.metadata)
+        is_valid = _get_is_valid_dict(data, table_name)
+        is_valid[table_name] = self._get_valid_table_data(data[table_name])
+
+        return is_valid

--- a/sdv/cag/range.py
+++ b/sdv/cag/range.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 from sdv._utils import _convert_to_timedelta, _create_unique_name
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.cag._utils import (
     _get_is_valid_dict,
     _remove_columns_from_metadata,
@@ -116,7 +116,7 @@ class Range(BasePattern):
                 The metadata to validate against.
 
         Raises:
-            PatternNotMetError:
+            ConstraintNotMetError:
                 If any of the validations fail.
         """
         columns = [self._low_column_name, self._middle_column_name, self._high_column_name]
@@ -125,7 +125,7 @@ class Range(BasePattern):
         for column in columns:
             col_sdtype = metadata.tables[table_name].columns[column]['sdtype']
             if col_sdtype not in ['numerical', 'datetime']:
-                raise PatternNotMetError(
+                raise ConstraintNotMetError(
                     f"Column '{column}' has an incompatible sdtype '{col_sdtype}'. The column "
                     "sdtype must be either 'numerical' or 'datetime'."
                 )
@@ -134,7 +134,7 @@ class Range(BasePattern):
         mid_column_sdtype = metadata.tables[table_name].columns[self._middle_column_name]['sdtype']
         high_column_sdtype = metadata.tables[table_name].columns[self._high_column_name]['sdtype']
         if low_column_sdtype != mid_column_sdtype or mid_column_sdtype != high_column_sdtype:
-            raise PatternNotMetError(
+            raise ConstraintNotMetError(
                 f"Columns '{self._low_column_name}', '{self._middle_column_name}' and "
                 f"'{self._high_column_name}' must have the same sdtype. Found '{low_column_sdtype}'"
                 f", '{mid_column_sdtype}' and '{high_column_sdtype}'."
@@ -172,7 +172,7 @@ class Range(BasePattern):
                 remaining = len(invalid_rows) - 5
                 invalid_rows_str = f'{first_five}, +{remaining} more'
 
-            raise PatternNotMetError(
+            raise ConstraintNotMetError(
                 f'The range requirement is not met for row indices: [{invalid_rows_str}]'
             )
 

--- a/sdv/cag/range.py
+++ b/sdv/cag/range.py
@@ -7,7 +7,10 @@ import pandas as pd
 
 from sdv._utils import _convert_to_timedelta, _create_unique_name
 from sdv.cag._errors import PatternNotMetError
-from sdv.cag._utils import _validate_table_and_column_names
+from sdv.cag._utils import (
+    _get_is_valid_dict,
+    _validate_table_and_column_names,
+)
 from sdv.cag.base import BasePattern
 from sdv.constraints.utils import (
     cast_to_datetime64,
@@ -355,11 +358,7 @@ class Range(BasePattern):
                 Whether each row is valid.
         """
         table_name = self._get_single_table_name(self.metadata)
-        is_valid = {
-            table: pd.Series(True, index=table_data.index)
-            for table, table_data in data.items()
-            if table != table_name
-        }
+        is_valid = _get_is_valid_dict(data, table_name)
         is_valid[table_name] = self._get_valid_table_data(data[table_name])
 
         return is_valid

--- a/sdv/cag/range.py
+++ b/sdv/cag/range.py
@@ -1,4 +1,4 @@
-"""Range CAG constraint."""
+"""Range constraint."""
 
 import operator
 
@@ -103,7 +103,7 @@ class Range(BasePattern):
         # Set during transform
         self._nan_column_name = None
 
-    def _validate_pattern_with_metadata(self, metadata):
+    def _validate_constraint_with_metadata(self, metadata):
         """Validate the constraint is compatible with the provided metadata.
 
         Validates that:
@@ -158,7 +158,7 @@ class Range(BasePattern):
 
         return low_lt_middle & mid_lt_high & low_lt_high
 
-    def _validate_pattern_with_data(self, data, metadata):
+    def _validate_constraint_with_data(self, data, metadata):
         """Validate the data is compatible with the constraint."""
         table_name = self._get_single_table_name(metadata)
         valid = self._get_valid_table_data(data[table_name])

--- a/sdv/cag/range.py
+++ b/sdv/cag/range.py
@@ -1,4 +1,4 @@
-"""Range CAG pattern."""
+"""Range CAG constraint."""
 
 import operator
 
@@ -24,7 +24,7 @@ from sdv.constraints.utils import (
 class Range(BasePattern):
     """Ensure that the `middle_column_name` is between `low_column_name` and `high_column_name`.
 
-    The transformation strategy works the same as the Inequality pattern but with two
+    The transformation strategy works the same as the Inequality constraint but with two
     columns instead of one. We compute the difference between the `middle_column_name`
     and the `low_column_name` column and then apply a logarithm to the difference + 1 to ensure
     that the value stays positive when reverted afterwards using an exponential.
@@ -104,7 +104,7 @@ class Range(BasePattern):
         self._nan_column_name = None
 
     def _validate_pattern_with_metadata(self, metadata):
-        """Validate the pattern is compatible with the provided metadata.
+        """Validate the constraint is compatible with the provided metadata.
 
         Validates that:
         - If no table_name is provided the metadata contains a single table
@@ -159,7 +159,7 @@ class Range(BasePattern):
         return low_lt_middle & mid_lt_high & low_lt_high
 
     def _validate_pattern_with_data(self, data, metadata):
-        """Validate the data is compatible with the pattern."""
+        """Validate the data is compatible with the constraint."""
         table_name = self._get_single_table_name(metadata)
         valid = self._get_valid_table_data(data[table_name])
 
@@ -177,7 +177,7 @@ class Range(BasePattern):
             )
 
     def _get_updated_metadata(self, metadata):
-        """Get the new output metadata after applying the pattern to the input metadata."""
+        """Get the new output metadata after applying the constraint to the input metadata."""
         table_name = self._get_single_table_name(metadata)
         low_diff_column = _create_unique_name(
             self._low_diff_column_name, metadata.tables[table_name].columns.keys()
@@ -200,7 +200,7 @@ class Range(BasePattern):
         return metadata.tables[table_name].columns[column_name].get('datetime_format')
 
     def _fit(self, data, metadata):
-        """Fit the pattern.
+        """Fit the constraint.
 
         Args:
             data (dict[str, pd.DataFrame]):

--- a/sdv/cag/range.py
+++ b/sdv/cag/range.py
@@ -1,0 +1,365 @@
+"""Range CAG pattern."""
+
+import operator
+
+import numpy as np
+import pandas as pd
+
+from sdv._utils import _convert_to_timedelta, _create_unique_name
+from sdv.cag._errors import PatternNotMetError
+from sdv.cag._utils import _validate_table_and_column_names
+from sdv.cag.base import BasePattern
+from sdv.constraints.utils import (
+    cast_to_datetime64,
+    compute_nans_column,
+    get_datetime_diff,
+    revert_nans_columns,
+)
+from sdv.metadata import Metadata
+
+
+class Range(BasePattern):
+    """Ensure that the `middle_column_name` is between `low_column_name` and `high_column_name`.
+
+    The transformation strategy works the same as the Inequality pattern but with two
+    columns instead of one. We compute the difference between the `middle_column_name`
+    and the `low_column_name` column and then apply a logarithm to the difference + 1 to ensure
+    that the value stays positive when reverted afterwards using an exponential.
+    We do the same for the difference between the `high_column_name` and `middle_column_name`.
+
+    Args:
+        low_column_name (str):
+            Name of the column which will be the lower bound.
+        middle_column_name (str):
+            Name of the column that has to be between the lower bound and upper bound.
+        high_column_name (str):
+            Name of the column which will be the higher bound.
+        strict_boundaries (bool, optional):
+            Whether the comparison of the values should be strict `>=` or
+            not `>` when comparing them.
+            Defaults to True.
+        table_name (str, optional):
+            The name of the table that contains the columns. Optional if the
+            data is only a single table. Defaults to None.
+    """
+
+    @staticmethod
+    def _validate_init_inputs(
+        low_column_name,
+        middle_column_name,
+        high_column_name,
+        strict_boundaries,
+        table_name,
+    ):
+        if not (
+            isinstance(low_column_name, str)
+            and isinstance(middle_column_name, str)
+            and isinstance(high_column_name, str)
+        ):
+            raise ValueError(
+                '`low_column_name`, `middle_column_name` and `high_column_name` must be strings.'
+            )
+
+        if not isinstance(strict_boundaries, bool):
+            raise ValueError('`strict_boundaries` must be a boolean.')
+
+        if table_name and not isinstance(table_name, str):
+            raise ValueError('`table_name` must be a string or None.')
+
+    def __init__(
+        self,
+        low_column_name,
+        middle_column_name,
+        high_column_name,
+        strict_boundaries=True,
+        table_name=None,
+    ):
+        super().__init__()
+        self._validate_init_inputs(
+            low_column_name,
+            middle_column_name,
+            high_column_name,
+            strict_boundaries,
+            table_name,
+        )
+        self._low_column_name = low_column_name
+        self._middle_column_name = middle_column_name
+        self._high_column_name = high_column_name
+        self._low_diff_column_name = f'{self._low_column_name}#{self._middle_column_name}'
+        self._high_diff_column_name = f'{self._middle_column_name}#{self._high_column_name}'
+        self._operator = operator.lt if strict_boundaries else operator.le
+        self.table_name = table_name
+
+        # Set during fit
+        self._is_datetime = None
+        self._dtype = None
+        self._low_datetime_format = None
+        self._middle_datetime_format = None
+        self._high_datetime_format = None
+
+        # Set during transform
+        self._nan_column_name = None
+
+    def _validate_pattern_with_metadata(self, metadata):
+        """Validate the pattern is compatible with the provided metadata.
+
+        Validates that:
+        - If no table_name is provided the metadata contains a single table
+        - All input columns exist in the table in the metadata.
+        - All columns have the same sdtype, and that it is either numerical or datetime
+
+        Args:
+            metadata (Metadata):
+                The metadata to validate against.
+
+        Raises:
+            PatternNotMetError:
+                If any of the validations fail.
+        """
+        columns = [self._low_column_name, self._middle_column_name, self._high_column_name]
+        _validate_table_and_column_names(self.table_name, columns, metadata)
+        table_name = self._get_single_table_name(metadata)
+        for column in columns:
+            col_sdtype = metadata.tables[table_name].columns[column]['sdtype']
+            if col_sdtype not in ['numerical', 'datetime']:
+                raise PatternNotMetError(
+                    f"Column '{column}' has an incompatible sdtype '{col_sdtype}'. The column "
+                    "sdtype must be either 'numerical' or 'datetime'."
+                )
+
+        low_column_sdtype = metadata.tables[table_name].columns[self._low_column_name]['sdtype']
+        mid_column_sdtype = metadata.tables[table_name].columns[self._middle_column_name]['sdtype']
+        high_column_sdtype = metadata.tables[table_name].columns[self._high_column_name]['sdtype']
+        if low_column_sdtype != mid_column_sdtype or mid_column_sdtype != high_column_sdtype:
+            raise PatternNotMetError(
+                f"Columns '{self._low_column_name}', '{self._middle_column_name}' and "
+                f"'{self._high_column_name}' must have the same sdtype. Found '{low_column_sdtype}'"
+                f", '{mid_column_sdtype}' and '{high_column_sdtype}'."
+            )
+
+    def _get_data(self, data):
+        low = data[self._low_column_name].to_numpy()
+        mid = data[self._middle_column_name].to_numpy()
+        high = data[self._high_column_name].to_numpy()
+        return low, mid, high
+
+    def _get_valid_table_data(self, table_data):
+        low, mid, high = self._get_data(table_data)
+        low_is_nan = pd.isna(low)
+        mid_is_nan = pd.isna(mid)
+        high_is_nan = pd.isna(high)
+
+        low_lt_middle = self._operator(low, mid) | low_is_nan | mid_is_nan
+        mid_lt_high = self._operator(mid, high) | mid_is_nan | high_is_nan
+        low_lt_high = self._operator(low, high) | low_is_nan | high_is_nan
+
+        return low_lt_middle & mid_lt_high & low_lt_high
+
+    def _validate_pattern_with_data(self, data, metadata):
+        """Validate the data is compatible with the pattern."""
+        table_name = self._get_single_table_name(metadata)
+        valid = self._get_valid_table_data(data[table_name])
+
+        if not valid.all():
+            invalid_rows = np.where(~valid)[0]
+            if len(invalid_rows) <= 5:
+                invalid_rows_str = ', '.join(str(i) for i in invalid_rows)
+            else:
+                first_five = ', '.join(str(i) for i in invalid_rows[:5])
+                remaining = len(invalid_rows) - 5
+                invalid_rows_str = f'{first_five}, +{remaining} more'
+
+            raise PatternNotMetError(
+                f'The range requirement is not met for row indices: [{invalid_rows_str}]'
+            )
+
+    def _get_updated_metadata(self, metadata):
+        """Get the new output metadata after applying the pattern to the input metadata."""
+        table_name = self._get_single_table_name(metadata)
+        low_diff_column = _create_unique_name(
+            self._low_diff_column_name, metadata.tables[table_name].columns.keys()
+        )
+        high_diff_column = _create_unique_name(
+            self._high_diff_column_name, metadata.tables[table_name].columns.keys()
+        )
+
+        metadata = metadata.to_dict()
+        metadata['tables'][table_name]['columns'][low_diff_column] = {'sdtype': 'numerical'}
+        metadata['tables'][table_name]['columns'][high_diff_column] = {'sdtype': 'numerical'}
+        del metadata['tables'][table_name]['columns'][self._high_column_name]
+        del metadata['tables'][table_name]['columns'][self._middle_column_name]
+
+        metadata['tables'][table_name]['column_relationships'] = [
+            rel
+            for rel in metadata['tables'][table_name].get('column_relationships', [])
+            if self._high_column_name not in rel['column_names']
+            and self._middle_column_name not in rel['column_names']
+        ]
+
+        return Metadata.load_from_dict(metadata)
+
+    def _get_is_datetime(self, metadata, table_name):
+        return metadata.tables[table_name].columns[self._low_column_name]['sdtype'] == 'datetime'
+
+    def _get_datetime_format(self, metadata, table_name, column_name):
+        return metadata.tables[table_name].columns[column_name].get('datetime_format')
+
+    def _fit(self, data, metadata):
+        """Fit the pattern.
+
+        Args:
+            data (dict[str, pd.DataFrame]):
+                Table data.
+            metadata (Metadata):
+                Metadata.
+        """
+        table_name = self._get_single_table_name(metadata)
+        table_data = data[table_name]
+        self._dtype = table_data[self._high_column_name].dtypes
+        self._is_datetime = self._get_is_datetime(metadata, table_name)
+        if self._is_datetime:
+            self._low_datetime_format = self._get_datetime_format(
+                metadata, table_name, self._low_column_name
+            )
+            self._middle_datetime_format = self._get_datetime_format(
+                metadata, table_name, self._middle_column_name
+            )
+            self._high_datetime_format = self._get_datetime_format(
+                metadata, table_name, self._high_column_name
+            )
+
+        self._low_diff_column_name = _create_unique_name(
+            self._low_diff_column_name, table_data.columns
+        )
+        self._high_diff_column_name = _create_unique_name(
+            self._high_diff_column_name, table_data.columns
+        )
+
+    def _transform(self, data):
+        """Transform the data.
+
+        The transformation consists in replacing `middle` and `high` by the difference
+        between them and `low` and `middle` respectively. To avoid negative values, the
+        logarithm of the difference + 1 is taken.
+
+        Args:
+            data (dict[str, pd.DataFrame]):
+                Table data.
+
+        Returns:
+            dict[str, pd.DataFrame]:
+                Transformed data.
+        """
+        table_name = self._get_single_table_name(self.metadata)
+        table_data = data[table_name]
+        low, mid, high = self._get_data(table_data)
+        if self._is_datetime:
+            low_diff_column = get_datetime_diff(
+                mid,
+                low,
+                high_datetime_format=self._middle_datetime_format,
+                low_datetime_format=self._low_datetime_format,
+                dtype=self._dtype,
+            )
+            high_diff_column = get_datetime_diff(
+                high,
+                mid,
+                high_datetime_format=self._high_datetime_format,
+                low_datetime_format=self._middle_datetime_format,
+                dtype=self._dtype,
+            )
+        else:
+            low_diff_column = mid - low
+            high_diff_column = high - mid
+
+        table_data[self._low_diff_column_name] = np.log(low_diff_column + 1)
+        table_data[self._high_diff_column_name] = np.log(high_diff_column + 1)
+
+        list_columns = [self._low_column_name, self._middle_column_name, self._high_column_name]
+        nan_column = compute_nans_column(table_data, list_columns)
+        if nan_column is not None:
+            self._nan_column_name = _create_unique_name(nan_column.name, table_data.columns)
+            table_data[self._nan_column_name] = nan_column
+            if self._is_datetime:
+                mean_value_low = table_data[self._low_column_name].mode()[0]
+            else:
+                mean_value_low = table_data[self._low_column_name].mean()
+
+            table_data = table_data.fillna({
+                self._low_column_name: mean_value_low,
+                self._low_diff_column_name: table_data[self._low_diff_column_name].mean(),
+                self._high_diff_column_name: table_data[self._high_diff_column_name].mean(),
+            })
+
+        data[table_name] = table_data.drop(
+            [self._middle_column_name, self._high_column_name], axis=1
+        )
+
+        return data
+
+    def _reverse_transform(self, data):
+        """Reverse transform the table data.
+
+        The reverse transformation consists in replacing `low_diff_column` and
+        `high_diff_column` by the sum of `low` and `low_diff_column` and `middle`
+        and `high_diff_column` respectively.
+
+        Args:
+            data (dict[str, pd.DataFrame]):
+                Table data.
+
+        Returns:
+            dict[str, pd.DataFrame]:
+                Transformed data.
+        """
+        table_name = self._get_single_table_name(self.metadata)
+        table_data = data[table_name]
+        low_diff_column = np.exp(table_data[self._low_diff_column_name]) - 1
+        high_diff_column = np.exp(table_data[self._high_diff_column_name]) - 1
+        if self._dtype != np.dtype('float'):
+            low_diff_column = low_diff_column.round()
+            high_diff_column = high_diff_column.round()
+
+        if self._is_datetime:
+            low_diff_column = _convert_to_timedelta(low_diff_column)
+            high_diff_column = _convert_to_timedelta(high_diff_column)
+
+        low = table_data[self._low_column_name].to_numpy()
+        if self._is_datetime and self._dtype == 'O':
+            low = cast_to_datetime64(low, self._low_datetime_format)
+
+        middle = pd.Series(low_diff_column + low).astype(self._dtype)
+        table_data[self._middle_column_name] = middle
+        table_data[self._high_column_name] = pd.Series(high_diff_column + middle.to_numpy()).astype(
+            self._dtype
+        )
+
+        if self._nan_column_name in table_data.columns:
+            table_data = revert_nans_columns(table_data, self._nan_column_name)
+
+        data[table_name] = table_data.drop(
+            [self._low_diff_column_name, self._high_diff_column_name], axis=1
+        )
+
+        return data
+
+    def _is_valid(self, data):
+        """Check whether the `middle` column is between the `low` and `high` columns.
+
+        Args:
+            data (dict[str, pd.DataFrame]):
+                Table data.
+
+        Returns:
+            dict[str, pd.Series]:
+                Whether each row is valid.
+        """
+        table_name = self._get_single_table_name(self.metadata)
+        is_valid = {
+            table: pd.Series(True, index=table_data.index)
+            for table, table_data in data.items()
+            if table != table_name
+        }
+        is_valid[table_name] = self._get_valid_table_data(data[table_name])
+
+        return is_valid

--- a/sdv/cag/range.py
+++ b/sdv/cag/range.py
@@ -12,7 +12,7 @@ from sdv.cag._utils import (
     _remove_columns_from_metadata,
     _validate_table_and_column_names,
 )
-from sdv.cag.base import BasePattern
+from sdv.cag.base import BaseConstraint
 from sdv.constraints.utils import (
     cast_to_datetime64,
     compute_nans_column,
@@ -21,7 +21,7 @@ from sdv.constraints.utils import (
 )
 
 
-class Range(BasePattern):
+class Range(BaseConstraint):
     """Ensure that the `middle_column_name` is between `low_column_name` and `high_column_name`.
 
     The transformation strategy works the same as the Inequality constraint but with two

--- a/sdv/cag/range.py
+++ b/sdv/cag/range.py
@@ -9,6 +9,7 @@ from sdv._utils import _convert_to_timedelta, _create_unique_name
 from sdv.cag._errors import PatternNotMetError
 from sdv.cag._utils import (
     _get_is_valid_dict,
+    _remove_columns_from_metadata,
     _validate_table_and_column_names,
 )
 from sdv.cag.base import BasePattern
@@ -18,7 +19,6 @@ from sdv.constraints.utils import (
     get_datetime_diff,
     revert_nans_columns,
 )
-from sdv.metadata import Metadata
 
 
 class Range(BasePattern):
@@ -189,17 +189,9 @@ class Range(BasePattern):
         metadata = metadata.to_dict()
         metadata['tables'][table_name]['columns'][low_diff_column] = {'sdtype': 'numerical'}
         metadata['tables'][table_name]['columns'][high_diff_column] = {'sdtype': 'numerical'}
-        del metadata['tables'][table_name]['columns'][self._high_column_name]
-        del metadata['tables'][table_name]['columns'][self._middle_column_name]
-
-        metadata['tables'][table_name]['column_relationships'] = [
-            rel
-            for rel in metadata['tables'][table_name].get('column_relationships', [])
-            if self._high_column_name not in rel['column_names']
-            and self._middle_column_name not in rel['column_names']
-        ]
-
-        return Metadata.load_from_dict(metadata)
+        return _remove_columns_from_metadata(
+            metadata, table_name, columns_to_drop=[self._high_column_name, self._middle_column_name]
+        )
 
     def _get_is_datetime(self, metadata, table_name):
         return metadata.tables[table_name].columns[self._low_column_name]['sdtype'] == 'datetime'

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -1271,7 +1271,7 @@ class FixedIncrements(Constraint):
     """Ensure every value in a column is a multiple of the specified increment.
 
     Args:
-        column_name (str or list[str]):
+        column_name (str):
             Name of the column.
         increment_value (int):
             The increment that each value in the column must be a multiple of. Must be greater

--- a/sdv/constraints/tabular.py
+++ b/sdv/constraints/tabular.py
@@ -32,6 +32,7 @@ Currently implemented constraints are:
 
 import operator
 import uuid
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -656,6 +657,11 @@ class ScalarInequality(Constraint):
             raise ValueError('Datetime must be represented as a string.')
 
     def __init__(self, column_name, relation, value):
+        deprecation_msg = (
+            f'Warning: The `{self.__class__.__name__}` constraint is deprecated. '
+            'Please use the `enforce_min_max_values` parameter instead.'
+        )
+        warnings.warn(deprecation_msg, FutureWarning)
         self._validate_init_inputs(column_name, value, relation)
         self._value = cast_to_datetime64(value) if _is_datetime_type(value) else value
         self._column_name = column_name
@@ -1130,6 +1136,11 @@ class ScalarRange(Constraint):
             )
 
     def __init__(self, column_name, low_value, high_value, strict_boundaries=True):
+        deprecation_msg = (
+            f'Warning: The `{self.__class__.__name__}` constraint is deprecated. '
+            'Please use the `enforce_min_max_values` parameter instead.'
+        )
+        warnings.warn(deprecation_msg, FutureWarning)
         self.constraint_columns = (column_name,)
         self._column_name = column_name
         self._validate_init_inputs(low_value, high_value)

--- a/sdv/constraints/utils.py
+++ b/sdv/constraints/utils.py
@@ -195,7 +195,7 @@ def revert_nans_columns(table_data, nan_column_name):
     """
     combinations = table_data[nan_column_name].unique()
     for combination in combinations:
-        if combination != 'None':
+        if not pd.isna(combination) and combination != 'None':
             column_names = [column_name.strip() for column_name in combination.split(',')]
             table_data.loc[table_data[nan_column_name] == combination, column_names] = np.nan
 

--- a/sdv/constraints/utils.py
+++ b/sdv/constraints/utils.py
@@ -159,8 +159,8 @@ def get_nan_component_value(row):
 
     if columns_with_nans:
         return ', '.join(columns_with_nans)
-    else:
-        return 'None'
+
+    return 'None'
 
 
 def compute_nans_column(table_data, list_column_names):

--- a/sdv/evaluation/single_table.py
+++ b/sdv/evaluation/single_table.py
@@ -31,9 +31,6 @@ def evaluate_quality(real_data, synthetic_data, metadata, verbose=True):
         metadata = metadata._convert_to_single_table()
 
     quality_report = QualityReport()
-    if isinstance(metadata, Metadata):
-        metadata = metadata._convert_to_single_table()
-
     quality_report.generate(real_data, synthetic_data, metadata.to_dict(), verbose)
     return quality_report
 

--- a/sdv/metadata/multi_table.py
+++ b/sdv/metadata/multi_table.py
@@ -844,7 +844,7 @@ class MultiTableMetadata:
                     self.tables[table_name].validate_data(table_data, table_sdtype_warnings)
 
             except InvalidDataError as error:
-                error_msg = f"Table: '{table_name}'"
+                error_msg = f'Errors in {table_name}:'
                 for _error in error.errors:
                     error_msg += f'\nError: {_error}'
 

--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -164,7 +164,7 @@ class BaseMultiTableSynthesizer:
 
         Args:
             constraints (list):
-                A list of CAG constraints to apply to the synthesizer.
+                A list of constraints to apply to the synthesizer.
         """
         if not hasattr(self, '_original_metadata'):
             self._original_metadata = self.metadata
@@ -216,14 +216,14 @@ class BaseMultiTableSynthesizer:
             transformed_data = pattern.transform(data=transformed_data)
 
     def get_metadata(self, version='original'):
-        """Get the metadata, either original or modified after applying CAG constraints.
+        """Get the metadata, either original or modified after applying constraints.
 
         Args:
             version (str, optional):
                 The version of metadata to return, must be one of 'original' or 'modified'. If
                 'original', will return the original metadata used to instantiate the
                 synthesizer. If 'modified', will return the modified metadata after applying this
-                synthesizer's CAG constraints. Defaults to 'original'.
+                synthesizer's constraints. Defaults to 'original'.
         """
         if version not in ('original', 'modified'):
             error_msg = f"Unrecognized version '{version}', please use 'original' or 'modified'."
@@ -235,7 +235,7 @@ class BaseMultiTableSynthesizer:
         return Metadata.load_from_dict(self.metadata.to_dict())
 
     def _transform_helper(self, data):
-        """Validate and transform all CAG constraints during preprocessing.
+        """Validate and transform all constraints during preprocessing.
 
         Args:
             data (dict[str, pd.DataFrame]):
@@ -255,7 +255,7 @@ class BaseMultiTableSynthesizer:
         return data
 
     def _reverse_transform_helper(self, sampled_data):
-        """Reverse transform CAG constraints after sampling."""
+        """Reverse transform constraints after sampling."""
         if not hasattr(self, 'constraints'):
             return sampled_data
 

--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -183,7 +183,7 @@ class BaseMultiTableSynthesizer:
 
         self._initialize_models()
 
-    def get_cag(self):
+    def get_constraints(self):
         """Get a list of constraint-augmented generation constraints applied to the synthesizer."""
         if hasattr(self, 'constraints'):
             return deepcopy(self.constraints)
@@ -702,21 +702,6 @@ class BaseMultiTableSynthesizer:
             f"Loss values are not available for table '{table_name}' "
             'because the table does not use a GAN-based model.'
         )
-
-    def get_constraints(self):
-        """Get constraints of the synthesizer.
-
-        Returns:
-            list:
-                List of dictionaries describing the constraints of the synthesizer.
-        """
-        constraints = []
-        for table_name, synthesizer in self._table_synthesizers.items():
-            for constraint in synthesizer.get_constraints():
-                constraint['table_name'] = table_name
-                constraints.append(constraint)
-
-        return constraints
 
     def load_custom_constraint_classes(self, filepath, class_names):
         """Load a custom constraint class for each table's synthesizer.

--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -132,6 +132,7 @@ class BaseMultiTableSynthesizer:
                 self._table_parameters[table_name] = deepcopy(self.DEFAULT_SYNTHESIZER_KWARGS)
 
         self._initialize_models()
+        self.constraints = []
         self._fitted = False
         self._creation_date = datetime.datetime.today().strftime('%Y-%m-%d')
         self._fitted_date = None
@@ -241,10 +242,10 @@ class BaseMultiTableSynthesizer:
             data (dict[str, pd.DataFrame]):
                 The data dictionary.
         """
-        if not hasattr(self, 'constraints'):
+        if not getattr(self, 'constraints', None):
             return data
 
-        metadata = self._original_metadata
+        metadata = getattr(self, '_original_metadata', self.metadata)
         for constraint in self.constraints:
             if not self._fitted:
                 constraint.fit(data, metadata)
@@ -256,7 +257,7 @@ class BaseMultiTableSynthesizer:
 
     def _reverse_transform_helper(self, sampled_data):
         """Reverse transform constraints after sampling."""
-        if not hasattr(self, 'constraints'):
+        if not getattr(self, 'constraints', None):
             return sampled_data
 
         for constraint in reversed(self.constraints):
@@ -266,8 +267,8 @@ class BaseMultiTableSynthesizer:
             drop_unknown_references,  # noqa: F401 Lazy import to fix circular dependency
         )
 
-        # issue
-        sampled_data = drop_unknown_references(sampled_data, self._original_metadata, verbose=False)
+        metadata = getattr(self, '_original_metadata', self.metadata)
+        sampled_data = drop_unknown_references(sampled_data, metadata, verbose=False)
         return sampled_data
 
     def get_table_parameters(self, table_name):

--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -200,13 +200,10 @@ class BaseMultiTableSynthesizer:
             error_msg = f"Unrecognized version '{version}', please use 'original' or 'modified'."
             raise ValueError(error_msg)
 
-        if version == 'original':
-            original = (
-                self._original_metadata if hasattr(self, '_original_metadata') else self.metadata
-            )
-            return original
-        else:
-            return self.metadata
+        if version == 'original' and hasattr(self, '_original_metadata'):
+            return Metadata.load_from_dict(self._original_metadata.to_dict())
+
+        return Metadata.load_from_dict(self.metadata.to_dict())
 
     def _transform_helper(self, data):
         """Validate and transform all CAG patterns during preprocessing.

--- a/sdv/sampling/independent_sampler.py
+++ b/sdv/sampling/independent_sampler.py
@@ -106,8 +106,7 @@ class BaseIndependentSampler:
                 try:
                     table_rows[name] = table_rows[name].dropna().astype(dtype)
                 except ValueError as e:
-                    column_metadata = metadata.columns.get(name)
-                    sdtype = column_metadata.get('sdtype')
+                    sdtype = metadata.columns.get(name).get('sdtype')
                     if sdtype not in dtypes_to_sdtype.values():
                         LOGGER.info(
                             f"The real data in '{table_name}' and column '{name}' was stored as "

--- a/sdv/sequential/par.py
+++ b/sdv/sequential/par.py
@@ -34,8 +34,8 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
     to be passed into PAR.
 
     Args:
-        metadata (sdv.metadata.SingleTableMetadata):
-            Single table metadata representing the data that this synthesizer will be used for.
+        metadata (sdv.metadata.Metadata):
+            Metadata representing the data that this synthesizer will be used for.
         enforce_min_max_values (bool):
             Specify whether or not to clip the data returned by ``reverse_transform`` of
             the numerical transformer, ``FloatFormatter``, to the min and max values seen
@@ -80,8 +80,9 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         for column, column_metadata in self._extra_context_columns.items():
             context_columns_dict[column] = column_metadata
 
+        table_metadata = self._get_table_metadata()
         for column in context_columns:
-            context_columns_dict[column] = self.metadata.columns[column]
+            context_columns_dict[column] = table_metadata.columns[column]
 
         context_metadata_dict['columns'] = self._update_context_column_dict(context_columns_dict)
         return SingleTableMetadata.load_from_dict(context_metadata_dict)
@@ -98,8 +99,9 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
                 Updated context column metadata.
         """
         default_transformers_by_sdtype = deepcopy(self._data_processor._transformers_by_sdtype)
+        table_metadata = self._get_table_metadata()
         for column in self.context_columns:
-            column_metadata = self.metadata.columns[column]
+            column_metadata = table_metadata.columns[column]
             if default_transformers_by_sdtype.get(column_metadata['sdtype']):
                 context_columns_dict[column] = {'sdtype': 'numerical'}
 
@@ -108,8 +110,9 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
     def _get_context_columns_for_processing(self):
         columns_to_be_processed = []
         default_transformers_by_sdtype = deepcopy(self._data_processor._transformers_by_sdtype)
+        table_metadata = self._get_table_metadata()
         for column in self.context_columns:
-            if default_transformers_by_sdtype.get(self.metadata.columns[column]['sdtype']):
+            if default_transformers_by_sdtype.get(table_metadata.columns[column]['sdtype']):
                 columns_to_be_processed.append(column)
 
         return columns_to_be_processed
@@ -139,7 +142,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
 
         # Cast the sequence key to an iterable. While the metadata only supports a single sequence
         # key, but PAR is set up to handle composite sequence keys
-        sequence_key = self.metadata.sequence_key
+        sequence_key = self._get_table_metadata().sequence_key
         self._sequence_key = list(_cast_to_iterable(sequence_key)) if sequence_key else None
         if not self._sequence_key:
             raise SynthesizerInputError(
@@ -147,7 +150,7 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
                 'sequence key. Your metadata does not include a sequence key.'
             )
 
-        self._sequence_index = self.metadata.sequence_index
+        self._sequence_index = self._get_table_metadata().sequence_index
         self.context_columns = context_columns or []
         self._validate_sequence_key_and_context_columns()
         self._extra_context_columns = {}
@@ -418,13 +421,14 @@ class PARSynthesizer(LossValuesMixin, BaseSynthesizer):
         )
         data_types = []
         context_types = []
+        table_metadata = self._get_table_metadata()
         for field in self._output_columns:
             dtype = timeseries_data[field].dtype
             kind = dtype.kind
             if kind in ('i', 'f'):
                 data_type = 'continuous'
                 # Check if metadata overrides this data type
-                if self.metadata.columns.get(field, {}).get('sdtype', None) == 'categorical':
+                if table_metadata.columns.get(field, {}).get('sdtype', None) == 'categorical':
                     data_type = 'categorical'
             elif kind in ('O', 'b'):
                 data_type = 'categorical'

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -101,16 +101,20 @@ class BaseSynthesizer:
             for sdtype, transformer in self._model_sdtype_transformers.items():
                 self._data_processor._update_transformers_by_sdtypes(sdtype, transformer)
 
-    def _check_original_metadata_updated(self):
-        if not hasattr(self, '_original_metadata'):
-            unified_metadata = Metadata.load_from_dict(self.metadata.to_dict())
-            setattr(self, '_original_metadata', unified_metadata)
+    def _check_input_metadata_updated(self):
+        if not hasattr(self, '_input_metadata'):
+            if hasattr(self, '_original_metadata'):
+                unified_metadata = Metadata.load_from_dict(self._original_metadata.to_dict())
+            else:
+                unified_metadata = Metadata.load_from_dict(self.metadata.to_dict())
 
-        if isinstance(self._original_metadata, Metadata):
-            metadata = self._original_metadata._convert_to_single_table()
+            setattr(self, '_input_metadata', unified_metadata)
+
+        if isinstance(self._input_metadata, Metadata):
+            metadata = self._input_metadata._convert_to_single_table()
 
         else:
-            metadata = self._original_metadata
+            metadata = self._input_metadata
 
         if metadata._updated:
             warnings.warn(
@@ -125,6 +129,11 @@ class BaseSynthesizer:
                 "We strongly recommend saving the metadata using 'save_to_json' for replicability"
                 ' in future SDV versions.'
             )
+            if hasattr(self, '_input_metadata'):
+                if hasattr(self._input_metadata, '_reset_updated_flag'):
+                    self._input_metadata._reset_updated_flag()
+                else:
+                    self._input_metadata._updated = False
 
     def _validate_regex_format(self):
         if self.metadata.tables:
@@ -139,7 +148,13 @@ class BaseSynthesizer:
         self, metadata, enforce_min_max_values=True, enforce_rounding=True, locales=['en_US']
     ):
         self._validate_inputs(enforce_min_max_values, enforce_rounding)
-        self._original_metadata = self.metadata = metadata
+
+        # Points to the input metadata object and allows us to check if user has changed it
+        self._input_metadata = metadata
+
+        # Points to a dynamic metadata object that could be modified by constraints
+        self.metadata = metadata
+
         self._table_name = Metadata.DEFAULT_SINGLE_TABLE_NAME
         if isinstance(metadata, Metadata):
             self._table_name = metadata._get_single_table_name()
@@ -151,6 +166,10 @@ class BaseSynthesizer:
 
         self.metadata.validate()
         self._check_metadata_updated()
+
+        # Points to a metadata object that conserves the initialized status of the synthesizer
+        self._original_metadata = deepcopy(self.metadata)
+
         self.enforce_min_max_values = enforce_min_max_values
         self.enforce_rounding = enforce_rounding
         self.locales = locales
@@ -343,12 +362,26 @@ class BaseSynthesizer:
 
         return instantiated_parameters
 
-    def get_metadata(self):
-        """Return the ``Metadata`` for this synthesizer."""
-        if isinstance(self.metadata, SingleTableMetadata):
-            table_name = getattr(self, '_table_name', None)
-            return Metadata.load_from_dict(self.metadata.to_dict(), table_name)
-        return self.metadata
+    def get_metadata(self, version='original'):
+        """Get the metadata, either original or modified after applying CAG patterns.
+
+        Args:
+            version (str, optional):
+                The version of metadata to return, must be one of 'original' or 'modified'. If
+                'original', will return the original metadata used to instantiate the
+                synthesizer. If 'modified', will return the modified metadata after applying this
+                synthesizer's CAG patterns. Defaults to 'original'.
+        """
+        if version not in ('original', 'modified'):
+            raise ValueError(
+                f"Unrecognized version '{version}', please use 'original' or 'modified'."
+            )
+
+        table_name = getattr(self, '_table_name', None)
+        if hasattr(self, '_original_metadata') and version == 'original':
+            return Metadata.load_from_dict(self._original_metadata.to_dict(), table_name)
+
+        return Metadata.load_from_dict(self.metadata.to_dict(), table_name)
 
     def load_custom_constraint_classes(self, filepath, class_names):
         """Load a custom constraint class for the current synthesizer.
@@ -558,7 +591,7 @@ class BaseSynthesizer:
         })
 
         check_synthesizer_version(self, is_fit_method=True, compare_operator=operator.lt)
-        self._check_original_metadata_updated()
+        self._check_input_metadata_updated()
         self._fitted = False
         self._data_processor.reset_sampling()
         self._random_state_set = False
@@ -688,26 +721,6 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
     def get_cag(self):
         """Get a list of constraint-augmented generation patterns applied to the synthesizer."""
         return deepcopy(self._chained_patterns + self._reject_sampling_patterns)
-
-    def get_metadata(self, version='original'):
-        """Get the metadata, either original or modified after applying CAG patterns.
-
-        Args:
-            version (str, optional):
-                The version of metadata to return, must be one of 'original' or 'modified'. If
-                'original', will return the original metadata used to instantiate the
-                synthesizer. If 'modified', will return the modified metadata after applying this
-                synthesizer's CAG patterns. Defaults to 'original'.
-        """
-        if version not in ('original', 'modified'):
-            raise ValueError(
-                f"Unrecognized version '{version}', please use 'original' or 'modified'."
-            )
-
-        if hasattr(self, '_original_metadata') and version == 'original':
-            return self._original_metadata
-
-        return super().get_metadata()
 
     def _transform_helper(self, data):
         """Validate and transform all CAG patterns during preprocessing.
@@ -1158,7 +1171,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                 ' sampling synthetic data.'
             )
 
-        self._check_original_metadata_updated()
+        self._check_input_metadata_updated()
         sample_timestamp = datetime.datetime.now()
         has_constraints = bool(self._data_processor._constraints)
         has_batches = batch_size is not None and batch_size != num_rows

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -117,17 +117,20 @@ class BaseSynthesizer:
             )
 
     def _check_metadata_updated(self):
-        if self.metadata._updated:
-            self.metadata._updated = False
+        if self.metadata._check_updated_flag():
+            self.metadata._reset_updated_flag()
             warnings.warn(
                 "We strongly recommend saving the metadata using 'save_to_json' for replicability"
                 ' in future SDV versions.'
             )
 
     def _validate_regex_format(self):
-        id_columns = self.metadata.get_column_names(sdtype='id')
+        # Using SingleTableMetadata because `get_column_names` raises an error
+        # if the metadata is empty
+        single_table_metadata = self.metadata._convert_to_single_table()
+        id_columns = single_table_metadata.get_column_names(sdtype='id')
         for column_name in id_columns:
-            regex = self.metadata.columns[column_name].get('regex_format')
+            regex = single_table_metadata.columns[column_name].get('regex_format')
             _check_regex_format(self._table_name, column_name, regex)
 
     def __init__(
@@ -138,19 +141,19 @@ class BaseSynthesizer:
         self._table_name = Metadata.DEFAULT_SINGLE_TABLE_NAME
         if isinstance(metadata, Metadata):
             self._table_name = metadata._get_single_table_name()
-            self.metadata = metadata._convert_to_single_table()
-
-        elif isinstance(metadata, SingleTableMetadata):
+        else:
             warnings.warn(DEPRECATION_MSG, FutureWarning)
+            self._table_name = Metadata.DEFAULT_SINGLE_TABLE_NAME
+            self.metadata = Metadata.load_from_dict(metadata.to_dict(), self._table_name)
+            self.metadata.tables[self._table_name]._updated = metadata._updated
 
-        self._validate_inputs(enforce_min_max_values, enforce_rounding)
         self.metadata.validate()
         self._check_metadata_updated()
         self.enforce_min_max_values = enforce_min_max_values
         self.enforce_rounding = enforce_rounding
         self.locales = locales
         self._data_processor = DataProcessor(
-            metadata=self.metadata,
+            metadata=self.metadata._convert_to_single_table(),
             enforce_rounding=self.enforce_rounding,
             enforce_min_max_values=self.enforce_min_max_values,
             locales=self.locales,
@@ -184,7 +187,7 @@ class BaseSynthesizer:
         """Validate that the data follows the metadata."""
         errors = []
         try:
-            self.metadata.validate_data(data)
+            self.metadata.validate_data({self._table_name: data})
         except InvalidDataError as error:
             errors += error.errors
 
@@ -209,10 +212,13 @@ class BaseSynthesizer:
         """
         return []
 
+    def _get_table_metadata(self):
+        return self.metadata.tables.get(self._table_name, SingleTableMetadata())
+
     def _validate_primary_key(self, data):
-        primary_key = self.metadata.primary_key
+        primary_key = self._get_table_metadata().primary_key
         is_int = primary_key and pd.api.types.is_integer_dtype(data[primary_key])
-        regex = self.metadata.columns.get(primary_key, {}).get('regex_format')
+        regex = self._get_table_metadata().columns.get(primary_key, {}).get('regex_format')
         if is_int and regex:
             possible_characters = get_possible_chars(regex, 1)
             if '0' in possible_characters:
@@ -251,8 +257,8 @@ class BaseSynthesizer:
             raise InvalidDataError(synthesizer_errors)
 
     def _validate_transformers(self, column_name_to_transformer):
-        primary_and_alternate_keys = self.metadata._get_primary_and_alternate_keys()
-        sequence_keys = self.metadata._get_set_of_sequence_keys()
+        primary_and_alternate_keys = self._get_table_metadata()._get_primary_and_alternate_keys()
+        sequence_keys = self._get_table_metadata()._get_set_of_sequence_keys()
         keys = primary_and_alternate_keys | sequence_keys
         for column, transformer in column_name_to_transformer.items():
             if transformer is None:
@@ -277,8 +283,9 @@ class BaseSynthesizer:
             column_name_to_transformer (dict):
                 Dict mapping column names to transformers to be used for that column.
         """
+        table_metadata = self._get_table_metadata()
         for column in column_name_to_transformer:
-            sdtype = self.metadata.columns.get(column, {}).get('sdtype')
+            sdtype = table_metadata.columns.get(column, {}).get('sdtype')
             if sdtype in {'categorical', 'boolean'}:
                 warnings.warn(
                     f"Replacing the default transformer for column '{column}' "
@@ -330,8 +337,10 @@ class BaseSynthesizer:
 
     def get_metadata(self):
         """Return the ``Metadata`` for this synthesizer."""
-        table_name = getattr(self, '_table_name', None)
-        return Metadata.load_from_dict(self.metadata.to_dict(), table_name)
+        if isinstance(self.metadata, SingleTableMetadata):
+            table_name = getattr(self, '_table_name', None)
+            return Metadata.load_from_dict(self.metadata.to_dict(), table_name)
+        return self.metadata
 
     def load_custom_constraint_classes(self, filepath, class_names):
         """Load a custom constraint class for the current synthesizer.
@@ -413,9 +422,10 @@ class BaseSynthesizer:
             )
 
         # Order the output to match metadata
+        table_metadata = self._get_table_metadata()
         ordered_field_transformers = {
             column_name: field_transformers.get(column_name)
-            for column_name in self.metadata.columns
+            for column_name in table_metadata.columns
             if column_name in field_transformers
         }
 
@@ -481,9 +491,7 @@ class BaseSynthesizer:
             )
 
         is_converted = self._store_and_convert_original_cols(data)
-
         preprocess_data = self._preprocess(data)
-
         if is_converted:
             data.columns = self._original_columns
 

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -724,26 +724,6 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
         """Get a list of constraint-augmented generation constraints applied to the synthesizer."""
         return deepcopy(self._chained_constraints + self._reject_sampling_constraints)
 
-    def get_metadata(self, version='original'):
-        """Get the metadata, either original or modified after applying CAG constraints.
-
-        Args:
-            version (str, optional):
-                The version of metadata to return, must be one of 'original' or 'modified'. If
-                'original', will return the original metadata used to instantiate the
-                synthesizer. If 'modified', will return the modified metadata after applying this
-                synthesizer's CAG constraints. Defaults to 'original'.
-        """
-        if version not in ('original', 'modified'):
-            raise ValueError(
-                f"Unrecognized version '{version}', please use 'original' or 'modified'."
-            )
-
-        if hasattr(self, '_original_metadata') and version == 'original':
-            return self._original_metadata
-
-        return super().get_metadata()
-
     def validate_cag(self, synthetic_data):
         """Validate synthetic_data against the CAG patterns.
 

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -189,7 +189,10 @@ class BaseSynthesizer:
         """Validate that the data follows the metadata."""
         errors = []
         try:
-            self.metadata.validate_data({self._table_name: data})
+            if isinstance(self.metadata, Metadata):
+                self.metadata.validate_data({self._table_name: data})
+            else:
+                self.metadata.validate_data(data)
         except InvalidDataError as error:
             errors += error.errors
 
@@ -215,7 +218,10 @@ class BaseSynthesizer:
         return []
 
     def _get_table_metadata(self):
-        return self.metadata.tables.get(self._table_name, SingleTableMetadata())
+        if isinstance(self.metadata, Metadata):
+            return self.metadata.tables.get(self._table_name, SingleTableMetadata())
+
+        return self.metadata
 
     def _validate_primary_key(self, data):
         primary_key = self._get_table_metadata().primary_key
@@ -649,7 +655,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
         super().__init__(metadata, enforce_min_max_values, enforce_rounding, locales)
         self._chained_patterns = []  # chain of patterns used to preprocess the data
         self._reject_sampling_patterns = []  # patterns used only for reject sampling
-        self._original_metadata = self.metadata
+        self._original_metadata = deepcopy(self.metadata)
 
     def add_cag(self, patterns):
         """Add the list of constraint-augmented generation patterns to the synthesizer.
@@ -699,7 +705,10 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                 f"Unrecognized version '{version}', please use 'original' or 'modified'."
             )
 
-        return self._original_metadata if version == 'original' else self.metadata
+        if hasattr(self, '_original_metadata') and version == 'original':
+            return self._original_metadata
+
+        return super().get_metadata()
 
     def _transform_helper(self, data):
         """Validate and transform all CAG patterns during preprocessing.
@@ -861,14 +870,15 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                 )
                 sampled = pd.concat([sampled, raw_sampled[missing_cols]], axis=1)
 
-            for pattern in reversed(self._chained_patterns):
-                sampled = pattern.reverse_transform(sampled)
-                valid_rows = pattern.is_valid(sampled)
-                sampled = sampled[valid_rows]
+            if hasattr(self, '_chained_patterns') and hasattr(self, '_reject_sampling_patterns'):
+                for pattern in reversed(self._chained_patterns):
+                    sampled = pattern.reverse_transform(sampled)
+                    valid_rows = pattern.is_valid(sampled)
+                    sampled = sampled[valid_rows]
 
-            for pattern in reversed(self._reject_sampling_patterns):
-                valid_rows = pattern.is_valid(sampled)
-                sampled = sampled[valid_rows]
+                for pattern in reversed(self._reject_sampling_patterns):
+                    valid_rows = pattern.is_valid(sampled)
+                    sampled = sampled[valid_rows]
 
             if previous_rows is not None:
                 sampled = pd.concat([previous_rows, sampled], ignore_index=True)

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -725,60 +725,32 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
         return deepcopy(self._chained_constraints + self._reject_sampling_constraints)
 
     def validate_cag(self, synthetic_data):
-        """Validate synthetic_data against the CAG patterns.
+        """Validate synthetic_data against the constraints.
 
         Args:
             synthetic_data (pd.DataFrame): The synthetic data to validate
 
         Raises:
-            PatternNotMetError:
-                Raised if synthetic data does not match CAG patterns.
+            ConstraintNotMetError:
+                Raised if synthetic data does not match constraints.
         """
         transformed_data = synthetic_data
-        for attribute in ['_reject_sampling_patterns', '_chained_patterns']:
-            for pattern in getattr(self, attribute, []):
-                if attribute == '_reject_sampling_patterns':
-                    valid = pattern.is_valid(data=synthetic_data)
+        for attribute in ['_reject_sampling_constraints', '_chained_constraints']:
+            for constraint in getattr(self, attribute, []):
+                if attribute == '_reject_sampling_constraints':
+                    valid = constraint.is_valid(data=synthetic_data)
                 else:
-                    valid = pattern.is_valid(data=transformed_data)
+                    valid = constraint.is_valid(data=transformed_data)
 
                 if not valid.all():
                     invalid_rows_str = _get_invalid_rows(valid)
-                    pattern_name = _convert_to_snake_case(pattern.__class__.__name__)
+                    pattern_name = _convert_to_snake_case(constraint.__class__.__name__)
                     pattern_name = pattern_name.replace('_', ' ')
                     msg = f'The {pattern_name} requirement is not met '
                     msg += f'for row indices: {invalid_rows_str}.'
-                    raise PatternNotMetError(msg)
-                elif attribute == '_chained_patterns':
-                    transformed_data = pattern.transform(data=transformed_data)
-
-    def validate_cag(self, synthetic_data):
-        """Validate synthetic_data against the CAG patterns.
-
-        Args:
-            synthetic_data (pd.DataFrame): The synthetic data to validate
-
-        Raises:
-            PatternNotMetError:
-                Raised if synthetic data does not match CAG patterns.
-        """
-        transformed_data = synthetic_data
-        for attribute in ['_reject_sampling_patterns', '_chained_patterns']:
-            for pattern in getattr(self, attribute, []):
-                if attribute == '_reject_sampling_patterns':
-                    valid = pattern.is_valid(data=synthetic_data)
-                else:
-                    valid = pattern.is_valid(data=transformed_data)
-
-                if not valid.all():
-                    invalid_rows_str = _get_invalid_rows(valid)
-                    pattern_name = _convert_to_snake_case(pattern.__class__.__name__)
-                    pattern_name = pattern_name.replace('_', ' ')
-                    msg = f'The {pattern_name} requirement is not met '
-                    msg += f'for row indices: {invalid_rows_str}.'
-                    raise PatternNotMetError(msg)
-                elif attribute == '_chained_patterns':
-                    transformed_data = pattern.transform(data=transformed_data)
+                    raise ConstraintNotMetError(msg)
+                elif attribute == '_chained_constraints':
+                    transformed_data = constraint.transform(data=transformed_data)
 
     def _transform_helper(self, data):
         """Validate and transform all constraints during preprocessing.

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -364,14 +364,14 @@ class BaseSynthesizer:
         return instantiated_parameters
 
     def get_metadata(self, version='original'):
-        """Get the metadata, either original or modified after applying CAG patterns.
+        """Get the metadata, either original or modified after applying constraints.
 
         Args:
             version (str, optional):
                 The version of metadata to return, must be one of 'original' or 'modified'. If
                 'original', will return the original metadata used to instantiate the
                 synthesizer. If 'modified', will return the modified metadata after applying this
-                synthesizer's CAG patterns. Defaults to 'original'.
+                synthesizer's constraints. Defaults to 'original'.
         """
         if version not in ('original', 'modified'):
             raise ValueError(
@@ -695,7 +695,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
 
         Args:
             constraints (list):
-                A list of CAG constraints to apply to the synthesizer.
+                A list of constraints to apply to the synthesizer.
         """
         constraints = _validate_constraints(constraints, self._fitted)
         for constraint in constraints:
@@ -781,7 +781,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                     transformed_data = pattern.transform(data=transformed_data)
 
     def _transform_helper(self, data):
-        """Validate and transform all CAG constraints during preprocessing.
+        """Validate and transform all constraints during preprocessing.
 
         Args:
             data (dict[str, pd.DataFrame]):

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -28,7 +28,7 @@ from sdv._utils import (
     generate_synthesizer_id,
     get_possible_chars,
 )
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.cag._utils import _convert_to_snake_case, _get_invalid_rows, _validate_constraints
 from sdv.constraints.errors import AggregateConstraintsError
 from sdv.data_processing.data_processor import DataProcessor
@@ -702,7 +702,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
             try:
                 self.metadata = constraint.get_updated_metadata(self.metadata)
                 self._chained_constraints.append(constraint)
-            except PatternNotMetError as e:
+            except ConstraintNotMetError as e:
                 LOGGER.info(
                     'Enforcing constraint %s using reject sampling.', constraint.__class__.__name__
                 )
@@ -710,7 +710,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                 try:
                     constraint.get_updated_metadata(self._original_metadata)
                     self._reject_sampling_constraints.append(constraint)
-                except PatternNotMetError:
+                except ConstraintNotMetError:
                     raise e
 
         self._data_processor = DataProcessor(

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -720,7 +720,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
             locales=self.locales,
         )
 
-    def get_cag(self):
+    def get_constraints(self):
         """Get a list of constraint-augmented generation constraints applied to the synthesizer."""
         return deepcopy(self._chained_constraints + self._reject_sampling_constraints)
 

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -127,13 +127,13 @@ class BaseSynthesizer:
             )
 
     def _validate_regex_format(self):
-        # Using SingleTableMetadata because `get_column_names` raises an error
-        # if the metadata is empty
-        single_table_metadata = self.metadata._convert_to_single_table()
-        id_columns = single_table_metadata.get_column_names(sdtype='id')
-        for column_name in id_columns:
-            regex = single_table_metadata.columns[column_name].get('regex_format')
-            _check_regex_format(self._table_name, column_name, regex)
+        if self.metadata.tables:
+            id_columns = self.metadata.get_column_names(table_name=self._table_name, sdtype='id')
+            for column_name in id_columns:
+                regex = (
+                    self.metadata.tables[self._table_name].columns[column_name].get('regex_format')
+                )
+                _check_regex_format(self._table_name, column_name, regex)
 
     def __init__(
         self, metadata, enforce_min_max_values=True, enforce_rounding=True, locales=['en_US']
@@ -655,7 +655,6 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
         super().__init__(metadata, enforce_min_max_values, enforce_rounding, locales)
         self._chained_patterns = []  # chain of patterns used to preprocess the data
         self._reject_sampling_patterns = []  # patterns used only for reject sampling
-        self._original_metadata = deepcopy(self.metadata)
 
     def add_cag(self, patterns):
         """Add the list of constraint-augmented generation patterns to the synthesizer.

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -29,6 +29,7 @@ from sdv._utils import (
     get_possible_chars,
 )
 from sdv.cag._errors import PatternNotMetError
+from sdv.cag._utils import _convert_to_snake_case, _get_invalid_rows
 from sdv.constraints.errors import AggregateConstraintsError
 from sdv.data_processing.data_processor import DataProcessor
 from sdv.errors import (
@@ -721,6 +722,34 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
     def get_cag(self):
         """Get a list of constraint-augmented generation patterns applied to the synthesizer."""
         return deepcopy(self._chained_patterns + self._reject_sampling_patterns)
+
+    def validate_cag(self, synthetic_data):
+        """Validate synthetic_data against the CAG patterns.
+
+        Args:
+            synthetic_data (pd.DataFrame): The synthetic data to validate
+
+        Raises:
+            PatternNotMetError:
+                Raised if synthetic data does not match CAG patterns.
+        """
+        transformed_data = synthetic_data
+        for attribute in ['_reject_sampling_patterns', '_chained_patterns']:
+            for pattern in getattr(self, attribute, []):
+                if attribute == '_reject_sampling_patterns':
+                    valid = pattern.is_valid(data=synthetic_data)
+                else:
+                    valid = pattern.is_valid(data=transformed_data)
+
+                if not valid.all():
+                    invalid_rows_str = _get_invalid_rows(valid)
+                    pattern_name = _convert_to_snake_case(pattern.__class__.__name__)
+                    pattern_name = pattern_name.replace('_', ' ')
+                    msg = f'The {pattern_name} requirement is not met '
+                    msg += f'for row indices: {invalid_rows_str}.'
+                    raise PatternNotMetError(msg)
+                elif attribute == '_chained_patterns':
+                    transformed_data = pattern.transform(data=transformed_data)
 
     def _transform_helper(self, data):
         """Validate and transform all CAG patterns during preprocessing.

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -10,6 +10,7 @@ import os
 import uuid
 import warnings
 from collections import defaultdict
+from copy import deepcopy
 
 import cloudpickle
 import copulas
@@ -27,6 +28,7 @@ from sdv._utils import (
     generate_synthesizer_id,
     get_possible_chars,
 )
+from sdv.cag._errors import PatternNotMetError
 from sdv.constraints.errors import AggregateConstraintsError
 from sdv.data_processing.data_processor import DataProcessor
 from sdv.errors import (
@@ -637,6 +639,118 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
     for all single-table synthesizers.
     """
 
+    def __init__(
+        self,
+        metadata,
+        enforce_min_max_values=True,
+        enforce_rounding=True,
+        locales=['en_US'],
+    ):
+        super().__init__(metadata, enforce_min_max_values, enforce_rounding, locales)
+        self._chained_patterns = []  # chain of patterns used to preprocess the data
+        self._reject_sampling_patterns = []  # patterns used only for reject sampling
+        self._original_metadata = self.metadata
+
+    def add_cag(self, patterns):
+        """Add the list of constraint-augmented generation patterns to the synthesizer.
+
+        Args:
+            patterns (list):
+                A list of CAG patterns to apply to the synthesizer.
+        """
+        for pattern in patterns:
+            try:
+                self.metadata = pattern.get_updated_metadata(self.metadata)
+                self._chained_patterns.append(pattern)
+            except PatternNotMetError as e:
+                LOGGER.info(
+                    'Enforcing pattern %s using reject sampling.', pattern.__class__.__name__
+                )
+
+                try:
+                    pattern.get_updated_metadata(self._original_metadata)
+                    self._reject_sampling_patterns.append(pattern)
+                except PatternNotMetError:
+                    raise e
+
+        self._data_processor = DataProcessor(
+            metadata=self.metadata._convert_to_single_table(),
+            enforce_rounding=self.enforce_rounding,
+            enforce_min_max_values=self.enforce_min_max_values,
+            locales=self.locales,
+        )
+
+    def get_cag(self):
+        """Get a list of constraint-augmented generation patterns applied to the synthesizer."""
+        return deepcopy(self._chained_patterns + self._reject_sampling_patterns)
+
+    def get_metadata(self, version='original'):
+        """Get the metadata, either original or modified after applying CAG patterns.
+
+        Args:
+            version (str, optional):
+                The version of metadata to return, must be one of 'original' or 'modified'. If
+                'original', will return the original metadata used to instantiate the
+                synthesizer. If 'modified', will return the modified metadata after applying this
+                synthesizer's CAG patterns. Defaults to 'original'.
+        """
+        if version not in ('original', 'modified'):
+            raise ValueError(
+                f"Unrecognized version '{version}', please use 'original' or 'modified'."
+            )
+
+        return self._original_metadata if version == 'original' else self.metadata
+
+    def _transform_helper(self, data):
+        """Validate and transform all CAG patterns during preprocessing.
+
+        Args:
+            data (dict[str, pd.DataFrame]):
+                The data dictionary.
+        """
+        if self._fitted:
+            for pattern in self._chained_patterns:
+                data = pattern.transform(data)
+            return data
+
+        metadata = self._original_metadata
+        original_data = data
+        for pattern in self._chained_patterns:
+            pattern.fit(data, metadata)
+            metadata = pattern.get_updated_metadata(metadata)
+            data = pattern.transform(data)
+
+        for pattern in self._reject_sampling_patterns:
+            pattern.fit(original_data, self._original_metadata)
+
+        return data
+
+    def preprocess(self, data):
+        """Transform the raw data to numerical space.
+
+        Args:
+            data (pandas.DataFrame):
+                The raw data to be transformed.
+
+        Returns:
+            pandas.DataFrame:
+                The preprocessed data.
+        """
+        if self._fitted:
+            warnings.warn(
+                'This model has already been fitted. To use the new preprocessed data, '
+                "please refit the model using 'fit' or 'fit_processed_data'."
+            )
+
+        is_converted = self._store_and_convert_original_cols(data)
+        data = self._transform_helper(data)
+        preprocess_data = self._preprocess(data)
+
+        if is_converted:
+            data.columns = self._original_columns
+
+        return preprocess_data
+
     def _set_random_state(self, random_state):
         """Set the random state of the model's random number generator.
 
@@ -746,6 +860,15 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                     set(raw_sampled.columns) - set(input_columns) - set(sampled.columns)
                 )
                 sampled = pd.concat([sampled, raw_sampled[missing_cols]], axis=1)
+
+            for pattern in reversed(self._chained_patterns):
+                sampled = pattern.reverse_transform(sampled)
+                valid_rows = pattern.is_valid(sampled)
+                sampled = sampled[valid_rows]
+
+            for pattern in reversed(self._reject_sampling_patterns):
+                valid_rows = pattern.is_valid(sampled)
+                sampled = sampled[valid_rows]
 
             if previous_rows is not None:
                 sampled = pd.concat([previous_rows, sampled], ignore_index=True)

--- a/sdv/single_table/copulagan.py
+++ b/sdv/single_table/copulagan.py
@@ -164,7 +164,10 @@ class CopulaGANSynthesizer(CTGANSynthesizer):
             cuda=cuda,
         )
 
-        validate_numerical_distributions(numerical_distributions, self.metadata.columns)
+        validate_numerical_distributions(
+            numerical_distributions,
+            self._get_table_metadata().columns,
+        )
         self.numerical_distributions = numerical_distributions or {}
         self.default_distribution = default_distribution or 'beta'
 
@@ -177,7 +180,7 @@ class CopulaGANSynthesizer(CTGANSynthesizer):
         }
 
     def _create_gaussian_normalizer_config(self, processed_data):
-        columns = self.metadata.columns
+        columns = self._get_table_metadata().columns
         transformers = {}
         sdtypes = {}
         for column in processed_data.columns:

--- a/sdv/single_table/copulas.py
+++ b/sdv/single_table/copulas.py
@@ -110,7 +110,10 @@ class GaussianCopulaSynthesizer(BaseSingleTableSynthesizer):
             enforce_rounding=enforce_rounding,
             locales=locales,
         )
-        validate_numerical_distributions(numerical_distributions, self.metadata.columns)
+        validate_numerical_distributions(
+            numerical_distributions,
+            self._get_table_metadata().columns,
+        )
 
         self.default_distribution = default_distribution or 'beta'
         self._default_distribution = self.get_distribution_class(self.default_distribution)
@@ -192,8 +195,9 @@ class GaussianCopulaSynthesizer(BaseSingleTableSynthesizer):
 
     def _get_valid_columns_from_metadata(self, columns):
         valid_columns = []
+        table_metadata = self._get_table_metadata()
         for column in columns:
-            for valid_column in self.metadata.columns:
+            for valid_column in table_metadata.columns:
                 if column.startswith(valid_column):
                     valid_columns.append(column)
                     break

--- a/sdv/single_table/utils.py
+++ b/sdv/single_table/utils.py
@@ -6,6 +6,7 @@ import warnings
 import numpy as np
 
 from sdv.errors import SynthesizerInputError
+from sdv.metadata import Metadata
 
 DISABLE_TMP_FILE = 'disable'
 IGNORED_DICT_KEYS = ['fitted', 'distribution', 'type']
@@ -19,7 +20,7 @@ def detect_discrete_columns(metadata, data, transformers):
     discrete.
 
     Args:
-        metadata (sdv.metadata.SingleTableMetadata):
+        metadata (sdv.metadata.Metadata):
             Metadata that belongs to the given ``data``.
 
         data (pandas.DataFrame):
@@ -33,6 +34,9 @@ def detect_discrete_columns(metadata, data, transformers):
         discrete_columns (list):
             A list of discrete columns to be used with some of ``sdv`` synthesizers.
     """
+    if isinstance(metadata, Metadata):
+        metadata = metadata._convert_to_single_table()
+
     discrete_columns = []
     for column in data.columns:
         if column in metadata.columns:

--- a/tests/integration/cag/__init__.py
+++ b/tests/integration/cag/__init__.py
@@ -1,0 +1,1 @@
+"""CAG integration tests."""

--- a/tests/integration/cag/test_fixed_combinations.py
+++ b/tests/integration/cag/test_fixed_combinations.py
@@ -1,0 +1,130 @@
+"""Integration tests for FixedCombinations CAG pattern."""
+
+import numpy as np
+import pandas as pd
+
+from sdv.cag import FixedCombinations
+from sdv.metadata import Metadata
+
+
+def test_fixed_combinations_integers():
+    """Test that FixedCombinations constraint works with integer columns."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [1, 2, 3, 1, 2, 1],
+        'B': [10, 20, 30, 10, 20, 10],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'categorical'},
+            'B': {'sdtype': 'categorical'},
+        }
+    })
+    pattern = FixedCombinations(['A', 'B'])
+
+    # Run
+    pattern.validate(data, metadata)
+    updated_metadata = pattern.get_updated_metadata(metadata)
+    pattern.fit(data, metadata)
+    transformed = pattern.transform(data)
+    reverse_transformed = pattern.reverse_transform(transformed)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A#B': {'sdtype': 'categorical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed.columns) == ['A#B']
+    pd.testing.assert_frame_equal(data, reverse_transformed)
+
+
+def test_fixed_combinations_with_nans():
+    """Test that FixedCombinations constraint works with NaNs."""
+    # Setup
+    data = pd.DataFrame({
+        'A': pd.Categorical([1, 2, np.nan, 1, 2, 1]),
+        'B': pd.Categorical([10, 20, 30, 10, 20, None]),
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'categorical'},
+            'B': {'sdtype': 'categorical'},
+        }
+    })
+
+    pattern = FixedCombinations(['A', 'B'])
+
+    # Run
+    pattern.validate(data, metadata)
+    updated_metadata = pattern.get_updated_metadata(metadata)
+    pattern.fit(data, metadata)
+    transformed = pattern.transform(data)
+    reverse_transformed = pattern.reverse_transform(transformed)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A#B': {'sdtype': 'categorical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed.columns) == ['A#B']
+    pd.testing.assert_frame_equal(data, reverse_transformed)
+
+
+def test_fixed_null_combinations_with_multi_table():
+    """Test that FixedCombinations constraint works with multi-table data."""
+    # Setup
+    data = {
+        'table1': pd.DataFrame({
+            'A': [1, 2, 3, 1, 2, 1],
+            'B': [10, 20, 30, 10, 20, 10],
+        }),
+        'table2': pd.DataFrame({'id': range(5)}),
+    }
+    metadata = Metadata.load_from_dict({
+        'tables': {
+            'table1': {
+                'columns': {
+                    'A': {'sdtype': 'categorical'},
+                    'B': {'sdtype': 'categorical'},
+                }
+            },
+            'table2': {
+                'columns': {
+                    'id': {'sdtype': 'id'},
+                }
+            },
+        }
+    })
+    pattern = FixedCombinations(['A', 'B'], table_name='table1')
+
+    # Run
+    pattern.validate(data, metadata)
+    updated_metadata = pattern.get_updated_metadata(metadata)
+    pattern.fit(data, metadata)
+    transformed = pattern.transform(data)
+    reverse_transformed = pattern.reverse_transform(transformed)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'tables': {
+            'table1': {
+                'columns': {
+                    'A#B': {'sdtype': 'categorical'},
+                }
+            },
+            'table2': {
+                'columns': {
+                    'id': {'sdtype': 'id'},
+                }
+            },
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed['table1'].columns) == ['A#B']
+    assert set(data.keys()) == set(reverse_transformed.keys())
+    for table_name, table in data.items():
+        pd.testing.assert_frame_equal(table, reverse_transformed[table_name])

--- a/tests/integration/cag/test_fixed_combinations.py
+++ b/tests/integration/cag/test_fixed_combinations.py
@@ -1,84 +1,53 @@
 """Integration tests for FixedCombinations CAG pattern."""
 
+import re
+
 import numpy as np
 import pandas as pd
+import pytest
 
 from sdv.cag import FixedCombinations
+from sdv.cag._errors import PatternNotMetError
 from sdv.metadata import Metadata
+from sdv.multi_table import HMASynthesizer
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
 from tests.utils import run_pattern
 
 
-def test_fixed_combinations_integers():
-    """Test that FixedCombinations constraint works with integer columns."""
-    # Setup
-    data = pd.DataFrame({
+@pytest.fixture()
+def data():
+    return pd.DataFrame({
         'A': [1, 2, 3, 1, 2, 1],
         'B': [10, 20, 30, 10, 20, 10],
     })
-    metadata = Metadata.load_from_dict({
-        'columns': {
-            'A': {'sdtype': 'categorical'},
-            'B': {'sdtype': 'categorical'},
-        }
-    })
-    pattern = FixedCombinations(['A', 'B'])
-
-    # Run
-    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
-
-    # Assert
-    expected_updated_metadata = Metadata.load_from_dict({
-        'columns': {
-            'A#B': {'sdtype': 'categorical'},
-        }
-    }).to_dict()
-    assert expected_updated_metadata == updated_metadata.to_dict()
-    assert list(transformed.columns) == ['A#B']
-    pd.testing.assert_frame_equal(data, reverse_transformed)
 
 
-def test_fixed_combinations_with_nans():
-    """Test that FixedCombinations constraint works with NaNs."""
-    # Setup
-    data = pd.DataFrame({
-        'A': pd.Categorical([1, 2, np.nan, 1, 2, 1]),
-        'B': pd.Categorical([10, 20, 30, 10, 20, None]),
-    })
-    metadata = Metadata.load_from_dict({
+@pytest.fixture()
+def metadata():
+    return Metadata.load_from_dict({
         'columns': {
             'A': {'sdtype': 'categorical'},
             'B': {'sdtype': 'categorical'},
         }
     })
 
-    pattern = FixedCombinations(['A', 'B'])
 
-    # Run
-    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
-
-    # Assert
-    expected_updated_metadata = Metadata.load_from_dict({
-        'columns': {
-            'A#B': {'sdtype': 'categorical'},
-        }
-    }).to_dict()
-    assert expected_updated_metadata == updated_metadata.to_dict()
-    assert list(transformed.columns) == ['A#B']
-    pd.testing.assert_frame_equal(data, reverse_transformed)
+@pytest.fixture()
+def pattern():
+    return FixedCombinations(['A', 'B'])
 
 
-def test_fixed_null_combinations_with_multi_table():
-    """Test that FixedCombinations constraint works with multi-table data."""
-    # Setup
-    data = {
-        'table1': pd.DataFrame({
-            'A': [1, 2, 3, 1, 2, 1],
-            'B': [10, 20, 30, 10, 20, 10],
-        }),
+@pytest.fixture()
+def data_multi(data):
+    return {
+        'table1': data,
         'table2': pd.DataFrame({'id': range(5)}),
     }
-    metadata = Metadata.load_from_dict({
+
+
+@pytest.fixture()
+def metadata_multi():
+    return Metadata.load_from_dict({
         'tables': {
             'table1': {
                 'columns': {
@@ -93,7 +62,57 @@ def test_fixed_null_combinations_with_multi_table():
             },
         }
     })
-    pattern = FixedCombinations(['A', 'B'], table_name='table1')
+
+
+@pytest.fixture()
+def pattern_multi():
+    return FixedCombinations(['A', 'B'], table_name='table1')
+
+
+def test_fixed_combinations_integers(data, metadata, pattern):
+    """Test that FixedCombinations constraint works with integer columns."""
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A#B': {'sdtype': 'categorical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed.columns) == ['A#B']
+    pd.testing.assert_frame_equal(data, reverse_transformed)
+
+
+def test_fixed_combinations_with_nans(metadata, pattern):
+    """Test that FixedCombinations constraint works with NaNs."""
+    # Setup
+    data = pd.DataFrame({
+        'A': pd.Categorical([1, 2, np.nan, 1, 2, 1]),
+        'B': pd.Categorical([10, 20, 30, 10, 20, None]),
+    })
+
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A#B': {'sdtype': 'categorical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed.columns) == ['A#B']
+    pd.testing.assert_frame_equal(data, reverse_transformed)
+
+
+def test_fixed_null_combinations_with_multi_table(data_multi, metadata_multi, pattern_multi):
+    """Test that FixedCombinations constraint works with multi-table data."""
+    # Setup
+    data = data_multi
+    metadata = metadata_multi
+    pattern = pattern_multi
 
     # Run
     updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
@@ -336,3 +355,83 @@ def test_fixed_combinations_multiple_patterns_three_patterns_reject_sampling():
     assert original_ab_combos == synthetic_ab_combos
     assert original_cd_combos == synthetic_cd_combos
     assert original_ac_combos == synthetic_ac_combos
+
+
+def test_validate_cag(data, metadata, pattern):
+    """Test validate_cag works with synthetic data generated with FixedCombinations."""
+    # Setup
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern])
+    synthesizer.fit(data)
+    synthetic_data = synthesizer.sample(100)
+
+    # Run
+    synthesizer.validate_cag(synthetic_data=synthetic_data)
+
+    # Assert
+    original_ab_combos = set(zip(data['A'], data['B']))
+    synthetic_ab_combos = set(zip(synthetic_data['A'], synthetic_data['B']))
+    assert original_ab_combos == synthetic_ab_combos
+
+
+def test_validate_cag_raises(data, metadata, pattern):
+    """Test validate_cag raises an error with bad synthetic data with FixedCombinations."""
+    # Setup
+    synthetic_data = data.copy()
+    synthetic_data['B'] = [11, 21, 31, 11, 21, 11]
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern])
+    synthesizer.fit(data)
+    msg = re.escape(
+        'The fixed combinations requirement is not met for row indices: 0, 1, 2, 3, 4, +1 more'
+    )
+
+    # Run and Assert
+    with pytest.raises(PatternNotMetError, match=msg):
+        synthesizer.validate_cag(synthetic_data=synthetic_data)
+
+
+def test_validate_cag_multi(data_multi, metadata_multi, pattern_multi):
+    """Test validate_cag works with multitable data generated with FixedCombinations."""
+    # Setup
+    data = data_multi
+    metadata = metadata_multi
+    pattern = pattern_multi
+    synthesizer = HMASynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern])
+    synthesizer.fit(data)
+    synthetic_data = synthesizer.sample(100)
+
+    # Run
+    synthesizer.validate_cag(synthetic_data=synthetic_data)
+
+    # Assert
+    original_ab_combos = set(zip(data['table1']['A'], data['table1']['B']))
+    synthetic_ab_combos = set(zip(synthetic_data['table1']['A'], synthetic_data['table1']['B']))
+    assert original_ab_combos == synthetic_ab_combos
+
+
+def test_validate_cag_multi_raises(data_multi, metadata_multi, pattern_multi):
+    """Test validate_cag raises an error with bad multitable data with FixedCombinations."""
+    # Setup
+    data = data_multi
+    metadata = metadata_multi
+    pattern = pattern_multi
+    synthetic_data = {
+        'table1': pd.DataFrame({
+            'A': [1, 2, 3, 1, 2, 1],
+            'B': [11, 21, 31, 11, 21, 11],
+        }),
+        'table2': pd.DataFrame({'id': range(5)}),
+    }
+    synthesizer = HMASynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern])
+    synthesizer.fit(data)
+    msg = re.escape(
+        "Table 'table1': The fixed combinations requirement is "
+        'not met for row indices: 0, 1, 2, 3, 4, +1 more'
+    )
+
+    # Run and Assert
+    with pytest.raises(PatternNotMetError, match=msg):
+        synthesizer.validate_cag(synthetic_data=synthetic_data)

--- a/tests/integration/cag/test_fixed_combinations.py
+++ b/tests/integration/cag/test_fixed_combinations.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from sdv.cag import FixedCombinations
 from sdv.metadata import Metadata
+from tests.utils import run_pattern
 
 
 def test_fixed_combinations_integers():
@@ -23,11 +24,7 @@ def test_fixed_combinations_integers():
     pattern = FixedCombinations(['A', 'B'])
 
     # Run
-    pattern.validate(data, metadata)
-    updated_metadata = pattern.get_updated_metadata(metadata)
-    pattern.fit(data, metadata)
-    transformed = pattern.transform(data)
-    reverse_transformed = pattern.reverse_transform(transformed)
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
 
     # Assert
     expected_updated_metadata = Metadata.load_from_dict({
@@ -57,11 +54,7 @@ def test_fixed_combinations_with_nans():
     pattern = FixedCombinations(['A', 'B'])
 
     # Run
-    pattern.validate(data, metadata)
-    updated_metadata = pattern.get_updated_metadata(metadata)
-    pattern.fit(data, metadata)
-    transformed = pattern.transform(data)
-    reverse_transformed = pattern.reverse_transform(transformed)
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
 
     # Assert
     expected_updated_metadata = Metadata.load_from_dict({
@@ -102,11 +95,7 @@ def test_fixed_null_combinations_with_multi_table():
     pattern = FixedCombinations(['A', 'B'], table_name='table1')
 
     # Run
-    pattern.validate(data, metadata)
-    updated_metadata = pattern.get_updated_metadata(metadata)
-    pattern.fit(data, metadata)
-    transformed = pattern.transform(data)
-    reverse_transformed = pattern.reverse_transform(transformed)
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
 
     # Assert
     expected_updated_metadata = Metadata.load_from_dict({

--- a/tests/integration/cag/test_fixed_combinations.py
+++ b/tests/integration/cag/test_fixed_combinations.py
@@ -1,4 +1,4 @@
-"""Integration tests for FixedCombinations CAG pattern."""
+"""Integration tests for FixedCombinations CAG constraint."""
 
 import re
 
@@ -72,7 +72,7 @@ def pattern_multi():
 def test_fixed_combinations_integers(data, metadata, pattern):
     """Test that FixedCombinations constraint works with integer columns."""
     # Run
-    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+    updated_metadata, transformed, reverse_transformed = run_pattern(constraint, data, metadata)
 
     # Assert
     expected_updated_metadata = Metadata.load_from_dict({
@@ -92,9 +92,17 @@ def test_fixed_combinations_with_nans(metadata, pattern):
         'A': pd.Categorical([1, 2, np.nan, 1, 2, 1]),
         'B': pd.Categorical([10, 20, 30, 10, 20, None]),
     })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'categorical'},
+            'B': {'sdtype': 'categorical'},
+        }
+    })
+
+    constraint = FixedCombinations(['A', 'B'])
 
     # Run
-    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+    updated_metadata, transformed, reverse_transformed = run_pattern(constraint, data, metadata)
 
     # Assert
     expected_updated_metadata = Metadata.load_from_dict({
@@ -112,10 +120,10 @@ def test_fixed_null_combinations_with_multi_table(data_multi, metadata_multi, pa
     # Setup
     data = data_multi
     metadata = metadata_multi
-    pattern = pattern_multi
+    constraint = pattern_multi
 
     # Run
-    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+    updated_metadata, transformed, reverse_transformed = run_pattern(constraint, data, metadata)
 
     # Assert
     expected_updated_metadata = Metadata.load_from_dict({
@@ -139,8 +147,8 @@ def test_fixed_null_combinations_with_multi_table(data_multi, metadata_multi, pa
         pd.testing.assert_frame_equal(table, reverse_transformed[table_name])
 
 
-def test_fixed_combinations_multiple_patterns():
-    """Test that FixedCombinations pattern works with multiple patterns."""
+def test_fixed_combinations_multiple_constraints():
+    """Test that FixedCombinations constraint works with multiple constraints."""
     # Setup
     data = pd.DataFrame({
         'A': [1, 2, 3, 1, 2, 1],
@@ -161,7 +169,7 @@ def test_fixed_combinations_multiple_patterns():
 
     # Run
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_cag(patterns=[pattern1, pattern2])
+    synthesizer.add_constraints(constraints=[pattern1, pattern2])
     synthesizer.fit(data)
     samples = synthesizer.sample(100)
     updated_metadata = synthesizer.get_metadata('modified')
@@ -191,8 +199,8 @@ def test_fixed_combinations_multiple_patterns():
     assert original_cd_combos == synthetic_cd_combos
 
 
-def test_fixed_combinations_multiple_patterns_reject_sampling():
-    """Test that FixedCombinations pattern works with multiple patterns and reject sampling."""
+def test_fixed_combinations_multiple_constraints_reject_sampling():
+    """Test that FixedCombinations works with multiple constraints and reject sampling."""
     # Setup
     data = pd.DataFrame({
         'A': [1, 2, 3, 1, 2, 1],
@@ -211,7 +219,7 @@ def test_fixed_combinations_multiple_patterns_reject_sampling():
 
     # Run
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_cag(patterns=[pattern1, pattern2])
+    synthesizer.add_constraints(constraints=[pattern1, pattern2])
     synthesizer.fit(data)
     samples = synthesizer.sample(100)
     updated_metadata = synthesizer.get_metadata('modified')
@@ -241,8 +249,8 @@ def test_fixed_combinations_multiple_patterns_reject_sampling():
     assert original_ac_combos == synthetic_ac_combos
 
 
-def test_fixed_combinations_multiple_patterns_three_patterns():
-    """Test that FixedCombinations pattern works with multiple patterns."""
+def test_fixed_combinations_multiple_constraints_three_constraints():
+    """Test that FixedCombinations constraint works with multiple constraints."""
     # Setup
     data = pd.DataFrame({
         'A': [1, 2, 3, 1, 2, 1],
@@ -264,7 +272,7 @@ def test_fixed_combinations_multiple_patterns_three_patterns():
 
     # Run
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_cag(patterns=[pattern1, pattern2, pattern3])
+    synthesizer.add_constraints(constraints=[pattern1, pattern2, pattern3])
     synthesizer.fit(data)
     samples = synthesizer.sample(100)
     updated_metadata = synthesizer.get_metadata('modified')
@@ -297,10 +305,10 @@ def test_fixed_combinations_multiple_patterns_three_patterns():
     assert original_ac_combos == synthetic_ac_combos
 
 
-def test_fixed_combinations_multiple_patterns_three_patterns_reject_sampling():
-    """Test that FixedCombinations pattern works with multiple patterns.
+def test_fixed_combinations_multiple_constraints_three_constraints_reject_sampling():
+    """Test that FixedCombinations constraint works with multiple constraints.
 
-    Test that when the second pattern in the chain fails, the third pattern still works.
+    Test that when the second constraint in the chain fails, the third constraint still works.
     """
     # Setup
     data = pd.DataFrame({
@@ -323,7 +331,7 @@ def test_fixed_combinations_multiple_patterns_three_patterns_reject_sampling():
 
     # Run
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_cag(patterns=[pattern1, pattern3, pattern2])
+    synthesizer.add_constraints(constraints=[pattern1, pattern3, pattern2])
     synthesizer.fit(data)
     samples = synthesizer.sample(100)
     updated_metadata = synthesizer.get_metadata('modified')

--- a/tests/integration/cag/test_fixed_combinations.py
+++ b/tests/integration/cag/test_fixed_combinations.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from sdv.cag import FixedCombinations
 from sdv.metadata import Metadata
+from sdv.single_table.copulas import GaussianCopulaSynthesizer
 from tests.utils import run_pattern
 
 
@@ -117,3 +118,221 @@ def test_fixed_null_combinations_with_multi_table():
     assert set(data.keys()) == set(reverse_transformed.keys())
     for table_name, table in data.items():
         pd.testing.assert_frame_equal(table, reverse_transformed[table_name])
+
+
+def test_fixed_combinations_multiple_patterns():
+    """Test that FixedCombinations pattern works with multiple patterns."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [1, 2, 3, 1, 2, 1],
+        'B': [10, 20, 30, 10, 20, 10],
+        'C': [100, 200, 300, 100, 200, 100],
+        'D': [1000, 2000, 3000, 1000, 2000, 1000],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'categorical'},
+            'B': {'sdtype': 'categorical'},
+            'C': {'sdtype': 'categorical'},
+            'D': {'sdtype': 'categorical'},
+        }
+    })
+    pattern1 = FixedCombinations(['A', 'B'])
+    pattern2 = FixedCombinations(['C', 'D'])
+
+    # Run
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern1, pattern2])
+    synthesizer.fit(data)
+    samples = synthesizer.sample(100)
+    updated_metadata = synthesizer.get_metadata('modified')
+    original_metadata = synthesizer.get_metadata('original')
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A#B': {'sdtype': 'categorical'},
+            'C#D': {'sdtype': 'categorical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+
+    assert original_metadata.to_dict() == metadata.to_dict()
+
+    # Get unique combinations from original data
+    original_ab_combos = set(zip(data['A'], data['B']))
+    original_cd_combos = set(zip(data['C'], data['D']))
+
+    # Get unique combinations from synthetic data
+    synthetic_ab_combos = set(zip(samples['A'], samples['B']))
+    synthetic_cd_combos = set(zip(samples['C'], samples['D']))
+
+    # Assert combinations match
+    assert original_ab_combos == synthetic_ab_combos
+    assert original_cd_combos == synthetic_cd_combos
+
+
+def test_fixed_combinations_multiple_patterns_reject_sampling():
+    """Test that FixedCombinations pattern works with multiple patterns and reject sampling."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [1, 2, 3, 1, 2, 1],
+        'B': [10, 20, 30, 10, 20, 10],
+        'C': [100, 200, 300, 100, 200, 100],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'categorical'},
+            'B': {'sdtype': 'categorical'},
+            'C': {'sdtype': 'categorical'},
+        }
+    })
+    pattern1 = FixedCombinations(['A', 'B'])
+    pattern2 = FixedCombinations(['A', 'C'])
+
+    # Run
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern1, pattern2])
+    synthesizer.fit(data)
+    samples = synthesizer.sample(100)
+    updated_metadata = synthesizer.get_metadata('modified')
+    original_metadata = synthesizer.get_metadata('original')
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A#B': {'sdtype': 'categorical'},
+            'C': {'sdtype': 'categorical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+
+    assert original_metadata.to_dict() == metadata.to_dict()
+
+    # Get unique combinations from original data
+    original_ab_combos = set(zip(data['A'], data['B']))
+    original_ac_combos = set(zip(data['A'], data['C']))
+
+    # Get unique combinations from synthetic data
+    synthetic_ab_combos = set(zip(samples['A'], samples['B']))
+    synthetic_ac_combos = set(zip(samples['A'], samples['C']))
+
+    # Assert combinations match
+    assert original_ab_combos == synthetic_ab_combos
+    assert original_ac_combos == synthetic_ac_combos
+
+
+def test_fixed_combinations_multiple_patterns_three_patterns():
+    """Test that FixedCombinations pattern works with multiple patterns."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [1, 2, 3, 1, 2, 1],
+        'B': [10, 20, 30, 10, 20, 10],
+        'C': [100, 200, 300, 100, 200, 100],
+        'D': [1000, 2000, 3000, 1000, 2000, 1000],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'categorical'},
+            'B': {'sdtype': 'categorical'},
+            'C': {'sdtype': 'categorical'},
+            'D': {'sdtype': 'categorical'},
+        }
+    })
+    pattern1 = FixedCombinations(['A', 'B'])
+    pattern2 = FixedCombinations(['C', 'D'])
+    pattern3 = FixedCombinations(['A', 'C'])
+
+    # Run
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern1, pattern2, pattern3])
+    synthesizer.fit(data)
+    samples = synthesizer.sample(100)
+    updated_metadata = synthesizer.get_metadata('modified')
+    original_metadata = synthesizer.get_metadata('original')
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A#B': {'sdtype': 'categorical'},
+            'C#D': {'sdtype': 'categorical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+
+    assert original_metadata.to_dict() == metadata.to_dict()
+
+    # Get unique combinations from original data
+    original_ab_combos = set(zip(data['A'], data['B']))
+    original_cd_combos = set(zip(data['C'], data['D']))
+    original_ac_combos = set(zip(data['A'], data['C']))
+
+    # Get unique combinations from synthetic data
+    synthetic_ab_combos = set(zip(samples['A'], samples['B']))
+    synthetic_cd_combos = set(zip(samples['C'], samples['D']))
+    synthetic_ac_combos = set(zip(samples['A'], samples['C']))
+
+    # Assert combinations match
+    assert original_ab_combos == synthetic_ab_combos
+    assert original_cd_combos == synthetic_cd_combos
+    assert original_ac_combos == synthetic_ac_combos
+
+
+def test_fixed_combinations_multiple_patterns_three_patterns_reject_sampling():
+    """Test that FixedCombinations pattern works with multiple patterns.
+
+    Test that when the second pattern in the chain fails, the third pattern still works.
+    """
+    # Setup
+    data = pd.DataFrame({
+        'A': [1, 2, 3, 1, 2, 1],
+        'B': [10, 20, 30, 10, 20, 10],
+        'C': [100, 200, 300, 100, 200, 100],
+        'D': [1000, 2000, 3000, 1000, 2000, 1000],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'categorical'},
+            'B': {'sdtype': 'categorical'},
+            'C': {'sdtype': 'categorical'},
+            'D': {'sdtype': 'categorical'},
+        }
+    })
+    pattern1 = FixedCombinations(['A', 'B'])
+    pattern2 = FixedCombinations(['C', 'D'])
+    pattern3 = FixedCombinations(['A', 'C'])
+
+    # Run
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern1, pattern3, pattern2])
+    synthesizer.fit(data)
+    samples = synthesizer.sample(100)
+    updated_metadata = synthesizer.get_metadata('modified')
+    original_metadata = synthesizer.get_metadata('original')
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A#B': {'sdtype': 'categorical'},
+            'C#D': {'sdtype': 'categorical'},
+        }
+    }).to_dict()
+
+    assert expected_updated_metadata == updated_metadata.to_dict()
+
+    assert original_metadata.to_dict() == metadata.to_dict()
+
+    # Get unique combinations from original data
+    original_ab_combos = set(zip(data['A'], data['B']))
+    original_cd_combos = set(zip(data['C'], data['D']))
+    original_ac_combos = set(zip(data['A'], data['C']))
+
+    # Get unique combinations from synthetic data
+    synthetic_ab_combos = set(zip(samples['A'], samples['B']))
+    synthetic_cd_combos = set(zip(samples['C'], samples['D']))
+    synthetic_ac_combos = set(zip(samples['A'], samples['C']))
+
+    # Assert combinations match
+    assert original_ab_combos == synthetic_ab_combos
+    assert original_cd_combos == synthetic_cd_combos
+    assert original_ac_combos == synthetic_ac_combos

--- a/tests/integration/cag/test_fixed_combinations.py
+++ b/tests/integration/cag/test_fixed_combinations.py
@@ -1,4 +1,4 @@
-"""Integration tests for FixedCombinations CAG constraint."""
+"""Integration tests for FixedCombinations constraint."""
 
 import re
 
@@ -164,12 +164,12 @@ def test_fixed_combinations_multiple_constraints():
             'D': {'sdtype': 'categorical'},
         }
     })
-    pattern1 = FixedCombinations(['A', 'B'])
-    pattern2 = FixedCombinations(['C', 'D'])
+    constraint1 = FixedCombinations(['A', 'B'])
+    constraint2 = FixedCombinations(['C', 'D'])
 
     # Run
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_constraints(constraints=[pattern1, pattern2])
+    synthesizer.add_constraints(constraints=[constraint1, constraint2])
     synthesizer.fit(data)
     samples = synthesizer.sample(100)
     updated_metadata = synthesizer.get_metadata('modified')
@@ -214,12 +214,12 @@ def test_fixed_combinations_multiple_constraints_reject_sampling():
             'C': {'sdtype': 'categorical'},
         }
     })
-    pattern1 = FixedCombinations(['A', 'B'])
-    pattern2 = FixedCombinations(['A', 'C'])
+    constraint1 = FixedCombinations(['A', 'B'])
+    constraint2 = FixedCombinations(['A', 'C'])
 
     # Run
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_constraints(constraints=[pattern1, pattern2])
+    synthesizer.add_constraints(constraints=[constraint1, constraint2])
     synthesizer.fit(data)
     samples = synthesizer.sample(100)
     updated_metadata = synthesizer.get_metadata('modified')
@@ -266,13 +266,13 @@ def test_fixed_combinations_multiple_constraints_three_constraints():
             'D': {'sdtype': 'categorical'},
         }
     })
-    pattern1 = FixedCombinations(['A', 'B'])
-    pattern2 = FixedCombinations(['C', 'D'])
-    pattern3 = FixedCombinations(['A', 'C'])
+    constraint1 = FixedCombinations(['A', 'B'])
+    constraint2 = FixedCombinations(['C', 'D'])
+    constraint3 = FixedCombinations(['A', 'C'])
 
     # Run
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_constraints(constraints=[pattern1, pattern2, pattern3])
+    synthesizer.add_constraints(constraints=[constraint1, constraint2, constraint3])
     synthesizer.fit(data)
     samples = synthesizer.sample(100)
     updated_metadata = synthesizer.get_metadata('modified')
@@ -325,13 +325,13 @@ def test_fixed_combinations_multiple_constraints_three_constraints_reject_sampli
             'D': {'sdtype': 'categorical'},
         }
     })
-    pattern1 = FixedCombinations(['A', 'B'])
-    pattern2 = FixedCombinations(['C', 'D'])
-    pattern3 = FixedCombinations(['A', 'C'])
+    constraint1 = FixedCombinations(['A', 'B'])
+    constraint2 = FixedCombinations(['C', 'D'])
+    constraint3 = FixedCombinations(['A', 'C'])
 
     # Run
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_constraints(constraints=[pattern1, pattern3, pattern2])
+    synthesizer.add_constraints(constraints=[constraint1, constraint3, constraint2])
     synthesizer.fit(data)
     samples = synthesizer.sample(100)
     updated_metadata = synthesizer.get_metadata('modified')

--- a/tests/integration/cag/test_fixed_combinations.py
+++ b/tests/integration/cag/test_fixed_combinations.py
@@ -11,7 +11,7 @@ from sdv.cag._errors import PatternNotMetError
 from sdv.metadata import Metadata
 from sdv.multi_table import HMASynthesizer
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
-from tests.utils import run_pattern
+from tests.utils import run_constraint
 
 
 @pytest.fixture()
@@ -72,7 +72,7 @@ def pattern_multi():
 def test_fixed_combinations_integers(data, metadata, pattern):
     """Test that FixedCombinations constraint works with integer columns."""
     # Run
-    updated_metadata, transformed, reverse_transformed = run_pattern(constraint, data, metadata)
+    updated_metadata, transformed, reverse_transformed = run_constraint(constraint, data, metadata)
 
     # Assert
     expected_updated_metadata = Metadata.load_from_dict({
@@ -102,7 +102,7 @@ def test_fixed_combinations_with_nans(metadata, pattern):
     constraint = FixedCombinations(['A', 'B'])
 
     # Run
-    updated_metadata, transformed, reverse_transformed = run_pattern(constraint, data, metadata)
+    updated_metadata, transformed, reverse_transformed = run_constraint(constraint, data, metadata)
 
     # Assert
     expected_updated_metadata = Metadata.load_from_dict({
@@ -123,7 +123,7 @@ def test_fixed_null_combinations_with_multi_table(data_multi, metadata_multi, pa
     constraint = pattern_multi
 
     # Run
-    updated_metadata, transformed, reverse_transformed = run_pattern(constraint, data, metadata)
+    updated_metadata, transformed, reverse_transformed = run_constraint(constraint, data, metadata)
 
     # Assert
     expected_updated_metadata = Metadata.load_from_dict({

--- a/tests/integration/cag/test_fixed_increments.py
+++ b/tests/integration/cag/test_fixed_increments.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from sdv.cag import FixedIncrements
-from sdv.cag._errors import constraintNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.metadata import Metadata
 from sdv.multi_table import HMASynthesizer
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
@@ -154,7 +154,7 @@ def test_fixed_incremements_with_multi_table(data_multi, metadata_multi, constra
 
 def run_copula(data, metadata, constraint):
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     return synthesizer
 
@@ -181,7 +181,7 @@ def test_validate_cag_raises(data, metadata, constraint):
     msg = re.escape('The fixed increments requirement is not met for row indices: 0, 1, 2, 3, 4')
 
     # Run and Assert
-    with pytest.raises(constraintNotMetError, match=msg):
+    with pytest.raises(ConstraintNotMetError, match=msg):
         synthesizer.validate_cag(synthetic_data=synthetic_data)
 
 
@@ -192,7 +192,7 @@ def test_validate_cag_multi(data_multi, metadata_multi, constraint_multi):
     metadata = metadata_multi
     constraint = constraint_multi
     synthesizer = HMASynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     synthetic_data = synthesizer.sample(100)
 
@@ -231,7 +231,7 @@ def test_validate_cag_multi_raises():
         'table2': pd.DataFrame({'id': range(5)}),
     }
     synthesizer = HMASynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     msg = re.escape(
         "Table 'table1': The fixed increments requirement is "
@@ -239,5 +239,5 @@ def test_validate_cag_multi_raises():
     )
 
     # Run and Assert
-    with pytest.raises(constraintNotMetError, match=msg):
+    with pytest.raises(ConstraintNotMetError, match=msg):
         synthesizer.validate_cag(synthetic_data=synthetic_data)

--- a/tests/integration/cag/test_fixed_increments.py
+++ b/tests/integration/cag/test_fixed_increments.py
@@ -1,0 +1,114 @@
+"""Integration tests for FixedIncrements CAG pattern."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sdv.cag import FixedIncrements
+from sdv.metadata import Metadata
+from tests.utils import run_pattern
+
+
+@pytest.mark.parametrize(
+    'dtype',
+    [
+        'int8',
+        'int16',
+        'int32',
+        'int64',
+        'Int8',
+        'Int16',
+        'Int32',
+        'Int64',
+        'float16',
+        'float32',
+        'float64',
+        'Float32',
+        'Float64',
+    ],
+)
+def test_fixed_increments_integers(dtype):
+    # Setup
+    increment_value = 5
+    values = np.random.randint(low=1, high=10, size=10) * increment_value
+    series = pd.Series(values, dtype=dtype)
+    if dtype.startswith('I') or dtype.startswith('F'):
+        series.iloc[-2:] = pd.NA
+    elif dtype.startswith('f'):
+        series.iloc[-2:] = np.nan
+    data = pd.DataFrame({dtype: series})
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            dtype: {'sdtype': 'numerical', 'computer_representation': dtype},
+        }
+    })
+    pattern = FixedIncrements(dtype, increment_value=increment_value)
+
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {f'{dtype}#increment': {'sdtype': 'numerical'}}
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed.columns) == [f'{dtype}#increment']
+    pd.testing.assert_frame_equal(data, reverse_transformed)
+
+
+def test_fixed_incremements_with_multi_table():
+    """Test that FixedIncrements constraint works with multi-table data."""
+    # Setup
+    increment_value = 1000
+    A_values = np.random.randint(low=1, high=10, size=10)
+    B_values = np.random.randint(low=1, high=100, size=10)
+    A_values *= increment_value
+    B_values *= increment_value
+
+    data = {
+        'table1': pd.DataFrame({
+            'A': pd.Series(A_values, dtype='int64'),
+            'B': pd.Series(B_values, dtype='Int64'),
+        }),
+        'table2': pd.DataFrame({'id': range(5)}),
+    }
+    metadata = Metadata.load_from_dict({
+        'tables': {
+            'table1': {
+                'columns': {
+                    'A': {'sdtype': 'numerical'},
+                    'B': {'sdtype': 'numerical'},
+                }
+            },
+            'table2': {
+                'columns': {
+                    'id': {'sdtype': 'id'},
+                }
+            },
+        }
+    })
+    pattern = FixedIncrements(column_name='A', table_name='table1', increment_value=increment_value)
+
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'tables': {
+            'table1': {
+                'columns': {
+                    'A#increment': {'sdtype': 'numerical'},
+                }
+            },
+            'table2': {
+                'columns': {
+                    'id': {'sdtype': 'id'},
+                }
+            },
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed['table1'].columns) == ['B', 'A#increment']
+    assert set(data.keys()) == set(reverse_transformed.keys())
+    for table_name, table in data.items():
+        pd.testing.assert_frame_equal(table, reverse_transformed[table_name])

--- a/tests/integration/cag/test_fixed_increments.py
+++ b/tests/integration/cag/test_fixed_increments.py
@@ -1,12 +1,77 @@
 """Integration tests for FixedIncrements CAG pattern."""
 
+import re
+
 import numpy as np
 import pandas as pd
 import pytest
 
 from sdv.cag import FixedIncrements
+from sdv.cag._errors import PatternNotMetError
 from sdv.metadata import Metadata
+from sdv.multi_table import HMASynthesizer
+from sdv.single_table.copulas import GaussianCopulaSynthesizer
 from tests.utils import run_pattern
+
+
+@pytest.fixture()
+def data():
+    return pd.DataFrame({'A': [10, 20, 30, 40, 50]})
+
+
+@pytest.fixture()
+def metadata():
+    return Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'numerical'},
+        }
+    })
+
+
+@pytest.fixture()
+def pattern():
+    return FixedIncrements(column_name='A', increment_value=10)
+
+
+@pytest.fixture()
+def data_multi():
+    increment_value = 1000
+    A_values = np.random.randint(low=1, high=10, size=10)
+    B_values = np.random.randint(low=1, high=100, size=10)
+    A_values *= increment_value
+    B_values *= increment_value
+
+    return {
+        'table1': pd.DataFrame({
+            'A': pd.Series(A_values, dtype='int64'),
+            'B': pd.Series(B_values, dtype='Int64'),
+        }),
+        'table2': pd.DataFrame({'id': range(5)}),
+    }
+
+
+@pytest.fixture()
+def metadata_multi():
+    return Metadata.load_from_dict({
+        'tables': {
+            'table1': {
+                'columns': {
+                    'A': {'sdtype': 'numerical'},
+                    'B': {'sdtype': 'numerical'},
+                }
+            },
+            'table2': {
+                'columns': {
+                    'id': {'sdtype': 'id'},
+                }
+            },
+        }
+    })
+
+
+@pytest.fixture()
+def pattern_multi():
+    return FixedIncrements(column_name='A', table_name='table1', increment_value=1000)
 
 
 @pytest.mark.parametrize(
@@ -56,40 +121,12 @@ def test_fixed_increments_integers(dtype):
     pd.testing.assert_frame_equal(data, reverse_transformed)
 
 
-def test_fixed_incremements_with_multi_table():
+def test_fixed_incremements_with_multi_table(data_multi, metadata_multi, pattern_multi):
     """Test that FixedIncrements constraint works with multi-table data."""
-    # Setup
-    increment_value = 1000
-    A_values = np.random.randint(low=1, high=10, size=10)
-    B_values = np.random.randint(low=1, high=100, size=10)
-    A_values *= increment_value
-    B_values *= increment_value
-
-    data = {
-        'table1': pd.DataFrame({
-            'A': pd.Series(A_values, dtype='int64'),
-            'B': pd.Series(B_values, dtype='Int64'),
-        }),
-        'table2': pd.DataFrame({'id': range(5)}),
-    }
-    metadata = Metadata.load_from_dict({
-        'tables': {
-            'table1': {
-                'columns': {
-                    'A': {'sdtype': 'numerical'},
-                    'B': {'sdtype': 'numerical'},
-                }
-            },
-            'table2': {
-                'columns': {
-                    'id': {'sdtype': 'id'},
-                }
-            },
-        }
-    })
-    pattern = FixedIncrements(column_name='A', table_name='table1', increment_value=increment_value)
-
     # Run
+    data = data_multi
+    metadata = metadata_multi
+    pattern = pattern_multi
     updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
 
     # Assert
@@ -98,6 +135,7 @@ def test_fixed_incremements_with_multi_table():
             'table1': {
                 'columns': {
                     'A#increment': {'sdtype': 'numerical'},
+                    'B': {'sdtype': 'numerical'},
                 }
             },
             'table2': {
@@ -112,3 +150,94 @@ def test_fixed_incremements_with_multi_table():
     assert set(data.keys()) == set(reverse_transformed.keys())
     for table_name, table in data.items():
         pd.testing.assert_frame_equal(table, reverse_transformed[table_name])
+
+
+def run_copula(data, metadata, pattern):
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern])
+    synthesizer.fit(data)
+    return synthesizer
+
+
+def test_validate_cag(data, metadata, pattern):
+    """Test validate_cag works with synthetic data generated with FixedIncrements."""
+    # Setup
+    synthesizer = run_copula(data, metadata, pattern)
+    synthetic_data = synthesizer.sample(100)
+
+    # Run
+    synthesizer.validate_cag(synthetic_data=synthetic_data)
+
+    # Assert
+    assert all(data['A'] % pattern.increment_value == 0)
+    assert all(synthetic_data['A'] % pattern.increment_value == 0)
+
+
+def test_validate_cag_raises(data, metadata, pattern):
+    """Test validate_cag raises an error with bad multitable data with FixedIncrements."""
+    # Setup
+    synthesizer = run_copula(data, metadata, pattern)
+    synthetic_data = pd.DataFrame({'A': [1, 3, 5, 7, 9, 12]})
+    msg = re.escape('The fixed increments requirement is not met for row indices: 0, 1, 2, 3, 4')
+
+    # Run and Assert
+    with pytest.raises(PatternNotMetError, match=msg):
+        synthesizer.validate_cag(synthetic_data=synthetic_data)
+
+
+def test_validate_cag_multi(data_multi, metadata_multi, pattern_multi):
+    """Test validate_cag works with multitable data generated with FixedIncrements."""
+    # Setup
+    data = data_multi
+    metadata = metadata_multi
+    pattern = pattern_multi
+    synthesizer = HMASynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern])
+    synthesizer.fit(data)
+    synthetic_data = synthesizer.sample(100)
+
+    # Run
+    synthesizer.validate_cag(synthetic_data=synthetic_data)
+
+    # Assert
+    assert all(data['table1']['A'] % pattern.increment_value == 0)
+    assert all(synthetic_data['table1']['A'] % pattern.increment_value == 0)
+
+
+def test_validate_cag_multi_raises():
+    """Test validate_cag raises an error with bad multitable data with FixedIncrements."""
+    # Setup
+    data = {
+        'table1': pd.DataFrame({'A': [2, 4, 6, 8, 10]}),
+        'table2': pd.DataFrame({'id': range(5)}),
+    }
+    metadata = Metadata.load_from_dict({
+        'tables': {
+            'table1': {
+                'columns': {
+                    'A': {'sdtype': 'numerical'},
+                }
+            },
+            'table2': {
+                'columns': {
+                    'id': {'sdtype': 'id'},
+                }
+            },
+        }
+    })
+    pattern = FixedIncrements(column_name='A', table_name='table1', increment_value=2)
+    synthetic_data = {
+        'table1': pd.DataFrame({'A': [1, 3, 5, 7, 9, 12]}),
+        'table2': pd.DataFrame({'id': range(5)}),
+    }
+    synthesizer = HMASynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern])
+    synthesizer.fit(data)
+    msg = re.escape(
+        "Table 'table1': The fixed increments requirement is "
+        'not met for row indices: 0, 1, 2, 3, 4.'
+    )
+
+    # Run and Assert
+    with pytest.raises(PatternNotMetError, match=msg):
+        synthesizer.validate_cag(synthetic_data=synthetic_data)

--- a/tests/integration/cag/test_fixed_increments.py
+++ b/tests/integration/cag/test_fixed_increments.py
@@ -1,4 +1,4 @@
-"""Integration tests for FixedIncrements CAG pattern."""
+"""Integration tests for FixedIncrements CAG constraint."""
 
 import re
 
@@ -107,10 +107,10 @@ def test_fixed_increments_integers(dtype):
             dtype: {'sdtype': 'numerical', 'computer_representation': dtype},
         }
     })
-    pattern = FixedIncrements(dtype, increment_value=increment_value)
+    constraint = FixedIncrements(dtype, increment_value=increment_value)
 
     # Run
-    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+    updated_metadata, transformed, reverse_transformed = run_pattern(constraint, data, metadata)
 
     # Assert
     expected_updated_metadata = Metadata.load_from_dict({
@@ -225,13 +225,13 @@ def test_validate_cag_multi_raises():
             },
         }
     })
-    pattern = FixedIncrements(column_name='A', table_name='table1', increment_value=2)
+    constraint = FixedIncrements(column_name='A', table_name='table1', increment_value=2)
     synthetic_data = {
         'table1': pd.DataFrame({'A': [1, 3, 5, 7, 9, 12]}),
         'table2': pd.DataFrame({'id': range(5)}),
     }
     synthesizer = HMASynthesizer(metadata)
-    synthesizer.add_cag(patterns=[pattern])
+    synthesizer.add_cag(patterns=[constraint])
     synthesizer.fit(data)
     msg = re.escape(
         "Table 'table1': The fixed increments requirement is "

--- a/tests/integration/cag/test_fixed_increments.py
+++ b/tests/integration/cag/test_fixed_increments.py
@@ -1,4 +1,4 @@
-"""Integration tests for FixedIncrements CAG constraint."""
+"""Integration tests for FixedIncrements constraint."""
 
 import re
 

--- a/tests/integration/cag/test_inequality.py
+++ b/tests/integration/cag/test_inequality.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 from sdv.cag import Inequality
-from sdv.cag._errors import constraintNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.datasets.demo import download_demo
 from sdv.metadata import Metadata
 from sdv.multi_table import HMASynthesizer
@@ -377,7 +377,7 @@ def test_inequality_with_timestamp_and_date_strict_boundaries():
 
     # Run and Assert
     error_msg = 'The inequality requirement is not met for row indices: '
-    with pytest.raises(constraintNotMetError) as error:
+    with pytest.raises(ConstraintNotMetError) as error:
         synthesizer.fit(data)
         assert error_msg in error
 
@@ -429,7 +429,7 @@ def test_inequality_constraint_date_less_than_timestamp_strict_boundaries():
 
     # Run and Assert
     error_msg = 'The inequality requirement is not met for row indices: '
-    with pytest.raises(constraintNotMetError) as error:
+    with pytest.raises(ConstraintNotMetError) as error:
         synthesizer.fit(data)
         assert error_msg in error
 
@@ -481,7 +481,7 @@ def test_inequality_constraint_timestamp_less_than_date_strict_boundaries():
 
     # Run and Assert
     err_msg = 'The inequality requirement is not met for row indices: '
-    with pytest.raises(constraintNotMetError) as error:
+    with pytest.raises(ConstraintNotMetError) as error:
         synthesizer.fit(data)
         assert err_msg in error
 

--- a/tests/integration/cag/test_inequality.py
+++ b/tests/integration/cag/test_inequality.py
@@ -750,7 +750,9 @@ def test_inequality_many_constraints():
     metadata = Metadata.load_from_dict({
         'columns': {f'{i}': {'sdtype': 'numerical'} for i in range(10)}
     })
-    constraints = [Inequality(low_column_name=f'{i}', high_column_name=f'{i + 1}') for i in range(9)]
+    constraints = [
+        Inequality(low_column_name=f'{i}', high_column_name=f'{i + 1}') for i in range(9)
+    ]
 
     # Run
     synthesizer = GaussianCopulaSynthesizer(metadata)
@@ -797,7 +799,7 @@ def test_inequality_with_nan():
         high_column_name='checkout_date',
     )
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_cag([inequality_cag])
+    synthesizer.add_constraints([inequality_cag])
 
     # Run
     synthesizer.fit(data)
@@ -816,7 +818,7 @@ def test_validate_cag(data, metadata, constraint):
     """Test validate_cag works with synthetic data generated with Inequality."""
     # Setup
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     synthetic_data = synthesizer.sample(100)
 
@@ -837,12 +839,12 @@ def test_validate_cag_raises(data, metadata, constraint):
     assert all(data['A'] < data['B'])
     assert all(synthetic_data['A'] > synthetic_data['B'])
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     msg = re.escape('The inequality requirement is not met for row indices: 0, 1, 2, 3, 4, +1 more')
 
     # Run and Assert
-    with pytest.raises(constraintNotMetError, match=msg):
+    with pytest.raises(ConstraintNotMetError, match=msg):
         synthesizer.validate_cag(synthetic_data=synthetic_data)
 
 
@@ -853,7 +855,7 @@ def test_validate_cag_multi(data_multi, metadata_multi, constraint_multi):
     metadata = metadata_multi
     constraint = constraint_multi
     synthesizer = HMASynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     synthetic_data = synthesizer.sample(100)
 
@@ -905,7 +907,7 @@ def test_validate_cag_multi_with_reject(data_reject, metadata_reject, constraint
     metadata = metadata_reject
     constraint1, constraint2 = constraints_reject
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint1, constraint2])
+    synthesizer.add_constraints(constraints=[constraint1, constraint2])
     synthesizer.fit(data)
     synthetic_data = synthesizer.sample(100)
 
@@ -923,7 +925,7 @@ def test_validate_cag_multi_with_reject_raises(data_reject, metadata_reject, con
     metadata = metadata_reject
     constraint1, constraint2 = constraints_reject
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint1, constraint2])
+    synthesizer.add_constraints(constraints=[constraint1, constraint2])
     synthesizer.fit(data)
     # constraint 1 matches, but constraint 2 does not
     synthetic_data = pd.DataFrame({
@@ -936,7 +938,7 @@ def test_validate_cag_multi_with_reject_raises(data_reject, metadata_reject, con
     )
 
     # Run and Assert
-    with pytest.raises(constraintNotMetError, match=msg):
+    with pytest.raises(ConstraintNotMetError, match=msg):
         synthesizer.validate_cag(synthetic_data=synthetic_data)
 
 
@@ -954,7 +956,7 @@ def test_validate_cag_multi_raises(data_multi, metadata_multi, constraint_multi)
         'table2': pd.DataFrame({'id': range(5)}),
     }
     synthesizer = HMASynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     msg = re.escape(
         "Table 'table1': The inequality requirement is not met for "
@@ -962,5 +964,5 @@ def test_validate_cag_multi_raises(data_multi, metadata_multi, constraint_multi)
     )
 
     # Run and Assert
-    with pytest.raises(constraintNotMetError, match=msg):
+    with pytest.raises(ConstraintNotMetError, match=msg):
         synthesizer.validate_cag(synthetic_data=synthetic_data)

--- a/tests/integration/cag/test_inequality.py
+++ b/tests/integration/cag/test_inequality.py
@@ -1,0 +1,616 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from sdv.cag import Inequality
+from sdv.cag._errors import PatternNotMetError
+from sdv.metadata import Metadata
+from sdv.single_table import GaussianCopulaSynthesizer
+from tests.utils import run_pattern
+
+
+def test_inequality_pattern_integers():
+    """Test that Inequality pattern works with integer columns."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [1, 2, 3, 1, 2, 1],
+        'B': [10, 20, 30, 10, 20, 10],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'numerical'},
+            'B': {'sdtype': 'numerical'},
+        }
+    })
+    pattern = Inequality(
+        low_column_name='A',
+        high_column_name='B',
+    )
+
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'numerical'},
+            'A#B': {'sdtype': 'numerical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed.columns) == ['A', 'A#B']
+    pd.testing.assert_frame_equal(data, reverse_transformed)
+
+
+def test_inequality_pattern_with_nans():
+    """Test that Inequality pattern works with NaNs."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [None, 2, np.nan, 1, 2, 1],
+        'B': [np.nan, 20, 30, 10, 20, None],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'numerical'},
+            'B': {'sdtype': 'numerical'},
+        }
+    })
+
+    pattern = Inequality(
+        low_column_name='A',
+        high_column_name='B',
+    )
+
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'numerical'},
+            'A#B': {'sdtype': 'numerical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed.columns) == ['A', 'A#B', 'A#B.nan_component']
+    pd.testing.assert_frame_equal(
+        pd.concat([data.iloc[:2], data.iloc[3:]]),
+        pd.concat([reverse_transformed.iloc[:2], reverse_transformed.iloc[3:]]),
+    )
+    assert 1 < reverse_transformed.iloc[2]['B'] < 30
+    assert pd.isna(reverse_transformed.iloc[2]['A'])
+
+
+def test_inequality_pattern_datetime():
+    """Test that Inequality pattern works with datetime columns."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [
+            pd.Timestamp('2024-01-01'),
+            pd.Timestamp('2024-01-02'),
+            pd.Timestamp('2024-01-03'),
+            pd.Timestamp('2024-01-01'),
+            pd.Timestamp('2024-01-02'),
+            pd.Timestamp('2024-01-01'),
+        ],
+        'B': [
+            pd.Timestamp('2024-01-02'),
+            pd.Timestamp('2024-01-03'),
+            pd.Timestamp('2024-01-04'),
+            pd.Timestamp('2024-01-05'),
+            pd.Timestamp('2024-01-06'),
+            pd.Timestamp('2024-01-07'),
+        ],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'datetime'},
+            'B': {'sdtype': 'datetime'},
+        }
+    })
+    pattern = Inequality(
+        low_column_name='A',
+        high_column_name='B',
+    )
+
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'datetime'},
+            'A#B': {'sdtype': 'numerical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed.columns) == ['A', 'A#B']
+
+    # Check that the timestamps are very close to each other
+    for col in ['A', 'B']:
+        diff = (data[col] - reverse_transformed[col]).abs()
+        assert (diff.dt.total_seconds() < 1e-6).all()
+
+
+def test_inequality_pattern_datetime_nans():
+    """Test that Inequality pattern works with datetime columns with NaNs."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [
+            np.nan,
+            pd.Timestamp('2024-01-02'),
+            None,
+            pd.Timestamp('2024-01-01'),
+            pd.Timestamp('2024-01-02'),
+            pd.Timestamp('2024-01-01'),
+        ],
+        'B': [
+            pd.Timestamp('2024-01-02'),
+            None,
+            np.nan,
+            pd.Timestamp('2024-01-05'),
+            pd.Timestamp('2024-01-06'),
+            pd.Timestamp('2024-01-07'),
+        ],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'datetime'},
+            'B': {'sdtype': 'datetime'},
+        }
+    })
+    pattern = Inequality(
+        low_column_name='A',
+        high_column_name='B',
+    )
+
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'datetime'},
+            'A#B': {'sdtype': 'numerical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed.columns) == ['A', 'A#B', 'A#B.nan_component']
+
+    pd.testing.assert_series_equal(data['A'], reverse_transformed['A'])
+    assert pd.Timestamp('2024-01-01') < reverse_transformed['B'][0] < pd.Timestamp('2024-01-07')
+    assert pd.isna(reverse_transformed['B'][1])
+    assert pd.isna(reverse_transformed['B'][2])
+
+    diff = (data['B'][3:] - reverse_transformed['B'][3:]).abs()
+    assert (diff.dt.total_seconds() < 1e-6).all()
+
+
+def test_inequality_pattern_with_multi_table():
+    """Test that Inequality pattern works with multi-table data."""
+    # Setup
+    data = {
+        'table1': pd.DataFrame({
+            'A': [1, 2, 3, 1, 2, 1],
+            'B': [10, 20, 30, 10, 20, 10],
+        }),
+        'table2': pd.DataFrame({'id': range(5)}),
+    }
+    metadata = Metadata.load_from_dict({
+        'tables': {
+            'table1': {
+                'columns': {
+                    'A': {'sdtype': 'numerical'},
+                    'B': {'sdtype': 'numerical'},
+                }
+            },
+            'table2': {
+                'columns': {
+                    'id': {'sdtype': 'id'},
+                }
+            },
+        }
+    })
+    pattern = Inequality(
+        low_column_name='A',
+        high_column_name='B',
+        table_name='table1',
+    )
+
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'tables': {
+            'table1': {
+                'columns': {
+                    'A': {'sdtype': 'numerical'},
+                    'A#B': {'sdtype': 'numerical'},
+                }
+            },
+            'table2': {
+                'columns': {
+                    'id': {'sdtype': 'id'},
+                }
+            },
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed['table1'].columns) == ['A', 'A#B']
+    assert set(data.keys()) == set(reverse_transformed.keys())
+    for table_name, table in data.items():
+        pd.testing.assert_frame_equal(table, reverse_transformed[table_name])
+
+
+@pytest.mark.skip(reason='Skipping until add_cag method is implemented')
+def test_inequality_with_numerical():
+    """Test it works with numerical columns."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [1, 2, 3, 1, 2, 1],
+        'B': [10, 20, 30, 10, 20, 10],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'numerical'},
+            'B': {'sdtype': 'numerical'},
+        }
+    })
+    pattern = Inequality(
+        low_column_name='A',
+        high_column_name='B',
+    )
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern])
+
+    # Run
+    synthesizer.fit(data)
+    synthetic_data = synthesizer.sample(num_rows=10)
+
+    # Assert
+    assert (synthetic_data['A'] < synthetic_data['B']).all()
+    assert len(synthetic_data) == 10
+
+
+@pytest.mark.skip(reason='Skipping until add_cag method is implemented')
+def test_inequality_with_timestamp_and_date():
+    """Test that the inequality pattern passes without strict boundaries.
+
+    This test checks if the `Inequality` pattern can handle two columns
+    with different datetime formats when `strict_boundaries` is set to `False`.
+    The pattern allows the `SUBMISSION_TIMESTAMP` column to be less than
+    or equal to the `DUE_DATE` column, even when they differ in precision but end
+    within the same day.
+    """
+    # Setup
+    data = pd.DataFrame(
+        data={
+            'SUBMISSION_TIMESTAMP': [
+                '2016-07-10 17:04:00',
+                '2016-07-11 13:23:00',
+                '2016-07-12 08:45:30',
+                '2016-07-11 12:00:00',
+                '2016-07-12 10:30:00',
+            ],
+            'DUE_DATE': ['2016-07-10', '2016-07-11', '2016-07-12', '2016-07-13', '2016-07-14'],
+        }
+    )
+
+    metadata = Metadata.load_from_dict({
+        'tables': {
+            'table': {
+                'columns': {
+                    'SUBMISSION_TIMESTAMP': {
+                        'sdtype': 'datetime',
+                        'datetime_format': '%Y-%m-%d %H:%M:%S',
+                    },
+                    'DUE_DATE': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+                }
+            }
+        }
+    })
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    pattern = Inequality(
+        low_column_name='SUBMISSION_TIMESTAMP',
+        high_column_name='DUE_DATE',
+        strict_boundaries=False,
+    )
+
+    synthesizer.add_cag(patterns=[pattern])
+
+    # Run
+    synthesizer.fit(data)
+    synthetic_data = synthesizer.sample(num_rows=10)
+
+    # Assert
+    synthetic_data['SUBMISSION_TIMESTAMP'] = pd.to_datetime(
+        synthetic_data['SUBMISSION_TIMESTAMP'], errors='coerce'
+    )
+    synthetic_data['DUE_DATE'] = pd.to_datetime(synthetic_data['DUE_DATE'], errors='coerce')
+    invalid_rows = synthetic_data[
+        synthetic_data['SUBMISSION_TIMESTAMP'].dt.date > synthetic_data['DUE_DATE'].dt.date
+    ]
+    assert invalid_rows.empty
+
+
+@pytest.mark.skip(reason='Skipping until add_cag method is implemented')
+def test_inequality_with_timestamp_and_date_strict_boundaries():
+    """Test that the inequality pattern fails with strict boundaries.
+
+    This test evaluates the `Inequality` pattern when `strict_boundaries`
+    is set to `True`. The `SUBMISSION_TIMESTAMP` column values must be strictly
+    less than the `DUE_DATE` values to satisfy the pattern. If any
+    `SUBMISSION_TIMESTAMP` matches or exceeds the `DUE_DATE`, an error should
+    be raised.
+    """
+    # Setup
+    data = pd.DataFrame(
+        data={
+            'SUBMISSION_TIMESTAMP': [
+                '2016-07-10 17:04:00',
+                '2016-07-11 13:23:00',
+                '2016-07-12 08:45:30',
+                '2016-07-11 12:00:00',
+                '2016-07-12 10:30:00',
+            ],
+            'DUE_DATE': ['2016-07-10', '2016-07-11', '2016-07-12', '2016-07-13', '2016-07-14'],
+        }
+    )
+
+    metadata = Metadata.load_from_dict({
+        'tables': {
+            'table': {
+                'columns': {
+                    'SUBMISSION_TIMESTAMP': {
+                        'sdtype': 'datetime',
+                        'datetime_format': '%Y-%m-%d %H:%M:%S',
+                    },
+                    'DUE_DATE': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+                }
+            }
+        }
+    })
+
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    pattern = Inequality(
+        low_column_name='SUBMISSION_TIMESTAMP',
+        high_column_name='DUE_DATE',
+        strict_boundaries=True,
+    )
+    synthesizer.add_cag(patterns=[pattern])
+
+    # Run and Assert
+    error_msg = 'The inequality requirement is not met for row indices: '
+    with pytest.raises(PatternNotMetError) as error:
+        synthesizer.fit(data)
+        assert error_msg in error
+
+
+@pytest.mark.skip(reason='Skipping until add_cag method is implemented')
+def test_inequality_pattern_date_less_than_timestamp_strict_boundaries():
+    """Test that the inequality pattern fails when date is less than timestamp.
+
+    This case evaluates the `Inequality` pattern with
+    `strict_boundaries=True` when the `DUE_DATE` column contains dates, and the
+    `SUBMISSION_TIMESTAMP` contains a timestamp. Since `DUE_DATE` lacks
+    time precision, and `SUBMISSION_TIMESTAMP` contains a timestamp, it
+    violates the pattern when the date is less than the timestamp.
+    """
+    # Setup
+    data = pd.DataFrame(
+        data={
+            'SUBMISSION_TIMESTAMP': [
+                '2024-11-12 02:34:45',
+                '2024-11-13 10:45:30',
+                '2024-11-14 14:30:00',
+                '2024-11-15 16:20:10',
+                '2024-11-16 08:00:00',
+            ],
+            'DUE_DATE': ['2024-11-12', '2024-11-13', '2024-11-14', '2024-11-15', '2024-11-16'],
+        }
+    )
+
+    metadata = Metadata.load_from_dict({
+        'tables': {
+            'table': {
+                'columns': {
+                    'SUBMISSION_TIMESTAMP': {
+                        'sdtype': 'datetime',
+                        'datetime_format': '%Y-%m-%d %H:%M:%S',
+                    },
+                    'DUE_DATE': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+                }
+            }
+        }
+    })
+
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    pattern = Inequality(
+        low_column_name='DUE_DATE',
+        high_column_name='SUBMISSION_TIMESTAMP',
+        strict_boundaries=True,
+    )
+    synthesizer.add_cag(patterns=[pattern])
+
+    # Run and Assert
+    error_msg = 'The inequality requirement is not met for row indices: '
+    with pytest.raises(PatternNotMetError) as error:
+        synthesizer.fit(data)
+        assert error_msg in error
+
+
+@pytest.mark.skip(reason='Skipping until add_cag method is implemented')
+def test_inequality_pattern_timestamp_less_than_date_strict_boundaries():
+    """Test that the inequality pattern fails when timestamp is less than date.
+
+    This case evaluates the `Inequality` pattern with
+    `strict_boundaries=True` when the `SUBMISSION_TIMESTAMP` column contains a
+    timestamp, and the `DUE_DATE` contains a date. This case should violate the
+    pattern, as the `SUBMISSION_TIMESTAMP` (which includes time) is not
+    strictly less than the `DUE_DATE` (which has no time).
+    """
+    # Setup
+    data = pd.DataFrame(
+        data={
+            'SUBMISSION_TIMESTAMP': [
+                '2024-11-12 02:34:45',
+                '2024-11-13 08:23:15',
+                '2024-11-14 11:10:10',
+                '2024-11-15 13:55:30',
+                '2024-11-16 09:05:00',
+            ],
+            'DUE_DATE': ['2024-11-12', '2024-11-13', '2024-11-14', '2024-11-15', '2024-11-16'],
+        }
+    )
+
+    metadata = Metadata.load_from_dict({
+        'tables': {
+            'table': {
+                'columns': {
+                    'SUBMISSION_TIMESTAMP': {
+                        'sdtype': 'datetime',
+                        'datetime_format': '%Y-%m-%d %H:%M:%S',
+                    },
+                    'DUE_DATE': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+                }
+            }
+        }
+    })
+
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    pattern = Inequality(
+        low_column_name='SUBMISSION_TIMESTAMP',
+        high_column_name='DUE_DATE',
+        strict_boundaries=True,
+    )
+    synthesizer.add_cag(patterns=[pattern])
+
+    # Run and Assert
+    err_msg = 'The inequality requirement is not met for row indices: '
+    with pytest.raises(PatternNotMetError) as error:
+        synthesizer.fit(data)
+        assert err_msg in error
+
+
+@pytest.mark.skip(reason='Skipping until add_cag method is implemented')
+def test_inequality_pattern_date_less_than_timestamp_no_strict_boundaries():
+    """Test that the inequality pattern passes when date is less than timestamp.
+
+    This case evaluates the `Inequality` pattern with
+    `strict_boundaries=False`. Since `strict_boundaries` is set to `False`, we
+    assume that a date in the `DUE_DATE` column should be treated as the
+    beginning of the day,
+    so there will be no violation if the `SUBMISSION_TIMESTAMP` is later on the
+    same day.
+    """
+    # Setup
+    data = pd.DataFrame(
+        data={
+            'SUBMISSION_TIMESTAMP': [
+                '2024-11-12 02:34:45',
+                '2024-11-13 10:45:30',
+                '2024-11-14 14:30:00',
+                '2024-11-15 16:20:10',
+                '2024-11-16 08:00:00',
+            ],
+            'DUE_DATE': ['2024-11-12', '2024-11-13', '2024-11-14', '2024-11-15', '2024-11-16'],
+        }
+    )
+
+    metadata = Metadata.load_from_dict({
+        'tables': {
+            'table': {
+                'columns': {
+                    'SUBMISSION_TIMESTAMP': {
+                        'sdtype': 'datetime',
+                        'datetime_format': '%Y-%m-%d %H:%M:%S',
+                    },
+                    'DUE_DATE': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+                }
+            }
+        }
+    })
+
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    pattern = Inequality(
+        low_column_name='DUE_DATE',
+        high_column_name='SUBMISSION_TIMESTAMP',
+        strict_boundaries=False,
+    )
+    synthesizer.add_cag(patterns=[pattern])
+
+    # Run
+    synthesizer.fit(data)
+    synthetic_data = synthesizer.sample(10)
+
+    # Assert
+    synthetic_data['SUBMISSION_TIMESTAMP'] = pd.to_datetime(
+        synthetic_data['SUBMISSION_TIMESTAMP'], errors='coerce'
+    )
+    synthetic_data['DUE_DATE'] = pd.to_datetime(synthetic_data['DUE_DATE'], errors='coerce')
+    invalid_rows = synthetic_data[
+        synthetic_data['SUBMISSION_TIMESTAMP'].dt.date > synthetic_data['DUE_DATE'].dt.date
+    ]
+    assert invalid_rows.empty
+
+
+@pytest.mark.skip(reason='Skipping until add_cag method is implemented')
+def test_inequality_pattern_timestamp_less_than_date_no_strict_boundaries():
+    """Test that the inequality pattern passes when timestamp is less than date.
+
+    This case evaluates the `Inequality` pattern with
+    `strict_boundaries=False`. Since `strict_boundaries` is set to `False`, we
+    assume that a date in the `DUE_DATE` column should be treated as the end of
+    the day, so there will be no violation if the `SUBMISSION_TIMESTAMP` is
+    earlier on the same day.
+    """
+    # Setup
+    data = pd.DataFrame(
+        data={
+            'SUBMISSION_TIMESTAMP': [
+                '2024-11-12 02:34:45',
+                '2024-11-13 08:23:15',
+                '2024-11-14 11:10:10',
+                '2024-11-15 13:55:30',
+                '2024-11-16 09:05:00',
+            ],
+            'DUE_DATE': ['2024-11-12', '2024-11-13', '2024-11-14', '2024-11-15', '2024-11-16'],
+        }
+    )
+
+    metadata = Metadata.load_from_dict({
+        'tables': {
+            'table': {
+                'columns': {
+                    'SUBMISSION_TIMESTAMP': {
+                        'sdtype': 'datetime',
+                        'datetime_format': '%Y-%m-%d %H:%M:%S',
+                    },
+                    'DUE_DATE': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+                }
+            }
+        }
+    })
+
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    pattern = Inequality(
+        low_column_name='SUBMISSION_TIMESTAMP',
+        high_column_name='DUE_DATE',
+        strict_boundaries=False,
+    )
+    synthesizer.add_cag(patterns=[pattern])
+
+    # Run
+    synthesizer.fit(data)
+    synthetic_data = synthesizer.sample(10)
+
+    # Assert
+    synthetic_data['SUBMISSION_TIMESTAMP'] = pd.to_datetime(
+        synthetic_data['SUBMISSION_TIMESTAMP'], errors='coerce'
+    )
+    synthetic_data['DUE_DATE'] = pd.to_datetime(synthetic_data['DUE_DATE'], errors='coerce')
+    invalid_rows = synthetic_data[
+        synthetic_data['SUBMISSION_TIMESTAMP'].dt.date > synthetic_data['DUE_DATE'].dt.date
+    ]
+    assert invalid_rows.empty

--- a/tests/integration/cag/test_one_hot_encoding.py
+++ b/tests/integration/cag/test_one_hot_encoding.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 from sdv.cag import OneHotEncoding
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.metadata import Metadata
 from sdv.multi_table import HMASynthesizer
 from sdv.single_table import GaussianCopulaSynthesizer
@@ -60,21 +60,21 @@ def metadata_multi():
 
 
 @pytest.fixture()
-def pattern_multi():
+def constraint_multi():
     return OneHotEncoding(column_names=['a', 'b', 'c'], table_name='table1')
 
 
 def run_synthesizer(data, metadata):
-    pattern = OneHotEncoding(column_names=['a', 'b', 'c'])
+    constraint = OneHotEncoding(column_names=['a', 'b', 'c'])
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_cag(patterns=[pattern])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     return synthesizer
 
 
-def run_hma(data, metadata, pattern):
+def run_hma(data, metadata, constraint):
     synthesizer = HMASynthesizer(metadata)
-    synthesizer.add_cag(patterns=[pattern])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     return synthesizer
 
@@ -106,21 +106,21 @@ def test_validate_cag_raises(data, metadata):
     msg = re.escape('The one hot encoding requirement is not met for row indices: 1, 2')
 
     # Run and Assert
-    with pytest.raises(PatternNotMetError, match=msg):
+    with pytest.raises(ConstraintNotMetError, match=msg):
         synthesizer.validate_cag(synthetic_data=synthetic_data)
 
 
 def test_validate_cag_multi(
     data_multi,
     metadata_multi,
-    pattern_multi,
+    constraint_multi,
 ):
     """Test validate_cag with synthetic data generated with OneHotEncoding with multitable data."""
     # Setup
     data = data_multi
     metadata = metadata_multi
-    pattern = pattern_multi
-    synthesizer = run_hma(data, metadata, pattern)
+    constraint = constraint_multi
+    synthesizer = run_hma(data, metadata, constraint)
     synthetic_data = synthesizer.sample(100)
 
     # Run
@@ -135,13 +135,13 @@ def test_validate_cag_multi(
 def test_validate_cag_multi_raises(
     data_multi,
     metadata_multi,
-    pattern_multi,
+    constraint_multi,
 ):
     """Test validate_cag raises an error with bad multitable synthetic data with OneHotEncoding."""
     data = data_multi
     metadata = metadata_multi
-    pattern = pattern_multi
-    synthesizer = run_hma(data, metadata, pattern)
+    constraint = constraint_multi
+    synthesizer = run_hma(data, metadata, constraint)
     synthetic_data = {
         'table1': pd.DataFrame({
             'a': [1, 2, 0],
@@ -155,5 +155,5 @@ def test_validate_cag_multi_raises(
     )
 
     # Run and Assert
-    with pytest.raises(PatternNotMetError, match=msg):
+    with pytest.raises(ConstraintNotMetError, match=msg):
         synthesizer.validate_cag(synthetic_data=synthetic_data)

--- a/tests/integration/cag/test_one_hot_encoding.py
+++ b/tests/integration/cag/test_one_hot_encoding.py
@@ -1,0 +1,159 @@
+import re
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sdv.cag import OneHotEncoding
+from sdv.cag._errors import PatternNotMetError
+from sdv.metadata import Metadata
+from sdv.multi_table import HMASynthesizer
+from sdv.single_table import GaussianCopulaSynthesizer
+
+
+@pytest.fixture()
+def data():
+    return pd.DataFrame({
+        'a': [1, 0, 0],
+        'b': [0, 1, 0],
+        'c': [0, 0, 1],
+    })
+
+
+@pytest.fixture()
+def metadata():
+    return Metadata.load_from_dict({
+        'columns': {
+            'a': {'sdtype': 'numerical'},
+            'b': {'sdtype': 'numerical'},
+            'c': {'sdtype': 'numerical'},
+        }
+    })
+
+
+@pytest.fixture()
+def data_multi(data):
+    return {
+        'table1': data,
+        'table2': pd.DataFrame({'id': range(5)}),
+    }
+
+
+@pytest.fixture()
+def metadata_multi():
+    return Metadata.load_from_dict({
+        'tables': {
+            'table1': {
+                'columns': {
+                    'a': {'sdtype': 'numerical'},
+                    'b': {'sdtype': 'numerical'},
+                    'c': {'sdtype': 'numerical'},
+                }
+            },
+            'table2': {
+                'columns': {
+                    'id': {'sdtype': 'id'},
+                }
+            },
+        }
+    })
+
+
+@pytest.fixture()
+def pattern_multi():
+    return OneHotEncoding(column_names=['a', 'b', 'c'], table_name='table1')
+
+
+def run_synthesizer(data, metadata):
+    pattern = OneHotEncoding(column_names=['a', 'b', 'c'])
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern])
+    synthesizer.fit(data)
+    return synthesizer
+
+
+def run_hma(data, metadata, pattern):
+    synthesizer = HMASynthesizer(metadata)
+    synthesizer.add_cag(patterns=[pattern])
+    synthesizer.fit(data)
+    return synthesizer
+
+
+def test_validate_cag(data, metadata):
+    """Test validate_cag works with synthetic data generated with OneHotEncoding."""
+    # Setup
+    synthesizer = run_synthesizer(data, metadata)
+    synthetic_data = synthesizer.sample(100)
+
+    # Run
+    synthesizer.validate_cag(synthetic_data=synthetic_data)
+
+    # Assert
+    for col in ['a', 'b', 'c']:
+        assert synthetic_data[col].nunique() == 2
+        assert sorted(synthetic_data[col].unique().tolist()) == [0, 1]
+
+
+def test_validate_cag_raises(data, metadata):
+    """Test validate_cag raises an error with bad synthetic data with OneHotEncoding."""
+    # Setup
+    synthetic_data = pd.DataFrame({
+        'a': [1, 2, 0],
+        'b': [0, 1, np.nan],
+        'c': [0, 0, 3],
+    })
+    synthesizer = run_synthesizer(data, metadata)
+    msg = re.escape('The one hot encoding requirement is not met for row indices: 1, 2')
+
+    # Run and Assert
+    with pytest.raises(PatternNotMetError, match=msg):
+        synthesizer.validate_cag(synthetic_data=synthetic_data)
+
+
+def test_validate_cag_multi(
+    data_multi,
+    metadata_multi,
+    pattern_multi,
+):
+    """Test validate_cag with synthetic data generated with OneHotEncoding with multitable data."""
+    # Setup
+    data = data_multi
+    metadata = metadata_multi
+    pattern = pattern_multi
+    synthesizer = run_hma(data, metadata, pattern)
+    synthetic_data = synthesizer.sample(100)
+
+    # Run
+    synthesizer.validate_cag(synthetic_data=synthetic_data)
+
+    # Assert
+    for col in ['a', 'b', 'c']:
+        assert synthetic_data['table1'][col].nunique() == 2
+        assert sorted(synthetic_data['table1'][col].unique().tolist()) == [0, 1]
+
+
+def test_validate_cag_multi_raises(
+    data_multi,
+    metadata_multi,
+    pattern_multi,
+):
+    """Test validate_cag raises an error with bad multitable synthetic data with OneHotEncoding."""
+    data = data_multi
+    metadata = metadata_multi
+    pattern = pattern_multi
+    synthesizer = run_hma(data, metadata, pattern)
+    synthetic_data = {
+        'table1': pd.DataFrame({
+            'a': [1, 2, 0],
+            'b': [0, 1, np.nan],
+            'c': [0, 0, 3],
+        }),
+        'table2': pd.DataFrame({'id': range(5)}),
+    }
+    msg = re.escape(
+        "Table 'table1': The one hot encoding requirement is not met for row indices: 1, 2."
+    )
+
+    # Run and Assert
+    with pytest.raises(PatternNotMetError, match=msg):
+        synthesizer.validate_cag(synthetic_data=synthetic_data)

--- a/tests/integration/cag/test_range.py
+++ b/tests/integration/cag/test_range.py
@@ -1,0 +1,280 @@
+import numpy as np
+import pandas as pd
+
+from sdv.cag import Range
+from sdv.metadata import Metadata
+from tests.utils import run_pattern
+
+
+def test_range_pattern_integers():
+    """Test that Range pattern works with integer columns."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [1, 2, 3, 1, 2, 1],
+        'B': [10, 20, 30, 10, 20, 10],
+        'C': [100, 200, 300, 100, 200, 100],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'numerical'},
+            'B': {'sdtype': 'numerical'},
+            'C': {'sdtype': 'numerical'},
+        }
+    })
+    pattern = Range(
+        low_column_name='A',
+        middle_column_name='B',
+        high_column_name='C',
+    )
+
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'numerical'},
+            'A#B': {'sdtype': 'numerical'},
+            'B#C': {'sdtype': 'numerical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed.columns) == ['A', 'A#B', 'B#C']
+    pd.testing.assert_frame_equal(data, reverse_transformed)
+
+
+def test_range_pattern_with_nans():
+    """Test that Range pattern works with NaNs."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [None, 2, np.nan, 1, 2, 1],
+        'B': [np.nan, 20, 30, 10, 20, None],
+        'C': [None, 200, 300, 100, 200, None],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'numerical'},
+            'B': {'sdtype': 'numerical'},
+            'C': {'sdtype': 'numerical'},
+        }
+    })
+
+    pattern = Range(
+        low_column_name='A',
+        middle_column_name='B',
+        high_column_name='C',
+    )
+
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'numerical'},
+            'A#B': {'sdtype': 'numerical'},
+            'B#C': {'sdtype': 'numerical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed.columns) == ['A', 'A#B', 'B#C', 'A#B#C.nan_component']
+    pd.testing.assert_frame_equal(
+        pd.concat([data.iloc[:2], data.iloc[3:]]),
+        pd.concat([reverse_transformed.iloc[:2], reverse_transformed.iloc[3:]]),
+    )
+    assert 1 < reverse_transformed.iloc[2]['B'] < 30
+    assert pd.isna(reverse_transformed.iloc[2]['A'])
+    assert 100 < reverse_transformed.iloc[2]['C'] < 300
+
+
+def test_range_pattern_datetime():
+    """Test that Range pattern works with datetime columns."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [
+            pd.Timestamp('2024-01-01'),
+            pd.Timestamp('2024-01-02'),
+            pd.Timestamp('2024-01-03'),
+            pd.Timestamp('2024-01-01'),
+            pd.Timestamp('2024-01-02'),
+            pd.Timestamp('2024-01-01'),
+        ],
+        'B': [
+            pd.Timestamp('2024-01-02'),
+            pd.Timestamp('2024-01-03'),
+            pd.Timestamp('2024-01-04'),
+            pd.Timestamp('2024-01-05'),
+            pd.Timestamp('2024-01-06'),
+            pd.Timestamp('2024-01-07'),
+        ],
+        'C': [
+            pd.Timestamp('2024-01-03'),
+            pd.Timestamp('2024-01-04'),
+            pd.Timestamp('2024-01-05'),
+            pd.Timestamp('2024-01-06'),
+            pd.Timestamp('2024-01-07'),
+            pd.Timestamp('2024-01-08'),
+        ],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'datetime'},
+            'B': {'sdtype': 'datetime'},
+            'C': {'sdtype': 'datetime'},
+        }
+    })
+    pattern = Range(
+        low_column_name='A',
+        middle_column_name='B',
+        high_column_name='C',
+    )
+
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'datetime'},
+            'A#B': {'sdtype': 'numerical'},
+            'B#C': {'sdtype': 'numerical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed.columns) == ['A', 'A#B', 'B#C']
+
+    # Check that the timestamps are very close to each other
+    for col in ['A', 'B', 'C']:
+        diff = (data[col] - reverse_transformed[col]).abs()
+        assert (diff.dt.total_seconds() < 1e-6).all()
+
+
+def test_range_pattern_datetime_nans():
+    """Test that Range pattern works with datetime columns with NaNs."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [
+            np.nan,
+            pd.Timestamp('2024-01-02'),
+            None,
+            pd.Timestamp('2024-01-01'),
+            pd.Timestamp('2024-01-02'),
+            pd.Timestamp('2024-01-01'),
+        ],
+        'B': [
+            pd.Timestamp('2024-01-02'),
+            None,
+            np.nan,
+            pd.Timestamp('2024-01-05'),
+            pd.Timestamp('2024-01-06'),
+            pd.Timestamp('2024-01-07'),
+        ],
+        'C': [
+            pd.Timestamp('2024-01-03'),
+            None,
+            None,
+            pd.Timestamp('2024-01-06'),
+            pd.Timestamp('2024-01-07'),
+            pd.Timestamp('2024-01-08'),
+        ],
+    })
+    metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'datetime'},
+            'B': {'sdtype': 'datetime'},
+            'C': {'sdtype': 'datetime'},
+        }
+    })
+    pattern = Range(
+        low_column_name='A',
+        middle_column_name='B',
+        high_column_name='C',
+    )
+
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'columns': {
+            'A': {'sdtype': 'datetime'},
+            'A#B': {'sdtype': 'numerical'},
+            'B#C': {'sdtype': 'numerical'},
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed.columns) == ['A', 'A#B', 'B#C', 'A#B#C.nan_component']
+
+    pd.testing.assert_series_equal(data['A'], reverse_transformed['A'])
+    assert pd.Timestamp('2024-01-01') < reverse_transformed['B'][0] < pd.Timestamp('2024-01-07')
+    assert pd.isna(reverse_transformed['B'][1])
+    assert pd.isna(reverse_transformed['B'][2])
+
+    diff = (data['B'][3:] - reverse_transformed['B'][3:]).abs()
+    assert (diff.dt.total_seconds() < 1e-6).all()
+
+    assert reverse_transformed['B'][3] == reverse_transformed['C'][3] - pd.Timedelta(days=1)
+
+    diff = (data['B'][3:] - reverse_transformed['B'][3:]).abs()
+    assert (diff.dt.total_seconds() < 1e-6).all()
+
+
+def test_range_pattern_with_multi_table():
+    """Test that Range pattern works with multi-table data."""
+    # Setup
+    data = {
+        'table1': pd.DataFrame({
+            'A': [1, 2, 3, 1, 2, 1],
+            'B': [10, 20, 30, 10, 20, 10],
+            'C': [100, 200, 300, 100, 200, 100],
+        }),
+        'table2': pd.DataFrame({'id': range(5)}),
+    }
+    metadata = Metadata.load_from_dict({
+        'tables': {
+            'table1': {
+                'columns': {
+                    'A': {'sdtype': 'numerical'},
+                    'B': {'sdtype': 'numerical'},
+                    'C': {'sdtype': 'numerical'},
+                }
+            },
+            'table2': {
+                'columns': {
+                    'id': {'sdtype': 'id'},
+                }
+            },
+        }
+    })
+    pattern = Range(
+        low_column_name='A',
+        middle_column_name='B',
+        high_column_name='C',
+        table_name='table1',
+    )
+
+    # Run
+    updated_metadata, transformed, reverse_transformed = run_pattern(pattern, data, metadata)
+
+    # Assert
+    expected_updated_metadata = Metadata.load_from_dict({
+        'tables': {
+            'table1': {
+                'columns': {
+                    'A': {'sdtype': 'numerical'},
+                    'A#B': {'sdtype': 'numerical'},
+                    'B#C': {'sdtype': 'numerical'},
+                }
+            },
+            'table2': {
+                'columns': {
+                    'id': {'sdtype': 'id'},
+                }
+            },
+        }
+    }).to_dict()
+    assert expected_updated_metadata == updated_metadata.to_dict()
+    assert list(transformed['table1'].columns) == ['A', 'A#B', 'B#C']
+    assert set(data.keys()) == set(reverse_transformed.keys())
+    for table_name, table in data.items():
+        pd.testing.assert_frame_equal(table, reverse_transformed[table_name])

--- a/tests/integration/cag/test_range.py
+++ b/tests/integration/cag/test_range.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 from sdv.cag import Range
-from sdv.cag._errors import constraintNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.metadata import Metadata
 from sdv.multi_table import HMASynthesizer
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
@@ -440,7 +440,7 @@ def test_validate_cag(data, metadata, constraint):
     """Test validate_cag works with synthetic data generated with Range."""
     # Setup
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     synthetic_data = synthesizer.sample(100)
 
@@ -461,12 +461,12 @@ def test_validate_cag_raises(data, metadata, constraint):
         'C': data['C'],
     })
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     msg = re.escape('The range requirement is not met for row indices: 0, 1, 2, 3, 4, +1 more')
 
     # Run and Assert
-    with pytest.raises(constraintNotMetError, match=msg):
+    with pytest.raises(ConstraintNotMetError, match=msg):
         synthesizer.validate_cag(synthetic_data=synthetic_data)
 
 
@@ -480,7 +480,7 @@ def test_validate_cag_multi(
     metadata = metadata_multi
     constraint = constraint_multi
     synthesizer = HMASynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     synthetic_data = synthesizer.sample(100)
 
@@ -503,7 +503,7 @@ def test_validate_cag_multi_datetime(
     metadata = metadata_multi_datetime
     constraint = constraint_multi
     synthesizer = HMASynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     synthetic_data = synthesizer.sample(100)
 
@@ -530,12 +530,12 @@ def test_validate_cag_multi_raises(data_multi, metadata_multi, constraint_multi)
         'table2': pd.DataFrame({'id': range(5)}),
     }
     synthesizer = HMASynthesizer(metadata)
-    synthesizer.add_cag(constraints=[constraint])
+    synthesizer.add_constraints(constraints=[constraint])
     synthesizer.fit(data)
     msg = re.escape(
         "Table 'table1': The range requirement is not met for row indices: 0, 1, 2, 3, 4, +1 more"
     )
 
     # Run and Assert
-    with pytest.raises(constraintNotMetError, match=msg):
+    with pytest.raises(ConstraintNotMetError, match=msg):
         synthesizer.validate_cag(synthetic_data=synthetic_data)

--- a/tests/integration/constraints/test_tabular.py
+++ b/tests/integration/constraints/test_tabular.py
@@ -7,6 +7,7 @@ from sdv.metadata import Metadata
 from sdv.single_table import GaussianCopulaSynthesizer
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_fixed_combinations_integers():
     """Test that FixedCombinations constraint works with integer columns."""
     data = pd.DataFrame({
@@ -40,6 +41,7 @@ def test_fixed_combinations_integers():
     )
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_fixed_combinations_with_nans():
     """Test that FixedCombinations constraint works with NaNs."""
     # Setup
@@ -77,6 +79,7 @@ def test_fixed_combinations_with_nans():
     )
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_fixedincrements_with_nullable_pandas_dtypes():
     """Test that FixedIncrements constraint works with nullable pandas dtypes."""
     # Setup
@@ -114,6 +117,7 @@ def test_fixedincrements_with_nullable_pandas_dtypes():
         assert np.all(synthetic_data[column] % 10 == 0)
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_inequality_constraint_with_timestamp_and_date():
     """Test that the inequality constraint passes without strict boundaries.
 
@@ -178,6 +182,7 @@ def test_inequality_constraint_with_timestamp_and_date():
     assert invalid_rows.empty
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_inequality_constraint_with_timestamp_and_date_strict_boundaries():
     """Test that the inequality constraint fails with strict boundaries.
 
@@ -233,6 +238,7 @@ def test_inequality_constraint_with_timestamp_and_date_strict_boundaries():
         assert error_msg in error
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_inequality_constraint_date_less_than_timestamp_strict_boundaries():
     """Test that the inequality constraint fails when date is less than timestamp.
 
@@ -286,6 +292,7 @@ def test_inequality_constraint_date_less_than_timestamp_strict_boundaries():
         synthesizer.fit(data)
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_inequality_constraint_timestamp_less_than_date_strict_boundaries():
     """Test that the inequality constraint fails when timestamp is less than date.
 

--- a/tests/integration/metadata/test_metadata.py
+++ b/tests/integration/metadata/test_metadata.py
@@ -610,7 +610,7 @@ def test_single_table_compatibility(tmp_path):
     loaded_synthesizer = GaussianCopulaSynthesizer.load(model_path)
     assert isinstance(synthesizer, GaussianCopulaSynthesizer)
     assert loaded_synthesizer.get_info() == synthesizer.get_info()
-    assert loaded_synthesizer.metadata.to_dict() == metadata.to_dict()
+    assert loaded_synthesizer.metadata._convert_to_single_table().to_dict() == metadata.to_dict()
     loaded_sample = loaded_synthesizer.sample(10)
     synthesizer.validate(loaded_sample)
 

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -711,8 +711,8 @@ class TestHMASynthesizer:
         captured = capsys.readouterr()
 
         # Assert
-        for pattern in key_phrases:
-            match = re.search(pattern, captured.out + captured.err)
+        for constraint in key_phrases:
+            match = re.search(constraint, captured.out + captured.err)
             assert match is not None
 
     def test_warning_message_too_many_cols(self, capsys):
@@ -732,8 +732,8 @@ class TestHMASynthesizer:
         captured = capsys.readouterr()
 
         # Assert
-        for pattern in key_phrases:
-            match = re.search(pattern, captured.out + captured.err)
+        for constraint in key_phrases:
+            match = re.search(constraint, captured.out + captured.err)
             assert match is not None
         (_, small_metadata) = download_demo(modality='multi_table', dataset_name='trains_v1')
 
@@ -743,8 +743,8 @@ class TestHMASynthesizer:
         captured = capsys.readouterr()
 
         # Assert that small amount of columns don't trigger the message
-        for pattern in key_phrases:
-            match = re.search(pattern, captured.out + captured.err)
+        for constraint in key_phrases:
+            match = re.search(constraint, captured.out + captured.err)
             assert match is None
 
     def test_hma_three_linear_nodes(self):
@@ -1532,7 +1532,7 @@ class TestHMASynthesizer:
         synthetic_data = synthesizer.sample()
 
         # Assert
-        # Check that IDs match the regex pattern
+        # Check that IDs match the regex constraint
         for table_name, table in synthetic_data.items():
             for col in table.columns:
                 if metadata.tables[table_name].columns[col].get('sdtype') == 'id':
@@ -1611,7 +1611,7 @@ class TestHMASynthesizer:
             synthetic_data = synthesizer.sample()
 
         # Assert
-        # Check that IDs match the regex pattern
+        # Check that IDs match the regex constraint
         for table_name, table in synthetic_data.items():
             for col in table.columns:
                 if metadata.tables[table_name].columns[col].get('sdtype') == 'id':
@@ -1713,7 +1713,7 @@ class TestHMASynthesizer:
             synthetic_data = synthesizer.sample()
 
         # Assert
-        # Check that IDs match the regex pattern
+        # Check that IDs match the regex constraint
         for table_name, table in synthetic_data.items():
             for col in table.columns:
                 if metadata.tables[table_name].columns[col].get('sdtype') == 'id':
@@ -1797,7 +1797,7 @@ class TestHMASynthesizer:
             synthetic_data = synthesizer.sample()
 
         # Assert
-        # Check that IDs match the regex pattern
+        # Check that IDs match the regex constraint
         for table_name, table in synthetic_data.items():
             for col in table.columns:
                 if metadata.tables[table_name].columns[col].get('sdtype') == 'id':
@@ -1872,7 +1872,7 @@ class TestHMASynthesizer:
             synthetic_data = synthesizer.sample()
 
         # Assert
-        # Check that IDs match the regex pattern
+        # Check that IDs match the regex constraint
         for table_name, table in synthetic_data.items():
             for col in table.columns:
                 if metadata.tables[table_name].columns[col].get('sdtype') == 'id':

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -1532,7 +1532,7 @@ class TestHMASynthesizer:
         synthetic_data = synthesizer.sample()
 
         # Assert
-        # Check that IDs match the regex constraint
+        # Check that IDs match the regex pattern
         for table_name, table in synthetic_data.items():
             for col in table.columns:
                 if metadata.tables[table_name].columns[col].get('sdtype') == 'id':
@@ -1611,7 +1611,7 @@ class TestHMASynthesizer:
             synthetic_data = synthesizer.sample()
 
         # Assert
-        # Check that IDs match the regex constraint
+        # Check that IDs match the regex pattern
         for table_name, table in synthetic_data.items():
             for col in table.columns:
                 if metadata.tables[table_name].columns[col].get('sdtype') == 'id':
@@ -1713,7 +1713,7 @@ class TestHMASynthesizer:
             synthetic_data = synthesizer.sample()
 
         # Assert
-        # Check that IDs match the regex constraint
+        # Check that IDs match the regex pattern
         for table_name, table in synthetic_data.items():
             for col in table.columns:
                 if metadata.tables[table_name].columns[col].get('sdtype') == 'id':
@@ -1797,7 +1797,7 @@ class TestHMASynthesizer:
             synthetic_data = synthesizer.sample()
 
         # Assert
-        # Check that IDs match the regex constraint
+        # Check that IDs match the regex pattern
         for table_name, table in synthetic_data.items():
             for col in table.columns:
                 if metadata.tables[table_name].columns[col].get('sdtype') == 'id':
@@ -1872,7 +1872,7 @@ class TestHMASynthesizer:
             synthetic_data = synthesizer.sample()
 
         # Assert
-        # Check that IDs match the regex constraint
+        # Check that IDs match the regex pattern
         for table_name, table in synthetic_data.items():
             for col in table.columns:
                 if metadata.tables[table_name].columns[col].get('sdtype') == 'id':

--- a/tests/integration/sequential/test_par.py
+++ b/tests/integration/sequential/test_par.py
@@ -124,7 +124,7 @@ def test_save_and_load(tmp_path):
 
     # Assert
     assert isinstance(loaded_instance, PARSynthesizer)
-    assert metadata._convert_to_single_table().to_dict() == instance.metadata.to_dict()
+    assert metadata.to_dict() == instance.metadata.to_dict()
 
 
 def test_synthesize_sequences(tmp_path):
@@ -193,7 +193,7 @@ def test_synthesize_sequences(tmp_path):
     assert model_path.exists()
     assert model_path.is_file()
     assert loaded_synthesizer.get_info() == synthesizer.get_info()
-    assert loaded_synthesizer.metadata.to_dict() == metadata._convert_to_single_table().to_dict()
+    assert loaded_synthesizer.metadata.to_dict() == metadata.to_dict()
     synthesizer.validate(synthetic_data)
     synthesizer.validate(custom_synthetic_data)
     synthesizer.validate(custom_synthetic_data_conditional)

--- a/tests/integration/single_table/test_base.py
+++ b/tests/integration/single_table/test_base.py
@@ -216,6 +216,7 @@ def test_sample_keys_are_scrambled():
     pd.testing.assert_series_equal(ids, expected_keys)
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_multiple_fits():
     """Test the synthesizer refits correctly on new data.
 

--- a/tests/integration/single_table/test_base.py
+++ b/tests/integration/single_table/test_base.py
@@ -526,12 +526,7 @@ def test_save_and_load(tmp_path):
 
     # Assert
     assert isinstance(loaded_instance, BaseSingleTableSynthesizer)
-    assert loaded_instance.metadata.columns == {}
-    assert loaded_instance.metadata.primary_key is None
-    assert loaded_instance.metadata.alternate_keys == []
-    assert loaded_instance.metadata.sequence_key is None
-    assert loaded_instance.metadata.sequence_index is None
-    assert loaded_instance.metadata._version == 'SINGLE_TABLE_V1'
+    assert loaded_instance.metadata.tables == {}
     assert instance._synthesizer_id == loaded_instance._synthesizer_id
 
 
@@ -550,12 +545,8 @@ def test_save_and_load_no_id(tmp_path):
 
     # Assert
     assert isinstance(loaded_instance, BaseSingleTableSynthesizer)
-    assert loaded_instance.metadata.columns == {}
-    assert loaded_instance.metadata.primary_key is None
-    assert loaded_instance.metadata.alternate_keys == []
-    assert loaded_instance.metadata.sequence_key is None
-    assert loaded_instance.metadata.sequence_index is None
-    assert loaded_instance.metadata._version == 'SINGLE_TABLE_V1'
+
+    assert loaded_instance.metadata.tables == {}
     assert hasattr(instance, '_synthesizer_id') is False
     assert hasattr(loaded_instance, '_synthesizer_id') is True
     assert isinstance(loaded_instance._synthesizer_id, str) is True
@@ -718,10 +709,10 @@ def test_metadata_updated_warning(method, kwargs):
     single_metadata = metadata._convert_to_single_table()
     single_metadata.__getattribute__(method)(**kwargs)
     with pytest.warns(UserWarning, match=expected_message):
-        BaseSingleTableSynthesizer(single_metadata)
+        instance = BaseSingleTableSynthesizer(single_metadata)
 
     # Assert
-    assert single_metadata._updated is False
+    assert instance.metadata.tables['table']._updated is False
 
 
 def test_fit_raises_version_error():

--- a/tests/integration/single_table/test_constraints.py
+++ b/tests/integration/single_table/test_constraints.py
@@ -1023,3 +1023,39 @@ def test_constraint_datetime_check():
         'high_col': ['05 Sep, 15', '26 Sep, 15', '12 Aug, 15'],
     })
     pd.testing.assert_frame_equal(samples, expected_dataframe)
+
+
+def test_backward_compatibility_old_style_constraints(tmpdir):
+    """Test that the old-style constraints are still supported."""
+    # Setup
+    data = pd.DataFrame({
+        'A': [1, 2, 3],
+        'B': [4, 5, 6],
+    })
+
+    metadata = Metadata()
+    metadata.add_table('table')
+    metadata.add_column('A', 'table', sdtype='numerical')
+    metadata.add_column('B', 'table', sdtype='numerical')
+
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    constraint = {
+        'constraint_class': 'Inequality',
+        'constraint_parameters': {
+            'low_column_name': 'A',
+            'high_column_name': 'B',
+            'strict_boundaries': False,
+        },
+    }
+    synthesizer._data_processor.add_constraints([constraint])
+
+    # Run
+    synthesizer.fit(data)
+    samples = synthesizer.sample(len(data))
+    synthesizer.save(tmpdir / 'test.pkl')
+    synthesizer_loaded = GaussianCopulaSynthesizer.load(tmpdir / 'test.pkl')
+    samples_loaded = synthesizer_loaded.sample(len(data))
+
+    # Assert
+    assert all(samples['A'] < samples['B'])
+    assert all(samples_loaded['A'] < samples_loaded['B'])

--- a/tests/integration/single_table/test_constraints.py
+++ b/tests/integration/single_table/test_constraints.py
@@ -94,6 +94,7 @@ def test_fit_with_unique_constraint_on_data_with_only_index_column():
     assert samples['index'].is_unique
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_fit_with_unique_constraint_on_data_which_has_index_column():
     """Test that the ``fit`` method runs without error when metadata specifies unique constraint,
     ``fit`` is called on data containing a column named index and other columns.
@@ -264,6 +265,7 @@ def test_conditional_sampling_with_constraints():
     assert samples['C'].isin(['Yes', 'No', 'Maybe']).all()
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 @patch('sdv.single_table.base.isinstance')
 @patch('sdv.single_table.copulas.multivariate.GaussianMultivariate', spec_set=GaussianMultivariate)
 def test_conditional_sampling_constraint_uses_reject_sampling(gm_mock, isinstance_mock):
@@ -330,6 +332,7 @@ def test_conditional_sampling_constraint_uses_reject_sampling(gm_mock, isinstanc
     pd.testing.assert_frame_equal(sampled_data, expected_data)
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_custom_constraints_from_file(tmpdir):
     """Ensure the correct loading for a custom constraint class defined in another file."""
     data = pd.DataFrame({
@@ -373,6 +376,7 @@ def test_custom_constraints_from_file(tmpdir):
     assert all(loaded_sampled['numerical_col'] > 1)
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_custom_constraints_from_object(tmpdir):
     """Ensure the correct loading for a custom constraint class passed as an object."""
     data = pd.DataFrame({
@@ -414,6 +418,7 @@ def test_custom_constraints_from_object(tmpdir):
     assert all(loaded_sampled['numerical_col'] > 1)
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_synthesizer_with_inequality_constraint(demo_data, demo_metadata):
     """Ensure that the ``Inequality`` constraint can sample from the model."""
     # Setup
@@ -436,6 +441,7 @@ def test_synthesizer_with_inequality_constraint(demo_data, demo_metadata):
     assert all(pd.to_datetime(_sampled['checkin_date']) < pd.to_datetime(_sampled['checkout_date']))
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_inequality_constraint_with_datetimes_and_nones():
     """Test that the ``Inequality`` constraint works with ``None`` and ``datetime``."""
     # Setup
@@ -498,6 +504,7 @@ def test_inequality_constraint_with_datetimes_and_nones():
     pd.testing.assert_frame_equal(expected_sampled, sampled)
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_scalar_inequality_constraint_with_datetimes_and_nones():
     """Test that the ``ScalarInequality`` constraint works with ``None`` and ``datetime``."""
     # Setup
@@ -550,6 +557,7 @@ def test_scalar_inequality_constraint_with_datetimes_and_nones():
     pd.testing.assert_frame_equal(expected_sampled, sampled)
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_scalar_range_constraint_with_datetimes_and_nones():
     """Test that the ``ScalarRange`` constraint works with ``None`` and ``datetime``."""
     # Setup
@@ -617,6 +625,7 @@ def test_scalar_range_constraint_with_datetimes_and_nones():
     pd.testing.assert_frame_equal(expected_sampled, sampled)
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_range_constraint_with_datetimes_and_nones():
     """Test that the ``Range`` constraint works with ``None`` and ``datetime``."""
     # Setup
@@ -698,6 +707,7 @@ def test_range_constraint_with_datetimes_and_nones():
     synth.validate(sampled)
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_inequality_constraint_all_possible_nans_configurations():
     """Test that the inequality constraint works with all possible NaN configurations."""
     # Setup
@@ -729,6 +739,7 @@ def test_inequality_constraint_all_possible_nans_configurations():
     assert (~(pd.isna(synthetic_data['A'])) & ~(pd.isna(synthetic_data['B']))).any()
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_range_constraint_all_possible_nans_configurations():
     """Test that the range constraint works with all possible NaN configurations."""
     # Setup
@@ -871,6 +882,7 @@ def test_timezone_aware_constraints():
     assert all(samples['col1'] < samples['col2'])
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_custom_and_overlapping_constraint_errors(caplog, demo_data, demo_metadata):
     """Test a synthesizer when constraints overlap or custom constraints raise an error.
 
@@ -935,6 +947,7 @@ def test_custom_and_overlapping_constraint_errors(caplog, demo_data, demo_metada
         assert log in log_messages
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_aggregate_constraint_errors(demo_data, demo_metadata):
     """Test that if there are multiple constraint errors, they are raised together."""
 
@@ -963,6 +976,7 @@ def test_aggregate_constraint_errors(demo_data, demo_metadata):
         synth.fit(demo_data)
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_constraint_datetime_check():
     """Test datetime columns are correctly identified in constraints. GH#1692"""
     # Setup

--- a/tests/integration/single_table/test_copulas.py
+++ b/tests/integration/single_table/test_copulas.py
@@ -124,6 +124,7 @@ def test_synthesize_table_gaussian_copula(tmp_path):
     assert real_data.shape[1] == simulated_synthetic_data.shape[1]
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_adding_constraints(tmp_path):
     """End to end test for adding constraints to a ``BaseSingleTableSynthesizer``.
 
@@ -299,6 +300,7 @@ def test_update_transformers_with_id_generator():
     assert samples['user_id'].min() == min_value_id
 
 
+@pytest.mark.skip('Old-style constraints are deprecated')
 def test_validate_with_failing_constraint():
     """Validate that the ``constraint`` are raising errors if there is an error during validate."""
     # Setup

--- a/tests/integration/single_table/test_copulas.py
+++ b/tests/integration/single_table/test_copulas.py
@@ -107,7 +107,7 @@ def test_synthesize_table_gaussian_copula(tmp_path):
     loaded_synthesizer = GaussianCopulaSynthesizer.load(model_path)
     assert isinstance(synthesizer, GaussianCopulaSynthesizer)
     assert loaded_synthesizer.get_info() == synthesizer.get_info()
-    assert loaded_synthesizer.metadata.to_dict() == metadata._convert_to_single_table().to_dict()
+    assert loaded_synthesizer.metadata.to_dict() == metadata.to_dict()
     loaded_synthesizer.sample(20)
 
     # Assert - custom synthesizer
@@ -193,7 +193,7 @@ def test_adding_constraints(tmp_path):
 
     assert isinstance(loaded_synthesizer, GaussianCopulaSynthesizer)
     assert loaded_synthesizer.get_info() == synthesizer.get_info()
-    assert loaded_synthesizer.metadata.to_dict() == metadata._convert_to_single_table().to_dict()
+    assert loaded_synthesizer.metadata.to_dict() == metadata.to_dict()
     sampled_data = loaded_synthesizer.sample(100)
     validation = sampled_data[sampled_data['has_rewards']]
     assert validation['amenities_fee'].sum() == 0.0

--- a/tests/integration/single_table/test_ctgan.py
+++ b/tests/integration/single_table/test_ctgan.py
@@ -114,7 +114,7 @@ def test_synthesize_table_ctgan(tmp_path):
     loaded_synthesizer = CTGANSynthesizer.load(model_path)
     assert isinstance(synthesizer, CTGANSynthesizer)
     assert loaded_synthesizer.get_info() == synthesizer.get_info()
-    assert loaded_synthesizer.metadata.to_dict() == metadata._convert_to_single_table().to_dict()
+    assert loaded_synthesizer.metadata.to_dict() == metadata.to_dict()
     loaded_synthesizer.sample(20)
 
     # Assert - custom synthesizer

--- a/tests/unit/cag/__init__.py
+++ b/tests/unit/cag/__init__.py
@@ -1,0 +1,1 @@
+"""CAG unit tests."""

--- a/tests/unit/cag/test__utils.py
+++ b/tests/unit/cag/test__utils.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.cag._utils import (
     _convert_to_snake_case,
     _is_list_of_type,
@@ -36,13 +36,13 @@ def test__validate_table_and_column_names():
 
     # Run and Assert
     _validate_table_and_column_names('parent', columns_correct, metadata)
-    with pytest.raises(PatternNotMetError, match=expected_not_single_table):
+    with pytest.raises(ConstraintNotMetError, match=expected_not_single_table):
         _validate_table_and_column_names(None, columns_correct, metadata)
 
-    with pytest.raises(PatternNotMetError, match=expected_error_wrong_table):
+    with pytest.raises(ConstraintNotMetError, match=expected_error_wrong_table):
         _validate_table_and_column_names('wrong_table', columns_correct, metadata)
 
-    with pytest.raises(PatternNotMetError, match=expected_error_wrong_columns):
+    with pytest.raises(ConstraintNotMetError, match=expected_error_wrong_columns):
         _validate_table_and_column_names('parent', wrong_columns, metadata)
 
 

--- a/tests/unit/cag/test__utils.py
+++ b/tests/unit/cag/test__utils.py
@@ -1,0 +1,55 @@
+"""CAG _utils unit tests."""
+
+import re
+from unittest.mock import Mock
+
+import pytest
+
+from sdv.cag._errors import PatternNotMetError
+from sdv.cag._utils import _validate_table_and_column_names
+
+
+def test__validate_table_and_column_names():
+    """Test `_validate_table_and_column_names` method."""
+    # Setup
+    columns_correct = {'parent_1', 'parent_2'}
+    wrong_columns = {'wrong_column_1', 'wrong_column_2'}
+    metadata = Mock()
+    metadata.tables = {'parent': Mock(), 'child': Mock()}
+    metadata.tables['parent'].columns = columns_correct
+
+    expected_not_single_table = re.escape(
+        'Metadata contains more than 1 table but no ``table_name`` provided.'
+    )
+    expected_error_wrong_table = re.escape("Table 'wrong_table' missing from metadata.")
+    expected_error_wrong_columns = re.escape(
+        "Table 'parent' is missing columns 'wrong_column_1', 'wrong_column_2'."
+    )
+
+    # Run and Assert
+    _validate_table_and_column_names('parent', columns_correct, metadata)
+    with pytest.raises(PatternNotMetError, match=expected_not_single_table):
+        _validate_table_and_column_names(None, columns_correct, metadata)
+
+    with pytest.raises(PatternNotMetError, match=expected_error_wrong_table):
+        _validate_table_and_column_names('wrong_table', columns_correct, metadata)
+
+    with pytest.raises(PatternNotMetError, match=expected_error_wrong_columns):
+        _validate_table_and_column_names('parent', wrong_columns, metadata)
+
+
+def test__validate_table_and_column_names_single_table():
+    """Test `_validate_table_and_column_names` method with only a single table."""
+    # Setup
+    columns_correct = {'parent_1', 'parent_2'}
+    metadata = Mock()
+    metadata.tables = {'parent': Mock()}
+    metadata.tables['parent'].columns = columns_correct
+    metadata._get_single_table_name.return_value = 'parent'
+
+    # Run
+    _validate_table_and_column_names('parent', columns_correct, metadata)
+    _validate_table_and_column_names(None, columns_correct, metadata)
+
+    # Assert
+    metadata._get_single_table_name.assert_called_once()

--- a/tests/unit/cag/test__utils.py
+++ b/tests/unit/cag/test__utils.py
@@ -1,18 +1,22 @@
 """CAG _utils unit tests."""
 
 import re
-from unittest.mock import Mock
+import warnings
+from unittest.mock import Mock, patch
 
 import pytest
 
 from sdv.cag._errors import ConstraintNotMetError
 from sdv.cag._utils import (
     _convert_to_snake_case,
+    _filter_old_style_constraints,
     _is_list_of_type,
     _remove_columns_from_metadata,
+    _validate_constraints,
     _validate_table_and_column_names,
     _validate_table_name_if_defined,
 )
+from sdv.cag.base import BaseConstraint
 from sdv.metadata.metadata import Metadata
 
 
@@ -238,3 +242,54 @@ def test__remove_columns_from_metadata_multiple_duplicate_columns():
     assert 'A' in original_metadata.tables['table'].columns
     assert 'A' not in new_metadata.tables['table'].columns
     assert 'B' in new_metadata.tables['table'].columns
+
+
+def test__filter_old_style_constraints():
+    """Test `_filter_old_style_constraints` method"""
+
+    # Setup
+    class DummyConstraint(BaseConstraint):
+        pass
+
+    constraint_1 = DummyConstraint()
+    constraint_2 = DummyConstraint()
+    old_style_constraint = {}
+    expected_warning = re.escape(
+        'The `add_constraints` function no longer supports constraints using the older '
+        'dictionary-style definition. Such constraints will be ignored. Please supply '
+        'objects from `sdv.cag` instead.'
+    )
+
+    # Run
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter('always')
+        result_1 = _filter_old_style_constraints([constraint_1, constraint_2])
+        assert len(record) == 0
+
+    with pytest.warns(DeprecationWarning, match=expected_warning):
+        result_2 = _filter_old_style_constraints([constraint_1, constraint_2, old_style_constraint])
+
+    # Assert
+    assert result_1 == [constraint_1, constraint_2]
+    assert result_2 == result_1
+
+
+@patch('sdv.cag._utils._filter_old_style_constraints')
+def test__validate_constraints(mock_filter_old_style_constraints):
+    """Test `_validate_constraints` method"""
+    # Setup
+    constraint_1 = Mock()
+    constraint_2 = Mock()
+    expected_error = re.escape('Constraints must be a list of sdv.cag objects.')
+    expected_warning = re.escape(
+        "For these constraints to take effect, please refit the synthesizer using 'fit'."
+    )
+
+    # Run and Assert
+    _validate_constraints(constraints=[constraint_1, constraint_2], synthesizer_fitted=False)
+    mock_filter_old_style_constraints.assert_called_once_with([constraint_1, constraint_2])
+    with pytest.raises(ValueError, match=expected_error):
+        _validate_constraints(constraints=constraint_1, synthesizer_fitted=True)
+
+    with pytest.warns(UserWarning, match=expected_warning):
+        _validate_constraints(constraints=[constraint_1], synthesizer_fitted=True)

--- a/tests/unit/cag/test__utils.py
+++ b/tests/unit/cag/test__utils.py
@@ -7,7 +7,7 @@ import pytest
 
 from sdv.cag._errors import PatternNotMetError
 from sdv.cag._utils import (
-    _is_list_of_strings,
+    _is_list_of_type,
     _remove_columns_from_metadata,
     _validate_table_and_column_names,
     _validate_table_name_if_defined,
@@ -192,10 +192,10 @@ def test__remove_columns_from_metadata_raises_pk():
         )
 
 
-def test__is_list_of_strings():
-    """Test `_is_list_of_strings` method"""
-    assert _is_list_of_strings(['a', 'b'])
-    assert not _is_list_of_strings(['a', 1])
-    assert not _is_list_of_strings([1, 2])
-    assert not _is_list_of_strings(1)
-    assert not _is_list_of_strings('a')
+def test__is_list_of_type():
+    """Test `_is_list_of_type` method"""
+    assert _is_list_of_type(['a', 'b'])
+    assert not _is_list_of_type(['a', 1])
+    assert not _is_list_of_type([1, 2])
+    assert not _is_list_of_type(1)
+    assert not _is_list_of_type('a')

--- a/tests/unit/cag/test__utils.py
+++ b/tests/unit/cag/test__utils.py
@@ -247,10 +247,10 @@ def test__remove_columns_from_metadata_multiple_duplicate_columns():
 def test__filter_old_style_constraints():
     """Test `_filter_old_style_constraints` method"""
 
-    # Setup
     class DummyConstraint(BaseConstraint):
         pass
 
+    # Setup
     constraint_1 = DummyConstraint()
     constraint_2 = DummyConstraint()
     old_style_constraint = {}

--- a/tests/unit/cag/test__utils.py
+++ b/tests/unit/cag/test__utils.py
@@ -6,7 +6,13 @@ from unittest.mock import Mock
 import pytest
 
 from sdv.cag._errors import PatternNotMetError
-from sdv.cag._utils import _validate_table_and_column_names
+from sdv.cag._utils import (
+    _is_list_of_strings,
+    _remove_columns_from_metadata,
+    _validate_table_and_column_names,
+    _validate_table_name_if_defined,
+)
+from sdv.metadata.metadata import Metadata
 
 
 def test__validate_table_and_column_names():
@@ -21,6 +27,7 @@ def test__validate_table_and_column_names():
     expected_not_single_table = re.escape(
         'Metadata contains more than 1 table but no ``table_name`` provided.'
     )
+
     expected_error_wrong_table = re.escape("Table 'wrong_table' missing from metadata.")
     expected_error_wrong_columns = re.escape(
         "Table 'parent' is missing columns 'wrong_column_1', 'wrong_column_2'."
@@ -53,3 +60,142 @@ def test__validate_table_and_column_names_single_table():
 
     # Assert
     metadata._get_single_table_name.assert_called_once()
+
+
+def test__validate_table_name_if_defined():
+    """Test `_validate_table_name_if_defined` method works with None or string"""
+    _validate_table_name_if_defined(table_name='child')
+    _validate_table_name_if_defined(table_name=None)
+
+
+def test__validate_table_name_if_defined_raises():
+    """Test `_validate_table_name_if_defined` method raises an error with wrong type"""
+    expected_table_name_str_or_none = '`table_name` must be a string or None.'
+    with pytest.raises(ValueError, match=expected_table_name_str_or_none):
+        _validate_table_name_if_defined(table_name=1)
+
+
+def test__remove_columns_from_metadata_single():
+    """Test `_remove_columns_from_metadata` method removes columns from metadata (single-table)"""
+    # Setup
+    original_metadata = Metadata.load_from_dict({
+        'tables': {
+            'table': {
+                'columns': {
+                    'country_column': {'sdtype': 'categorical'},
+                    'city_column': {'sdtype': 'categorical'},
+                },
+                'column_relationships': [
+                    {'type': 'address', 'column_names': ['country_column', 'city_column']}
+                ],
+            }
+        },
+        'relationships': [],
+        'METADATA_SPEC_VERSION': 'V1',
+    })
+
+    # Run
+    column_to_drop = 'country_column'
+    new_metadata = _remove_columns_from_metadata(
+        metadata=original_metadata,
+        table_name='table',
+        columns_to_drop=[column_to_drop],
+    )
+
+    # Assert
+    assert isinstance(new_metadata, Metadata)
+    assert column_to_drop in original_metadata.tables['table'].columns
+    assert (
+        column_to_drop in original_metadata.tables['table'].column_relationships[0]['column_names']
+    )
+    assert column_to_drop not in new_metadata.tables['table'].columns
+    assert 'city_column' in new_metadata.tables['table'].columns
+    assert len(new_metadata.tables['table'].column_relationships) == 0
+
+
+def test__remove_columns_from_metadata_multi():
+    """Test `_remove_columns_from_metadata` method removes columns from metadata (multi-table)"""
+    # Setup
+    original_metadata = Metadata.load_from_dict({
+        'tables': {
+            'parent': {
+                'primary_key': 'id',
+                'columns': {
+                    'id': {'sdtype': 'id'},
+                    'A': {'sdtype': 'numerical'},
+                    'B': {'sdtype': 'numerical'},
+                },
+                'column_relationships': [{'type': 'gps', 'column_names': ['A', 'B']}],
+            },
+            'child': {
+                'primary_key': 'id',
+                'columns': {
+                    'id': {'sdtype': 'id'},
+                },
+            },
+        },
+        'relationships': [
+            {
+                'parent_table_name': 'parent',
+                'parent_primary_key': 'id',
+                'child_table_name': 'child',
+                'child_foreign_key': 'id',
+            },
+        ],
+    })
+    columns_to_drop = ['A', 'B']
+
+    # Run
+    new_metadata = _remove_columns_from_metadata(
+        metadata=original_metadata,
+        table_name='parent',
+        columns_to_drop=columns_to_drop,
+    )
+
+    # Assert
+    assert isinstance(new_metadata, Metadata)
+    for column in columns_to_drop:
+        assert column in original_metadata.tables['parent'].columns
+        assert column in original_metadata.tables['parent'].column_relationships[0]['column_names']
+
+        assert column not in new_metadata.tables['parent'].columns
+        assert len(new_metadata.tables['parent'].column_relationships) == 0
+
+
+def test__remove_columns_from_metadata_raises_pk():
+    """Test `_remove_columns_from_metadata` method raises an error if primary key is dropped"""
+    # Setup
+    original_metadata = Metadata.load_from_dict({
+        'tables': {
+            'parent': {
+                'primary_key': 'id',
+                'columns': {'id': {'sdtype': 'id'}},
+            },
+        },
+        'relationships': [
+            {
+                'parent_table_name': 'parent',
+                'parent_primary_key': 'id',
+                'child_table_name': 'child',
+                'child_foreign_key': 'id',
+            },
+        ],
+    })
+
+    # Run and Assert
+    cannot_remove_pk = 'Cannot remove primary key from Metadata'
+    with pytest.raises(ValueError, match=cannot_remove_pk):
+        _remove_columns_from_metadata(
+            metadata=original_metadata,
+            table_name='parent',
+            columns_to_drop=['id'],
+        )
+
+
+def test__is_list_of_strings():
+    """Test `_is_list_of_strings` method"""
+    assert _is_list_of_strings(['a', 'b'])
+    assert not _is_list_of_strings(['a', 1])
+    assert not _is_list_of_strings([1, 2])
+    assert not _is_list_of_strings(1)
+    assert not _is_list_of_strings('a')

--- a/tests/unit/cag/test_base.py
+++ b/tests/unit/cag/test_base.py
@@ -82,8 +82,8 @@ class TestBasePattern:
         """Test ``validate`` validates data and metadata."""
         # Setup
         instance = BasePattern()
-        instance._validate_pattern_with_data = Mock()
-        instance._validate_pattern_with_metadata = Mock()
+        instance._validate_constraint_with_data = Mock()
+        instance._validate_constraint_with_metadata = Mock()
         expected_msg = re.escape('Pattern must be fit before validating without metadata.')
         data_mock = Mock()
         metadata_mock = Mock()
@@ -95,8 +95,8 @@ class TestBasePattern:
         instance.validate(data_mock, metadata_mock)
 
         # Assert
-        instance._validate_pattern_with_metadata.assert_called_once_with(metadata_mock)
-        instance._validate_pattern_with_data.assert_called_once_with(data_mock, metadata_mock)
+        instance._validate_constraint_with_metadata.assert_called_once_with(metadata_mock)
+        instance._validate_constraint_with_data.assert_called_once_with(data_mock, metadata_mock)
 
     def test_validate_after_fitting(self):
         """Test ``validate`` validates with metadata after being fitted."""
@@ -104,14 +104,14 @@ class TestBasePattern:
         instance = BasePattern()
         instance._fitted = True
         instance.metadata = Mock()
-        instance._validate_pattern_with_data = Mock()
-        instance._validate_pattern_with_metadata = Mock()
+        instance._validate_constraint_with_data = Mock()
+        instance._validate_constraint_with_metadata = Mock()
 
         # Run
         instance.validate()
 
         # Assert
-        instance._validate_pattern_with_metadata.assert_called_once_with(instance.metadata)
+        instance._validate_constraint_with_metadata.assert_called_once_with(instance.metadata)
 
     def test_validate_single_table(self):
         """Test ``validate`` handles single table data."""
@@ -119,8 +119,8 @@ class TestBasePattern:
         instance = BasePattern()
         instance._single_table = True
         instance._table_name = 'table1'
-        instance._validate_pattern_with_data = Mock()
-        instance._validate_pattern_with_metadata = Mock()
+        instance._validate_constraint_with_data = Mock()
+        instance._validate_constraint_with_metadata = Mock()
         data_mock = Mock(spec=pd.DataFrame)
         metadata_mock = Mock()
 
@@ -128,8 +128,8 @@ class TestBasePattern:
         instance.validate(data_mock, metadata_mock)
 
         # Assert
-        instance._validate_pattern_with_metadata.assert_called_once_with(metadata_mock)
-        instance._validate_pattern_with_data.assert_called_once_with(
+        instance._validate_constraint_with_metadata.assert_called_once_with(metadata_mock)
+        instance._validate_constraint_with_data.assert_called_once_with(
             {'table1': data_mock}, metadata_mock
         )
 
@@ -152,8 +152,8 @@ class TestBasePattern:
         """Test ``fit`` method."""
         # Setup
         instance = BasePattern()
-        instance._validate_pattern_with_metadata = Mock()
-        instance._validate_pattern_with_data = Mock()
+        instance._validate_constraint_with_metadata = Mock()
+        instance._validate_constraint_with_data = Mock()
         instance._fit = Mock()
         metadata = Metadata.load_from_dict({
             'tables': {
@@ -169,8 +169,8 @@ class TestBasePattern:
 
         # Assert
         assert instance.metadata == metadata
-        instance._validate_pattern_with_metadata.assert_called_once_with(metadata)
-        instance._validate_pattern_with_data.assert_called_once_with(data, metadata)
+        instance._validate_constraint_with_metadata.assert_called_once_with(metadata)
+        instance._validate_constraint_with_data.assert_called_once_with(data, metadata)
         instance._fit.assert_called_once_with(data, metadata)
         assert instance._dtypes == {
             'table1': {'col1': 'int64', 'col2': 'object', 'col3': 'float64'},
@@ -186,8 +186,8 @@ class TestBasePattern:
         # Setup
         instance = BasePattern()
         instance.table_name = 'table1'
-        instance._validate_pattern_with_metadata = Mock()
-        instance._validate_pattern_with_data = Mock()
+        instance._validate_constraint_with_metadata = Mock()
+        instance._validate_constraint_with_data = Mock()
         instance._fit = Mock()
         metadata = Metadata.load_from_dict({
             'tables': {
@@ -204,8 +204,8 @@ class TestBasePattern:
         assert instance._single_table is True
         assert instance._table_name == 'table1'
         assert instance.metadata == metadata
-        instance._validate_pattern_with_metadata.assert_called_once_with(metadata)
-        instance._validate_pattern_with_data.assert_called_once_with(
+        instance._validate_constraint_with_metadata.assert_called_once_with(metadata)
+        instance._validate_constraint_with_data.assert_called_once_with(
             DataFrameDictMatcher({'table1': data['table1']}), metadata
         )
         instance._fit.assert_called_once_with(

--- a/tests/unit/cag/test_base.py
+++ b/tests/unit/cag/test_base.py
@@ -1,0 +1,370 @@
+"""Test BasePattern Class."""
+
+import re
+from copy import deepcopy
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from sdv.cag.base import BasePattern
+from sdv.errors import NotFittedError
+from sdv.metadata import Metadata
+from tests.utils import DataFrameDictMatcher
+
+
+@pytest.fixture
+def data():
+    return {
+        'table1': pd.DataFrame({
+            'col1': range(5),
+            'col2': ['A', 'A', 'A', 'B', 'B'],
+            'col3': [0.0, 0.1, 0.2, 0.3, 0.4],
+        }),
+        'table2': pd.DataFrame({'col4': range(5, 10), 'col5': ['X', 'Y', 'Z', 'Z', 'X']}),
+    }
+
+
+class TestBasePattern:
+    def test___init__(self):
+        """Test the ``__init__`` method."""
+        # Setup
+        instance = BasePattern()
+
+        # Assert
+        assert instance._fitted is False
+        assert instance.metadata is None
+
+    def test__get_single_table_name(self):
+        """Test the ``_get_single_table_name`` helper method."""
+        # Setup
+        instance = BasePattern()
+        instance.table_name = None
+        single_table_metadata = Metadata.load_from_dict({
+            'tables': {
+                'table1': {'columns': {'col4': {}, 'col5': {}}},
+            }
+        })
+        multi_table_metadata = Metadata.load_from_dict({
+            'tables': {
+                'table1': {
+                    'columns': {'col1': {}, 'col2': {}, 'col3': {}},
+                },
+                'table2': {'columns': {'col4': {}, 'col5': {}}},
+            }
+        })
+
+        # Run
+        from_single_table_name = instance._get_single_table_name(single_table_metadata)
+        instance.table_name = 'table2'
+        from_multi_table_name = instance._get_single_table_name(multi_table_metadata)
+
+        # Assert
+        assert from_single_table_name == 'table1'
+        assert from_multi_table_name == 'table2'
+
+    def test__get_single_table_name_errors_if_no_table_name_attr(self):
+        """Test ``_get_single_table_name`` errors if ``table_name`` does not exist."""
+        # Setup
+        instance = BasePattern()
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table1': {'columns': {'col4': {}, 'col5': {}}},
+            }
+        })
+
+        # Run and assert
+        error_msg = re.escape('No ``table_name`` attribute has been set.')
+        with pytest.raises(ValueError, match=error_msg):
+            instance._get_single_table_name(metadata)
+
+    def test_validate(self):
+        """Test ``validate`` validates data and metadata."""
+        # Setup
+        instance = BasePattern()
+        instance._validate_pattern_with_data = Mock()
+        instance._validate_pattern_with_metadata = Mock()
+        expected_msg = re.escape('Pattern must be fit before validating without metadata.')
+        data_mock = Mock()
+        metadata_mock = Mock()
+
+        # Run
+        with pytest.raises(NotFittedError, match=expected_msg):
+            instance.validate()
+
+        instance.validate(data_mock, metadata_mock)
+
+        # Assert
+        instance._validate_pattern_with_metadata.assert_called_once_with(metadata_mock)
+        instance._validate_pattern_with_data.assert_called_once_with(data_mock, metadata_mock)
+
+    def test_validate_after_fitting(self):
+        """Test ``validate`` validates with metadata after being fitted."""
+        # Setup
+        instance = BasePattern()
+        instance._fitted = True
+        instance.metadata = Mock()
+        instance._validate_pattern_with_data = Mock()
+        instance._validate_pattern_with_metadata = Mock()
+
+        # Run
+        instance.validate()
+
+        # Assert
+        instance._validate_pattern_with_metadata.assert_called_once_with(instance.metadata)
+
+    def test_validate_single_table(self):
+        """Test ``validate`` handles single table data."""
+        # Setup
+        instance = BasePattern()
+        instance._single_table = True
+        instance._table_name = 'table1'
+        instance._validate_pattern_with_data = Mock()
+        instance._validate_pattern_with_metadata = Mock()
+        data_mock = Mock()
+        metadata_mock = Mock()
+
+        # Run
+        instance.validate(data_mock, metadata_mock)
+
+        # Assert
+        instance._validate_pattern_with_metadata.assert_called_once_with(metadata_mock)
+        instance._validate_pattern_with_data.assert_called_once_with(
+            {'table1': data_mock}, metadata_mock
+        )
+
+    def test_get_updated_metadata(self):
+        """Test method calls private ``_get_updated_metadata`` method."""
+        # Setup
+        instance = BasePattern()
+        metadata = Mock()
+        instance._get_updated_metadata = Mock()
+        instance.validate = Mock()
+
+        # Run
+        instance.get_updated_metadata(metadata)
+
+        # Assert
+        instance.validate.assert_called_once_with(metadata=metadata)
+        instance._get_updated_metadata.assert_called_once()
+
+    def test_fit(self, data):
+        """Test ``fit`` method."""
+        # Setup
+        instance = BasePattern()
+        instance._validate_pattern_with_metadata = Mock()
+        instance._validate_pattern_with_data = Mock()
+        instance._fit = Mock()
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table1': {
+                    'columns': {'col1': {}, 'col2': {}, 'col3': {}},
+                },
+                'table2': {'columns': {'col4': {}, 'col5': {}}},
+            }
+        })
+
+        # Run
+        instance.fit(data, metadata)
+
+        # Assert
+        assert instance.metadata == metadata
+        instance._validate_pattern_with_metadata.assert_called_once_with(metadata)
+        instance._validate_pattern_with_data.assert_called_once_with(data, metadata)
+        instance._fit.assert_called_once_with(data, metadata)
+        assert instance._dtypes == {
+            'table1': {'col1': 'int64', 'col2': 'object', 'col3': 'float64'},
+            'table2': {'col4': 'int64', 'col5': 'object'},
+        }
+        assert instance._original_data_columns == {
+            'table1': ['col1', 'col2', 'col3'],
+            'table2': ['col4', 'col5'],
+        }
+
+    def test_fit_single_table(self, data):
+        """Test ``fit`` method with a single table."""
+        # Setup
+        instance = BasePattern()
+        instance.table_name = 'table1'
+        instance._validate_pattern_with_metadata = Mock()
+        instance._validate_pattern_with_data = Mock()
+        instance._fit = Mock()
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table1': {
+                    'columns': {'col1': {}, 'col2': {}, 'col3': {}},
+                }
+            }
+        })
+
+        # Run
+        instance.fit(data['table1'], metadata)
+
+        # Assert
+        assert instance._single_table is True
+        assert instance._table_name == 'table1'
+        assert instance.metadata == metadata
+        instance._validate_pattern_with_metadata.assert_called_once_with(metadata)
+        instance._validate_pattern_with_data.assert_called_once_with(
+            DataFrameDictMatcher({'table1': data['table1']}), metadata
+        )
+        instance._fit.assert_called_once_with(
+            DataFrameDictMatcher({'table1': data['table1']}), metadata
+        )
+        assert instance._dtypes == {
+            'table1': {'col1': 'int64', 'col2': 'object', 'col3': 'float64'},
+        }
+        assert instance._original_data_columns == {
+            'table1': ['col1', 'col2', 'col3'],
+        }
+
+    def test_transform(self, data):
+        """Test ``transform`` method."""
+        # Setup
+        instance = BasePattern()
+        instance._fitted = True
+        instance.validate = Mock()
+        instance._transform = Mock()
+        instance.metadata = Mock()
+
+        # Run
+        instance.transform(data)
+
+        # Assert
+        instance.validate.assert_called_once_with(DataFrameDictMatcher(data))
+        instance._transform.assert_called_once_with(DataFrameDictMatcher(data))
+
+    def test_transform_single_table(self, data):
+        """Test ``transform`` method with a single table."""
+        # Setup
+        data = data['table1']
+        instance = BasePattern()
+        instance._fitted = True
+        instance._single_table = True
+        instance._table_name = 'table1'
+        instance.validate = Mock()
+        instance._transform = Mock()
+        instance._transform.return_value = {'table1': data}
+        instance.metadata = Mock()
+
+        # Run
+        transformed = instance.transform(data)
+
+        # Assert
+        instance.validate.assert_called_once_with(data)
+        instance._transform.assert_called_once_with(DataFrameDictMatcher({'table1': data}))
+        pd.testing.assert_frame_equal(transformed, data)
+
+    def test_transform_not_fitted(self, data):
+        """Test ``transform`` method errors before pattern has been fit."""
+        # Setup
+        instance = BasePattern()
+        expected_msg = re.escape('Pattern must be fit using ``fit`` before transforming.')
+
+        # Run and Assert
+        with pytest.raises(NotFittedError, match=expected_msg):
+            instance.transform(data)
+
+    def test_reverse_transform(self, data):
+        """Test ``reverse_transform`` method."""
+        # Setup
+        instance = BasePattern()
+        instance._dtypes = {
+            'table1': {'col1': 'float64', 'col2': 'object', 'col3': 'float64'},
+            'table2': {'col4': 'object', 'col5': 'object'},
+        }
+        instance._original_data_columns = {
+            'table1': ['col3', 'col2', 'col1'],
+            'table2': ['col4', 'col5'],
+        }
+        instance._reverse_transform = Mock()
+        instance._reverse_transform.return_value = deepcopy(data)
+
+        # Run
+        reversed_data = instance.reverse_transform(data)
+
+        # Assert
+        instance._reverse_transform.assert_called_once_with(DataFrameDictMatcher(data))
+        assert set(reversed_data.keys()) == {'table1', 'table2'}
+        expected_table1 = pd.DataFrame({
+            'col3': [0.0, 0.1, 0.2, 0.3, 0.4],
+            'col2': ['A', 'A', 'A', 'B', 'B'],
+            'col1': [0.0, 1.0, 2.0, 3.0, 4.0],
+        })
+        expected_table2 = pd.DataFrame(
+            {'col4': [5, 6, 7, 8, 9], 'col5': ['X', 'Y', 'Z', 'Z', 'X']}, dtype='object'
+        )
+        pd.testing.assert_frame_equal(reversed_data['table1'], expected_table1)
+        pd.testing.assert_frame_equal(reversed_data['table2'], expected_table2)
+
+    def test_reverse_transform_single_table(self, data):
+        """Test ``reverse_transform`` method with single table data."""
+        # Setup
+        data = data['table1']
+        instance = BasePattern()
+        instance._single_table = True
+        instance._table_name = 'table1'
+        instance._dtypes = {
+            'table1': {'col1': 'float64', 'col2': 'object', 'col3': 'float64'},
+        }
+        instance._original_data_columns = {
+            'table1': ['col3', 'col2', 'col1'],
+        }
+        instance._reverse_transform = Mock()
+        instance._reverse_transform.return_value = {'table1': data.copy()}
+
+        # Run
+        reversed_data = instance.reverse_transform(data)
+
+        # Assert
+        instance._reverse_transform.assert_called_once_with(DataFrameDictMatcher({'table1': data}))
+        expected_table1 = pd.DataFrame({
+            'col3': [0.0, 0.1, 0.2, 0.3, 0.4],
+            'col2': ['A', 'A', 'A', 'B', 'B'],
+            'col1': [0.0, 1.0, 2.0, 3.0, 4.0],
+        })
+        pd.testing.assert_frame_equal(reversed_data, expected_table1)
+
+    def test_is_valid_errors_if_not_fitted(self, data):
+        """Test the ``is_valid`` method errors if the CAG has not been fit."""
+        # Setup
+        instance = BasePattern()
+        expected_msg = re.escape(
+            'Pattern must be fit using ``fit`` before determining if data is valid.'
+        )
+
+        # Run and assert
+        with pytest.raises(NotFittedError, match=expected_msg):
+            instance.is_valid(data)
+
+    def test_is_valid(self, data):
+        """Test ``is_valid`` calls the ``_is_valid`` method and returns its result."""
+        # Setup
+        instance = BasePattern()
+        instance._is_valid = Mock()
+        instance._fitted = True
+
+        # Run
+        is_valid_result = instance.is_valid(data)
+
+        # Assert
+        instance._is_valid.assert_called_once_with(data)
+        assert is_valid_result == instance._is_valid.return_value
+
+    def test_is_valid_single_table(self, data):
+        """Test ``is_valid`` with single table data."""
+        # Setup
+        data = data['table1']
+        instance = BasePattern()
+        instance._single_table = True
+        instance._table_name = 'table1'
+        instance._is_valid = Mock()
+        instance._is_valid.return_value = {'table1': data.copy()}
+        instance._fitted = True
+
+        # Run
+        is_valid_result = instance.is_valid(data)
+
+        # Assert
+        instance._is_valid.assert_called_once_with(DataFrameDictMatcher({'table1': data}))
+        pd.testing.assert_frame_equal(is_valid_result, data)

--- a/tests/unit/cag/test_base.py
+++ b/tests/unit/cag/test_base.py
@@ -1,4 +1,4 @@
-"""Test BasePattern Class."""
+"""Test BaseConstraint Class."""
 
 import re
 from copy import deepcopy
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 import pandas as pd
 import pytest
 
-from sdv.cag.base import BasePattern
+from sdv.cag.base import BaseConstraint
 from sdv.errors import NotFittedError
 from sdv.metadata import Metadata
 from tests.utils import DataFrameDictMatcher
@@ -25,11 +25,11 @@ def data():
     }
 
 
-class TestBasePattern:
+class TestBaseConstraint:
     def test___init__(self):
         """Test the ``__init__`` method."""
         # Setup
-        instance = BasePattern()
+        instance = BaseConstraint()
 
         # Assert
         assert instance._fitted is False
@@ -38,7 +38,7 @@ class TestBasePattern:
     def test__get_single_table_name(self):
         """Test the ``_get_single_table_name`` helper method."""
         # Setup
-        instance = BasePattern()
+        instance = BaseConstraint()
         instance.table_name = None
         single_table_metadata = Metadata.load_from_dict({
             'tables': {
@@ -66,7 +66,7 @@ class TestBasePattern:
     def test__get_single_table_name_errors_if_no_table_name_attr(self):
         """Test ``_get_single_table_name`` errors if ``table_name`` does not exist."""
         # Setup
-        instance = BasePattern()
+        instance = BaseConstraint()
         metadata = Metadata.load_from_dict({
             'tables': {
                 'table1': {'columns': {'col4': {}, 'col5': {}}},
@@ -81,10 +81,10 @@ class TestBasePattern:
     def test_validate(self):
         """Test ``validate`` validates data and metadata."""
         # Setup
-        instance = BasePattern()
+        instance = BaseConstraint()
         instance._validate_constraint_with_data = Mock()
         instance._validate_constraint_with_metadata = Mock()
-        expected_msg = re.escape('Pattern must be fit before validating without metadata.')
+        expected_msg = re.escape('Constraint must be fit before validating without metadata.')
         data_mock = Mock()
         metadata_mock = Mock()
 
@@ -101,7 +101,7 @@ class TestBasePattern:
     def test_validate_after_fitting(self):
         """Test ``validate`` validates with metadata after being fitted."""
         # Setup
-        instance = BasePattern()
+        instance = BaseConstraint()
         instance._fitted = True
         instance.metadata = Mock()
         instance._validate_constraint_with_data = Mock()
@@ -116,7 +116,7 @@ class TestBasePattern:
     def test_validate_single_table(self):
         """Test ``validate`` handles single table data."""
         # Setup
-        instance = BasePattern()
+        instance = BaseConstraint()
         instance._single_table = True
         instance._table_name = 'table1'
         instance._validate_constraint_with_data = Mock()
@@ -136,7 +136,7 @@ class TestBasePattern:
     def test_get_updated_metadata(self):
         """Test method calls private ``_get_updated_metadata`` method."""
         # Setup
-        instance = BasePattern()
+        instance = BaseConstraint()
         metadata = Mock()
         instance._get_updated_metadata = Mock()
         instance.validate = Mock()
@@ -151,7 +151,7 @@ class TestBasePattern:
     def test_fit(self, data):
         """Test ``fit`` method."""
         # Setup
-        instance = BasePattern()
+        instance = BaseConstraint()
         instance._validate_constraint_with_metadata = Mock()
         instance._validate_constraint_with_data = Mock()
         instance._fit = Mock()
@@ -184,7 +184,7 @@ class TestBasePattern:
     def test_fit_single_table(self, data):
         """Test ``fit`` method with a single table."""
         # Setup
-        instance = BasePattern()
+        instance = BaseConstraint()
         instance.table_name = 'table1'
         instance._validate_constraint_with_metadata = Mock()
         instance._validate_constraint_with_data = Mock()
@@ -221,7 +221,7 @@ class TestBasePattern:
     def test_transform(self, data):
         """Test ``transform`` method."""
         # Setup
-        instance = BasePattern()
+        instance = BaseConstraint()
         instance._fitted = True
         instance.validate = Mock()
         instance._transform = Mock()
@@ -238,7 +238,7 @@ class TestBasePattern:
         """Test ``transform`` method with a single table."""
         # Setup
         data = data['table1']
-        instance = BasePattern()
+        instance = BaseConstraint()
         instance._fitted = True
         instance._single_table = True
         instance._table_name = 'table1'
@@ -258,8 +258,8 @@ class TestBasePattern:
     def test_transform_not_fitted(self, data):
         """Test ``transform`` method errors before constraint has been fit."""
         # Setup
-        instance = BasePattern()
-        expected_msg = re.escape('Pattern must be fit using ``fit`` before transforming.')
+        instance = BaseConstraint()
+        expected_msg = re.escape('Constraint must be fit using ``fit`` before transforming.')
 
         # Run and Assert
         with pytest.raises(NotFittedError, match=expected_msg):
@@ -268,7 +268,7 @@ class TestBasePattern:
     def test_reverse_transform(self, data):
         """Test ``reverse_transform`` method."""
         # Setup
-        instance = BasePattern()
+        instance = BaseConstraint()
         instance._dtypes = {
             'table1': {'col1': 'float64', 'col2': 'object', 'col3': 'float64'},
             'table2': {'col4': 'object', 'col5': 'object'},
@@ -301,7 +301,7 @@ class TestBasePattern:
         """Test ``reverse_transform`` method with single table data."""
         # Setup
         data = data['table1']
-        instance = BasePattern()
+        instance = BaseConstraint()
         instance._single_table = True
         instance._table_name = 'table1'
         instance._dtypes = {
@@ -328,9 +328,9 @@ class TestBasePattern:
     def test_is_valid_errors_if_not_fitted(self, data):
         """Test the ``is_valid`` method errors if the CAG has not been fit."""
         # Setup
-        instance = BasePattern()
+        instance = BaseConstraint()
         expected_msg = re.escape(
-            'Pattern must be fit using ``fit`` before determining if data is valid.'
+            'Constraint must be fit using ``fit`` before determining if data is valid.'
         )
 
         # Run and assert
@@ -340,7 +340,7 @@ class TestBasePattern:
     def test_is_valid(self, data):
         """Test ``is_valid`` calls the ``_is_valid`` method and returns its result."""
         # Setup
-        instance = BasePattern()
+        instance = BaseConstraint()
         instance._is_valid = Mock()
         instance._fitted = True
 
@@ -355,7 +355,7 @@ class TestBasePattern:
         """Test ``is_valid`` with single table data."""
         # Setup
         data = data['table1']
-        instance = BasePattern()
+        instance = BaseConstraint()
         instance._single_table = True
         instance._table_name = 'table1'
         instance._is_valid = Mock()

--- a/tests/unit/cag/test_base.py
+++ b/tests/unit/cag/test_base.py
@@ -121,7 +121,7 @@ class TestBasePattern:
         instance._table_name = 'table1'
         instance._validate_pattern_with_data = Mock()
         instance._validate_pattern_with_metadata = Mock()
-        data_mock = Mock()
+        data_mock = Mock(spec=pd.DataFrame)
         metadata_mock = Mock()
 
         # Run

--- a/tests/unit/cag/test_base.py
+++ b/tests/unit/cag/test_base.py
@@ -256,7 +256,7 @@ class TestBasePattern:
         pd.testing.assert_frame_equal(transformed, data)
 
     def test_transform_not_fitted(self, data):
-        """Test ``transform`` method errors before pattern has been fit."""
+        """Test ``transform`` method errors before constraint has been fit."""
         # Setup
         instance = BasePattern()
         expected_msg = re.escape('Pattern must be fit using ``fit`` before transforming.')

--- a/tests/unit/cag/test_fixed_combinations.py
+++ b/tests/unit/cag/test_fixed_combinations.py
@@ -1,4 +1,4 @@
-"""Unit tests for FixedCombinations CAG constraint."""
+"""Unit tests for FixedCombinations constraint."""
 
 import re
 from unittest.mock import call, patch
@@ -54,7 +54,7 @@ class TestFixedCombinations:
             FixedCombinations(column_names=['col1', 'col2'], table_name=bad_table_name)
 
     @patch('sdv.cag.fixed_combinations._validate_table_and_column_names')
-    def test__validate_pattern_with_metadata(self, validate_table_and_col_names_mock):
+    def test__validate_constraint_with_metadata(self, validate_table_and_col_names_mock):
         """Test validating the constraint with metadata."""
         # Setup
         instance = FixedCombinations(['col1', 'col2'])
@@ -74,10 +74,10 @@ class TestFixedCombinations:
         })
 
         # Run
-        instance._validate_pattern_with_metadata(metadata)
+        instance._validate_constraint_with_metadata(metadata)
 
     @patch('sdv.cag.fixed_combinations._validate_table_and_column_names')
-    def test__validate_pattern_with_metadata_bad_col_sdtype(
+    def test__validate_constraint_with_metadata_bad_col_sdtype(
         self, validate_table_and_col_names_mock
     ):
         """Test validating the constraint with metadata."""
@@ -101,10 +101,10 @@ class TestFixedCombinations:
             "must be either 'boolean' or 'categorical'."
         )
         with pytest.raises(ConstraintNotMetError, match=expected_msg):
-            instance._validate_pattern_with_metadata(metadata)
+            instance._validate_constraint_with_metadata(metadata)
 
     @patch('sdv.cag.fixed_combinations._validate_table_and_column_names')
-    def test__validate_pattern_with_metadata_col_relationship(
+    def test__validate_constraint_with_metadata_col_relationship(
         self, validate_table_and_col_names_mock
     ):
         """Test validating the constraint with metadata."""
@@ -130,7 +130,7 @@ class TestFixedCombinations:
             "Cannot apply constraint because columns ['col2'] are part of a column relationship."
         )
         with pytest.raises(ConstraintNotMetError, match=expected_msg):
-            instance._validate_pattern_with_metadata(metadata)
+            instance._validate_constraint_with_metadata(metadata)
 
     def test__get_updated_metadata(self):
         """Test the ``_get_updated_metadata`` method."""

--- a/tests/unit/cag/test_fixed_combinations.py
+++ b/tests/unit/cag/test_fixed_combinations.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from sdv.cag import FixedCombinations
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.metadata import Metadata
 
 
@@ -100,7 +100,7 @@ class TestFixedCombinations:
             "Column 'col2' has an incompatible sdtype ('id'). The column sdtype "
             "must be either 'boolean' or 'categorical'."
         )
-        with pytest.raises(PatternNotMetError, match=expected_msg):
+        with pytest.raises(ConstraintNotMetError, match=expected_msg):
             instance._validate_pattern_with_metadata(metadata)
 
     @patch('sdv.cag.fixed_combinations._validate_table_and_column_names')
@@ -129,7 +129,7 @@ class TestFixedCombinations:
         expected_msg = re.escape(
             "Cannot apply constraint because columns ['col2'] are part of a column relationship."
         )
-        with pytest.raises(PatternNotMetError, match=expected_msg):
+        with pytest.raises(ConstraintNotMetError, match=expected_msg):
             instance._validate_pattern_with_metadata(metadata)
 
     def test__get_updated_metadata(self):

--- a/tests/unit/cag/test_fixed_combinations.py
+++ b/tests/unit/cag/test_fixed_combinations.py
@@ -1,0 +1,326 @@
+"""Unit tests for FixedCombinations CAG pattern."""
+
+import re
+from unittest.mock import call, patch
+
+import pandas as pd
+import pytest
+
+from sdv.cag import FixedCombinations
+from sdv.cag._errors import PatternNotMetError
+from sdv.metadata import Metadata
+
+
+class TestFixedCombinations:
+    def test___init__(self):
+        """Test the ``__init__`` method."""
+        # Setup
+        column_names = ['col1', 'col2', 'col3']
+        table_name = 'table'
+
+        # Run
+        instance = FixedCombinations(column_names, table_name=table_name)
+
+        # Assert
+        assert instance.column_names == column_names
+        assert instance.table_name == table_name
+        assert instance._joint_column == 'col1#col2#col3'
+        assert instance._combinations is None
+
+    def test___init___invalid_parameters(self):
+        """Test the ``__init__`` method errors with invalid arguments."""
+        # Setup
+        bad_column_names_type = 'col1'
+        bad_column_names = ['col1', 2]
+        short_column_names = ['col1']
+        bad_table_name = 1
+
+        # Run and assert
+        bad_column_names_msg = re.escape('`column_names` must be a list of strings.')
+        with pytest.raises(ValueError, match=bad_column_names_msg):
+            FixedCombinations(bad_column_names_type)
+
+        with pytest.raises(ValueError, match=bad_column_names_msg):
+            FixedCombinations(bad_column_names)
+
+        short_column_names_msg = re.escape(
+            'FixedCombinations pattern requires at least two columns.'
+        )
+        with pytest.raises(ValueError, match=short_column_names_msg):
+            FixedCombinations(short_column_names)
+
+        bad_table_name_msg = re.escape('`table_name` must be a string or None.')
+        with pytest.raises(ValueError, match=bad_table_name_msg):
+            FixedCombinations(column_names=['col1', 'col2'], table_name=bad_table_name)
+
+    @patch('sdv.cag.fixed_combinations._validate_table_and_column_names')
+    def test__validate_pattern_with_metadata(self, validate_table_and_col_names_mock):
+        """Test validating the pattern with metadata."""
+        # Setup
+        instance = FixedCombinations(['col1', 'col2'])
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'col1': {'sdtype': 'boolean'},
+                        'col2': {'sdtype': 'categorical'},
+                        'col3': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['col1', 'col2']}
+                    ],
+                }
+            }
+        })
+
+        # Run
+        instance._validate_pattern_with_metadata(metadata)
+
+    @patch('sdv.cag.fixed_combinations._validate_table_and_column_names')
+    def test__validate_pattern_with_metadata_bad_col_sdtype(
+        self, validate_table_and_col_names_mock
+    ):
+        """Test validating the pattern with metadata."""
+        # Setup
+        instance = FixedCombinations(['col1', 'col2'])
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'col1': {'sdtype': 'boolean'},
+                        'col2': {'sdtype': 'id'},
+                        'col3': {'sdtype': 'id'},
+                    }
+                }
+            }
+        })
+
+        # Run and assert
+        expected_msg = re.escape(
+            "Column 'col2' has an incompatible sdtype ('id'). The column sdtype "
+            "must be either 'boolean' or 'categorical'."
+        )
+        with pytest.raises(PatternNotMetError, match=expected_msg):
+            instance._validate_pattern_with_metadata(metadata)
+
+    @patch('sdv.cag.fixed_combinations._validate_table_and_column_names')
+    def test__validate_pattern_with_metadata_col_relationship(
+        self, validate_table_and_col_names_mock
+    ):
+        """Test validating the pattern with metadata."""
+        # Setup
+        instance = FixedCombinations(['col1', 'col2'])
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'col1': {'sdtype': 'boolean'},
+                        'col2': {'sdtype': 'categorical'},
+                        'col3': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['col2', 'col3']}
+                    ],
+                }
+            }
+        })
+
+        # Run and assert
+        expected_msg = re.escape(
+            "Cannot apply pattern because columns ['col2'] are part of a column relationship."
+        )
+        with pytest.raises(PatternNotMetError, match=expected_msg):
+            instance._validate_pattern_with_metadata(metadata)
+
+    def test__get_updated_metadata(self):
+        """Test the ``_get_updated_metadata`` method."""
+        # Setup
+        instance = FixedCombinations(['col1', 'col2'])
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'col1': {'sdtype': 'boolean'},
+                        'col2': {'sdtype': 'categorical'},
+                        'col3': {'sdtype': 'id'},
+                        'col4': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['col2', 'col3']},
+                        {'type': 'relationship', 'column_names': ['col3', 'col4']},
+                    ],
+                }
+            }
+        })
+
+        # Run
+        updated_metadata = instance._get_updated_metadata(metadata)
+
+        # Assert
+        expected_metadata_dict = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'col3': {'sdtype': 'id'},
+                        'col4': {'sdtype': 'id'},
+                        'col1#col2': {'sdtype': 'categorical'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['col3', 'col4']}
+                    ],
+                }
+            }
+        }).to_dict()
+        assert updated_metadata.to_dict() == expected_metadata_dict
+
+    @patch('sdv.cag.fixed_combinations.get_mappable_combination')
+    def test__fit(self, get_mappable_combination_mock):
+        """Test the ``FixedCombinations._fit`` method."""
+        # Setup
+        columns = ['b', 'c']
+        instance = FixedCombinations(column_names=columns)
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'a': {'sdtype': 'id'},
+                        'b': {'sdtype': 'id'},
+                        'c': {'sdtype': 'categorical'},
+                        'b#c': {'sdtype': 'categorical'},
+                    },
+                }
+            }
+        })
+        data = {
+            'table': pd.DataFrame({
+                'a': ['a', 'b', 'c'],
+                'b': ['d', 'e', 'f'],
+                'c': ['g', 'h', 'i'],
+                'b#c': ['1', '2', '3'],
+            })
+        }
+
+        # Run
+        instance._fit(data, metadata)
+
+        # Asserts
+        expected_combinations = pd.DataFrame({'b': ['d', 'e', 'f'], 'c': ['g', 'h', 'i']})
+        expected_calls = [
+            call(combination)
+            for combination in instance._combinations.itertuples(index=False, name=None)
+        ]
+        assert instance._joint_column == 'b#c_'
+        pd.testing.assert_frame_equal(instance._combinations, expected_combinations)
+        assert get_mappable_combination_mock.call_args_list == expected_calls
+
+    @patch('sdv.cag.fixed_combinations.uuid')
+    def test__transform(self, mock_uuid):
+        """Test the ``FixedCombinations.transform`` method."""
+        # Setup
+        mock_uuid.uuid5.side_effect = ['combination1', 'combination2', 'combination3']
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'a': {'sdtype': 'categorical'},
+                        'b': {'sdtype': 'categorical'},
+                        'c': {'sdtype': 'categorical'},
+                        'd': {'sdtype': 'categorical'},
+                    }
+                }
+            }
+        })
+        data = pd.DataFrame({
+            'a': ['a', 'b', 'c'],
+            'b': [1, 2, 3],
+            'c': ['g', 'h', 'i'],
+            'd': [2.4, 1.23, 5.6],
+        })
+        columns = ['b', 'c', 'd']
+        instance = FixedCombinations(column_names=columns)
+        instance.fit(data, metadata)
+
+        # Run
+        out = instance.transform(data)
+
+        # Assert
+        assert instance._combinations_to_uuids is not None
+        assert instance._uuids_to_combinations is not None
+        expected_out = pd.DataFrame({
+            'a': ['a', 'b', 'c'],
+            'b#c#d': ['combination1', 'combination2', 'combination3'],
+        })
+        pd.testing.assert_frame_equal(expected_out, out)
+
+    def test__reverse_transform(self):
+        """Test the ``FixedCombinations.reverse_transform`` method."""
+        # Setup
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'a': {'sdtype': 'categorical'},
+                        'b': {'sdtype': 'categorical'},
+                        'c': {'sdtype': 'categorical'},
+                        'd': {'sdtype': 'categorical'},
+                    }
+                }
+            }
+        })
+        data = pd.DataFrame({
+            'a': ['a', 'b', 'c'],
+            'b': [1, 2, 3],
+            'c': ['g', 'h', 'i'],
+            'd': [2.4, 1.23, 5.6],
+        })
+        columns = ['b', 'c', 'd']
+        instance = FixedCombinations(column_names=columns)
+        instance.fit(data, metadata)
+
+        # Run
+        transformed_data = instance.transform(data)
+        out = instance.reverse_transform(transformed_data)
+
+        # Assert
+        assert instance._combinations_to_uuids is not None
+        assert instance._uuids_to_combinations is not None
+        pd.testing.assert_frame_equal(data, out)
+
+    def test__is_valid(self):
+        """Test the ``FixedCombinations.is_valid`` method."""
+        # Setup
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'a': {'sdtype': 'categorical'},
+                        'b': {'sdtype': 'categorical'},
+                        'c': {'sdtype': 'categorical'},
+                        'd': {'sdtype': 'categorical'},
+                    }
+                }
+            }
+        })
+        data = pd.DataFrame({
+            'a': ['a', 'b', 'c'],
+            'b': ['d', 'e', 'f'],
+            'c': ['g', 'h', 'i'],
+        })
+        invalid_data = pd.DataFrame({
+            'a': ['a', 'b', 'c'],
+            'b': ['D', 'E', 'F'],
+            'c': ['g', 'h', 'i'],
+        })
+
+        columns = ['b', 'c']
+        instance = FixedCombinations(column_names=columns)
+        instance.fit(data, metadata)
+
+        # Run
+        valid_out = instance.is_valid(data)
+        invalid_out = instance.is_valid(invalid_data)
+
+        # Assert
+        expected_valid_out = pd.Series([True, True, True], name='b#c')
+        pd.testing.assert_series_equal(expected_valid_out, valid_out)
+        pd.testing.assert_series_equal(~expected_valid_out, invalid_out)

--- a/tests/unit/cag/test_fixed_combinations.py
+++ b/tests/unit/cag/test_fixed_combinations.py
@@ -1,4 +1,4 @@
-"""Unit tests for FixedCombinations CAG pattern."""
+"""Unit tests for FixedCombinations CAG constraint."""
 
 import re
 from unittest.mock import call, patch
@@ -44,7 +44,7 @@ class TestFixedCombinations:
             FixedCombinations(bad_column_names)
 
         short_column_names_msg = re.escape(
-            'FixedCombinations pattern requires at least two columns.'
+            'FixedCombinations constraint requires at least two columns.'
         )
         with pytest.raises(ValueError, match=short_column_names_msg):
             FixedCombinations(short_column_names)
@@ -55,7 +55,7 @@ class TestFixedCombinations:
 
     @patch('sdv.cag.fixed_combinations._validate_table_and_column_names')
     def test__validate_pattern_with_metadata(self, validate_table_and_col_names_mock):
-        """Test validating the pattern with metadata."""
+        """Test validating the constraint with metadata."""
         # Setup
         instance = FixedCombinations(['col1', 'col2'])
         metadata = Metadata.load_from_dict({
@@ -80,7 +80,7 @@ class TestFixedCombinations:
     def test__validate_pattern_with_metadata_bad_col_sdtype(
         self, validate_table_and_col_names_mock
     ):
-        """Test validating the pattern with metadata."""
+        """Test validating the constraint with metadata."""
         # Setup
         instance = FixedCombinations(['col1', 'col2'])
         metadata = Metadata.load_from_dict({
@@ -107,7 +107,7 @@ class TestFixedCombinations:
     def test__validate_pattern_with_metadata_col_relationship(
         self, validate_table_and_col_names_mock
     ):
-        """Test validating the pattern with metadata."""
+        """Test validating the constraint with metadata."""
         # Setup
         instance = FixedCombinations(['col1', 'col2'])
         metadata = Metadata.load_from_dict({
@@ -127,7 +127,7 @@ class TestFixedCombinations:
 
         # Run and assert
         expected_msg = re.escape(
-            "Cannot apply pattern because columns ['col2'] are part of a column relationship."
+            "Cannot apply constraint because columns ['col2'] are part of a column relationship."
         )
         with pytest.raises(PatternNotMetError, match=expected_msg):
             instance._validate_pattern_with_metadata(metadata)

--- a/tests/unit/cag/test_fixed_increments.py
+++ b/tests/unit/cag/test_fixed_increments.py
@@ -1,4 +1,4 @@
-"""Unit tests for Fixed Increments CAG constraint."""
+"""Unit tests for Fixed Increments constraint."""
 
 import re
 from unittest.mock import patch
@@ -63,7 +63,7 @@ class TestFixedIncremenets:
         assert instance.table_name == 'table1'
 
     @patch('sdv.cag.fixed_increments._validate_table_and_column_names')
-    def test__validate_pattern_with_metadata(
+    def test__validate_constraint_with_metadata(
         self,
         _validate_table_and_column_names_mock,
     ):
@@ -82,12 +82,12 @@ class TestFixedIncremenets:
         })
 
         # Run
-        instance._validate_pattern_with_metadata(metadata)
+        instance._validate_constraint_with_metadata(metadata)
 
         # Assert
         _validate_table_and_column_names_mock.assert_called_once()
 
-    def test__validate_pattern_with_metadata_incorrect_sdtype(self):
+    def test__validate_constraint_with_metadata_incorrect_sdtype(self):
         """Test it when the sdtype is not numerical."""
         # Setup
         instance = FixedIncrements(column_name='a', increment_value=2)
@@ -108,9 +108,9 @@ class TestFixedIncremenets:
 
         # Run and Assert
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_metadata(metadata)
+            instance._validate_constraint_with_metadata(metadata)
 
-    def test__validate_pattern_with_metadata_invalid_column_name(self):
+    def test__validate_constraint_with_metadata_invalid_column_name(self):
         """Test it when the column name is not in metadata."""
         # Setup
         column_name = 'column'
@@ -129,9 +129,9 @@ class TestFixedIncremenets:
 
         # Run and Assert
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_metadata(metadata)
+            instance._validate_constraint_with_metadata(metadata)
 
-    def test__validate_pattern_with_metadata_no_table_name(self):
+    def test__validate_constraint_with_metadata_no_table_name(self):
         """Test it when table name is undefined and metadata has 2 tables."""
         # Setup
         instance = FixedIncrements(column_name='a', increment_value=2, table_name=None)
@@ -154,7 +154,7 @@ class TestFixedIncremenets:
 
         # Run and Assert
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_metadata(metadata)
+            instance._validate_constraint_with_metadata(metadata)
 
     @pytest.mark.parametrize(
         'values',
@@ -163,7 +163,7 @@ class TestFixedIncremenets:
             [1, 3, 5, 7, 9, 11, 13],
         ],
     )
-    def test__validate_pattern_with_data(self, values):
+    def test__validate_constraint_with_data(self, values):
         """Test it when the data is not divisible by increment value"""
         # Setup
         increment_value = 2
@@ -194,7 +194,7 @@ class TestFixedIncremenets:
 
         # Run and Assert
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
     def test__get_updated_metadata(self):
         """Test the ``_get_updated_metadata`` method."""

--- a/tests/unit/cag/test_fixed_increments.py
+++ b/tests/unit/cag/test_fixed_increments.py
@@ -1,4 +1,4 @@
-"""Unit tests for Fixed Increments CAG pattern."""
+"""Unit tests for Fixed Increments CAG constraint."""
 
 import re
 from unittest.mock import patch
@@ -67,7 +67,7 @@ class TestFixedIncremenets:
         self,
         _validate_table_and_column_names_mock,
     ):
-        """Test validating the pattern with metadata."""
+        """Test validating the constraint with metadata."""
         # Setup
         instance = FixedIncrements(column_name='a', increment_value=5)
         metadata = Metadata.load_from_dict({

--- a/tests/unit/cag/test_fixed_increments.py
+++ b/tests/unit/cag/test_fixed_increments.py
@@ -1,0 +1,392 @@
+"""Unit tests for Fixed Increments CAG pattern."""
+
+import re
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sdv.cag import FixedIncrements
+from sdv.cag._errors import PatternNotMetError
+from sdv.metadata import Metadata
+
+
+class TestFixedIncremenets:
+    def test__validate_init_inputs(self):
+        """Test column_name, increment_value, and table_name type is checked."""
+        # Run and Assert
+        err_msg = '`column_name` must be a string.'
+        with pytest.raises(ValueError, match=err_msg):
+            FixedIncrements(column_name=1, increment_value=10)
+
+        err_msg = 'increment_value` must be an integer or float.'
+        with pytest.raises(ValueError, match=err_msg):
+            FixedIncrements(column_name='a', increment_value='b')
+
+        err_msg = '`table_name` must be a string if not None.'
+        with pytest.raises(ValueError, match=err_msg):
+            FixedIncrements(column_name='a', increment_value=2, table_name=1)
+
+        err_msg = '`increment_value` must be greater than 0.'
+        with pytest.raises(ValueError, match=err_msg):
+            FixedIncrements(column_name='a', increment_value=-1)
+
+        err_msg = '`increment_value` must be a whole number.'
+        with pytest.raises(ValueError, match=err_msg):
+            FixedIncrements(column_name='a', increment_value=1.5)
+
+    def test__init__(self):
+        """Test init sets attributes"""
+        # Setup
+        column_name = 'a'
+
+        # Run
+        instance = FixedIncrements(column_name=column_name, increment_value=10)
+
+        # Asserts
+        assert instance.column_name == 'a'
+        assert instance.table_name is None
+        assert instance._fixed_increments_column_name == f'{column_name}#increment'
+        assert instance._dtype is None
+        assert instance.increment_value == 10
+
+    def test__init__table_name(self):
+        """Test init sets attributes with table_name defined"""
+        # Run
+        instance = FixedIncrements(column_name='a', increment_value=10, table_name='table1')
+
+        # Asserts
+        assert instance.column_name == 'a'
+        assert instance.increment_value == 10
+        assert instance._dtype is None
+        assert instance.table_name == 'table1'
+
+    @patch('sdv.cag.fixed_increments._validate_table_and_column_names')
+    def test__validate_pattern_with_metadata(
+        self,
+        _validate_table_and_column_names_mock,
+    ):
+        """Test validating the pattern with metadata."""
+        # Setup
+        instance = FixedIncrements(column_name='a', increment_value=5)
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'id': {'sdtype': 'id'},
+                        'a': {'sdtype': 'numerical'},
+                    },
+                }
+            }
+        })
+
+        # Run
+        instance._validate_pattern_with_metadata(metadata)
+
+        # Assert
+        _validate_table_and_column_names_mock.assert_called_once()
+
+    def test__validate_pattern_with_metadata_incorrect_sdtype(self):
+        """Test it when the sdtype is not numerical."""
+        # Setup
+        instance = FixedIncrements(column_name='a', increment_value=2)
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'id': {'sdtype': 'id'},
+                        'a': {'sdtype': 'datetime'},
+                    },
+                }
+            }
+        })
+        err_msg = re.escape(
+            "Column 'a' has an incompatible sdtype ('datetime')."
+            "The column sdtype must be 'numerical'."
+        )
+
+        # Run and Assert
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_metadata(metadata)
+
+    def test__validate_pattern_with_metadata_invalid_column_name(self):
+        """Test it when the column name is not in metadata."""
+        # Setup
+        column_name = 'column'
+        instance = FixedIncrements(column_name=column_name, increment_value=2)
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'id': {'sdtype': 'id'},
+                        'a': {'sdtype': 'datetime'},
+                    },
+                }
+            }
+        })
+        err_msg = re.escape(f"Table 'table' is missing columns '{column_name}")
+
+        # Run and Assert
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_metadata(metadata)
+
+    def test__validate_pattern_with_metadata_no_table_name(self):
+        """Test it when table name is undefined and metadata has 2 tables."""
+        # Setup
+        instance = FixedIncrements(column_name='a', increment_value=2, table_name=None)
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'parent': {
+                    'columns': {
+                        'id': {'sdtype': 'id'},
+                        'a': {'sdtype': 'numerical'},
+                    },
+                },
+                'child': {
+                    'columns': {
+                        'id': {'sdtype': 'id'},
+                    },
+                },
+            }
+        })
+        err_msg = re.escape('Metadata contains more than 1 table but no ``table_name`` provided.')
+
+        # Run and Assert
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_metadata(metadata)
+
+    @pytest.mark.parametrize(
+        'values',
+        [
+            [1, 3, 5, 7],
+            [1, 3, 5, 7, 9, 11, 13],
+        ],
+    )
+    def test__validate_pattern_with_data(self, values):
+        """Test it when the data is not divisible by increment value"""
+        # Setup
+        increment_value = 2
+        table_name = 'table1'
+        column_name = 'odd'
+        data = {table_name: pd.DataFrame({column_name: values})}
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                table_name: {
+                    'columns': {
+                        'id': {'sdtype': 'id'},
+                        column_name: {'sdtype': 'numerical'},
+                    },
+                },
+            }
+        })
+        instance = FixedIncrements(
+            column_name=column_name, increment_value=increment_value, table_name=table_name
+        )
+        indices = data[table_name].index.tolist()
+        if len(indices) > 5:
+            indices = '[0, 1, 2, 3, 4, +2 more]'
+        err_msg = re.escape(
+            'The fixed increments requirement has not been met because the data is not '
+            f"evenly divisible by '{increment_value}' "
+            f'for row indices: {indices}'
+        )
+
+        # Run and Assert
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    def test__get_updated_metadata(self):
+        """Test the ``_get_updated_metadata`` method."""
+        # Setup
+        instance = FixedIncrements(column_name='a', increment_value=10)
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'a': {'sdtype': 'numerical'},
+                    },
+                }
+            }
+        })
+
+        # Run
+        updated_metadata = instance._get_updated_metadata(metadata)
+
+        # Assert
+        expected_metadata_dict = Metadata.load_from_dict({
+            'tables': {'table': {'columns': {'a#increment': {'sdtype': 'numerical'}}}},
+        }).to_dict()
+        assert updated_metadata.to_dict() == expected_metadata_dict
+        assert list(metadata.tables['table'].columns.keys()) == ['a']
+
+    @pytest.mark.parametrize(
+        'dtype',
+        [
+            'int8',
+            'int16',
+            'int32',
+            'int64',
+            'Int8',
+            'Int16',
+            'Int32',
+            'Int64',
+            'float16',
+            'float32',
+            'float64',
+            'Float32',
+            'Float64',
+        ],
+    )
+    def test__fit(self, dtype):
+        """Test it learns the correct attributes with different dtypes."""
+        # Setup
+        increment_value = 2
+        table_name = 'table1'
+        column_name = 'even'
+        data = {table_name: pd.DataFrame({column_name: pd.Series([2, 4, 6, 8, 10], dtype=dtype)})}
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                table_name: {
+                    'columns': {
+                        column_name: {'sdtype': 'numerical'},
+                    },
+                },
+            }
+        })
+        instance = FixedIncrements(
+            column_name=column_name, increment_value=increment_value, table_name=table_name
+        )
+
+        # Run
+        instance._fit(data, metadata)
+
+        # Assert
+        assert instance._dtype == dtype
+
+    @pytest.mark.parametrize(
+        'dtype',
+        [
+            'int8',
+            'int16',
+            'int32',
+            'int64',
+            'Int8',
+            'Int16',
+            'Int32',
+            'Int64',
+            'float16',
+            'float32',
+            'float64',
+            'Float32',
+            'Float64',
+        ],
+    )
+    @pytest.mark.parametrize(
+        'increment_value',
+        [2, 2.0],
+    )
+    def test__transform(self, dtype, increment_value):
+        """Test it transforms the data correctly."""
+        # Setup
+        table_name = 'table1'
+        column_name = 'even'
+        values = pd.Series([2, 4, 6, 8, 10], dtype=dtype)
+        data = {table_name: pd.DataFrame({column_name: values})}
+        instance = FixedIncrements(
+            column_name=column_name, increment_value=increment_value, table_name=table_name
+        )
+
+        # Run
+        transform_data = instance._transform(data)
+
+        # Assert
+        expected_transform = pd.DataFrame({'even#increment': pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])})
+        pd.testing.assert_frame_equal(transform_data[table_name], expected_transform)
+
+    def test__transform_nans(self):
+        """Test it transforms the data correctly with nans."""
+        # Setup
+        table_name = 'table1'
+        column_name = 'even'
+        values = pd.Series([2, 4, 6, 8, np.nan], dtype='float64')
+        data = {table_name: pd.DataFrame({column_name: values})}
+        instance = FixedIncrements(
+            column_name=column_name, increment_value=2, table_name=table_name
+        )
+
+        # Run
+        transform_data = instance._transform(data)
+
+        # Assert
+        expected_transform = pd.DataFrame({
+            'even#increment': pd.Series([1.0, 2.0, 3.0, 4.0, np.nan], dtype='float64')
+        })
+        pd.testing.assert_frame_equal(transform_data[table_name], expected_transform)
+
+    def test_transform_existing_column_name(self):
+        """Test ``_transform`` method when ``_fixed_increments_column_name`` already exists."""
+        # Setup
+        instance = FixedIncrements(column_name='a', table_name='table', increment_value=1)
+        table_data = {'table': pd.DataFrame({'a': [1, 2, 3], 'a#increment': [1, 3, 5]})}
+
+        # Run
+        transform_data = instance._transform(table_data)
+
+        # Assert
+        expected_column_name = ['a#increment', 'a#increment_']
+        assert list(transform_data['table'].columns) == expected_column_name
+
+    def test__reverse_transform(self):
+        """Test it reverses the transformation correctly."""
+        # Setup
+        increment_value = 10
+        table_name = 'table1'
+        original_column_name = 'a'
+        transformed_column_name = f'{original_column_name}#increment'
+        transformed_data = {
+            table_name: pd.DataFrame({
+                transformed_column_name: pd.Series([1, 10, 100, 1000, 10000])
+            })
+        }
+        instance = FixedIncrements(
+            column_name=original_column_name, increment_value=increment_value, table_name=table_name
+        )
+        instance._original_data_columns = {table_name: [original_column_name]}
+        instance._dtype = pd.Series([1], dtype='int64').dtype
+        instance._fixed_increments_column_name = transformed_column_name
+        instance._dtypes = {table_name: {original_column_name: pd.Series([1], dtype='int64').dtype}}
+
+        # Run
+        data = instance.reverse_transform(transformed_data)
+
+        # Assert
+        expected_out = pd.DataFrame({original_column_name: [10, 100, 1000, 10000, 100000]})
+        pd.testing.assert_frame_equal(data[table_name], expected_out)
+
+    @pytest.mark.parametrize(
+        'nan',
+        [np.nan, pd.NA],
+    )
+    def test__is_valid(self, nan):
+        """Test it checks if the data is valid."""
+        # Setup
+        table_name = 'table'
+        column_name = 'a'
+        increment_value = 1000
+        table_data = {
+            table_name: pd.DataFrame({
+                column_name: [100, 20000, 55000, 75000, 11000, nan],
+            })
+        }
+        instance = FixedIncrements(
+            column_name=column_name, table_name=table_name, increment_value=increment_value
+        )
+        instance._fitted = True
+
+        # Run
+        out = instance.is_valid(table_data)
+
+        # Assert
+        expected_out = [False, True, True, True, True, True]
+        np.testing.assert_array_equal(expected_out, out[table_name])

--- a/tests/unit/cag/test_fixed_increments.py
+++ b/tests/unit/cag/test_fixed_increments.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 from sdv.cag import FixedIncrements
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.metadata import Metadata
 
 
@@ -107,7 +107,7 @@ class TestFixedIncremenets:
         )
 
         # Run and Assert
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_metadata(metadata)
 
     def test__validate_pattern_with_metadata_invalid_column_name(self):
@@ -128,7 +128,7 @@ class TestFixedIncremenets:
         err_msg = re.escape(f"Table 'table' is missing columns '{column_name}")
 
         # Run and Assert
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_metadata(metadata)
 
     def test__validate_pattern_with_metadata_no_table_name(self):
@@ -153,7 +153,7 @@ class TestFixedIncremenets:
         err_msg = re.escape('Metadata contains more than 1 table but no ``table_name`` provided.')
 
         # Run and Assert
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_metadata(metadata)
 
     @pytest.mark.parametrize(
@@ -193,7 +193,7 @@ class TestFixedIncremenets:
         )
 
         # Run and Assert
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     def test__get_updated_metadata(self):

--- a/tests/unit/cag/test_inequality.py
+++ b/tests/unit/cag/test_inequality.py
@@ -2,7 +2,7 @@
 
 import re
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import Mock, call, patch
 
 import numpy as np
 import pandas as pd
@@ -432,6 +432,7 @@ class TestInequality:
                         'low': {'sdtype': 'numerical'},
                         'col': {'sdtype': 'id'},
                         'low#high': {'sdtype': 'numerical'},
+                        'low#high.nan_component': {'sdtype': 'categorical'},
                     },
                     'column_relationships': [
                         {'type': 'relationship', 'column_names': ['low', 'col']},
@@ -456,6 +457,7 @@ class TestInequality:
             }
         })
         instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+        instance._get_diff_and_nan_column_names = Mock(return_value=('a#b', 'a#b.nan_component'))
 
         # Run
         instance._fit(data, metadata)
@@ -465,6 +467,9 @@ class TestInequality:
         assert instance._dtype == pd.Series([1]).dtype  # exact dtype (32 or 64) depends on OS
         assert instance._low_datetime_format == '%y %m, %d'
         assert instance._high_datetime_format == '%y %m %d'
+        assert instance._diff_column_name == 'a#b'
+        assert instance._nan_column_name == 'a#b.nan_component'
+        instance._get_diff_and_nan_column_names.assert_called_once_with(metadata, 'a#b', 'table')
 
     @pytest.mark.parametrize(
         'dtype',
@@ -537,6 +542,7 @@ class TestInequality:
         }
         instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
         instance._diff_column_name = 'a#b'
+        instance._nan_column_name = 'a#b.nan_component'
 
         # Run
         out = instance._transform(table_data)
@@ -547,6 +553,7 @@ class TestInequality:
             'a': [1, 2, 3],
             'c': [7, 8, 9],
             'a#b': [np.log(4)] * 3,
+            'a#b.nan_component': [None] * 3,
         })
         pd.testing.assert_frame_equal(out, expected_out)
 
@@ -555,6 +562,7 @@ class TestInequality:
         # Setup
         instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
         instance._diff_column_name = 'a#b'
+        instance._nan_column_name = 'a#b.nan_component'
 
         table_data_with_nans = {
             'table': pd.DataFrame({
@@ -581,30 +589,41 @@ class TestInequality:
         expected_output_without_nans = pd.DataFrame({
             'a': [1, 2, 3],
             'a#b': [np.log(2)] * 3,
+            'a#b.nan_component': [None] * 3,
         })
 
         pd.testing.assert_frame_equal(output_with_nans, expected_output_with_nans)
         pd.testing.assert_frame_equal(output_without_nans, expected_output_without_nans)
 
-    def test_transform_existing_column_name(self):
-        """Test ``_transform`` method when the ``diff_column_name`` already exists in the table."""
+    @patch('sdv.cag.inequality._create_unique_name')
+    def test__get_new_column_names(self, mock_create_unique_name):
+        """Test ``_get_diff_and_nan_column_names`` method."""
         # Setup
+        mock_create_unique_name.side_effect = ['a#b', 'a#b.nan_component']
         instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
-        table_data = {
-            'table': pd.DataFrame({
-                'a': [1, 2, 3],
-                'b': [4, 5, 6],
-                'a#b': ['c', 'd', 'e'],
-            })
-        }
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'a': {'sdtype': 'numerical'},
+                        'b': {'sdtype': 'numerical'},
+                        'c': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [{'type': 'relationship', 'column_names': ['a', 'b']}],
+                }
+            }
+        })
 
         # Run
-        output = instance._transform(table_data)
+        diff_column, nan_column = instance._get_diff_and_nan_column_names(metadata, 'a#b', 'table')
 
         # Assert
-        output = output['table']
-        expected_column_name = ['a', 'a#b', 'a#b_']
-        assert list(output.columns) == expected_column_name
+        assert diff_column == 'a#b'
+        assert nan_column == 'a#b.nan_component'
+        mock_create_unique_name.assert_has_calls([
+            call('a#b', {'a', 'b', 'c'}),
+            call('a#b.nan_component', {'a', 'b', 'c'}),
+        ])
 
     def test__transform_datetime(self):
         """Test it transforms the data correctly when it contains datetimes."""
@@ -618,6 +637,7 @@ class TestInequality:
         }
         instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
         instance._diff_column_name = 'a#b'
+        instance._nan_column_name = 'a#b.nan_component'
         instance._is_datetime = True
 
         # Run
@@ -629,6 +649,7 @@ class TestInequality:
             'a': pd.to_datetime(['2020-01-01T00:00:00', '2020-01-02T00:00:00']),
             'c': [1, 2],
             'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
+            'a#b.nan_component': [None, None],
         })
         pd.testing.assert_frame_equal(out, expected_out)
 
@@ -644,6 +665,7 @@ class TestInequality:
         }
         instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
         instance._diff_column_name = 'a#b'
+        instance._nan_column_name = 'a#b.nan_component'
         instance._is_datetime = True
         instance._dtype = 'O'
 
@@ -656,6 +678,7 @@ class TestInequality:
             'a': ['2020-01-01T00:00:00', '2020-01-02T00:00:00'],
             'c': [1, 2],
             'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
+            'a#b.nan_component': [None] * 2,
         })
         pd.testing.assert_frame_equal(out, expected_out)
 
@@ -667,11 +690,13 @@ class TestInequality:
                 'a': [1, 2, 3],
                 'c': [7, 8, 9],
                 'a#b': [np.log(4)] * 3,
+                'a#b.nan_component': ['None'] * 3,
             })
         }
         instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
         instance._dtype = pd.Series([1]).dtype  # exact dtype (32 or 64) depends on OS
         instance._diff_column_name = 'a#b'
+        instance._nan_column_name = 'a#b.nan_component'
         instance._original_data_columns = {'table': ['a', 'b', 'c']}
         instance._dtypes = {
             'table': {
@@ -701,11 +726,13 @@ class TestInequality:
                 'a': [1.1, 2.2, 3.3],
                 'c': [7, 8, 9],
                 'a#b': [np.log(4)] * 3,
+                'a#b.nan_component': ['None'] * 3,
             })
         }
         instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
         instance._dtype = np.dtype('float')
         instance._diff_column_name = 'a#b'
+        instance._nan_column_name = 'a#b.nan_component'
         instance._original_data_columns = {'table': ['a', 'b', 'c']}
         instance._dtypes = {
             'table': {
@@ -735,11 +762,13 @@ class TestInequality:
                 'a': pd.to_datetime(['2020-01-01T00:00:00', '2020-01-02T00:00:00']),
                 'c': [1, 2],
                 'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
+                'a#b.nan_component': ['None', 'None'],
             })
         }
         instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
         instance._dtype = np.dtype('<M8[ns]')
         instance._diff_column_name = 'a#b'
+        instance._nan_column_name = 'a#b.nan_component'
         instance._is_datetime = True
         instance._original_data_columns = {'table': ['a', 'b', 'c']}
         instance._dtypes = {
@@ -770,11 +799,13 @@ class TestInequality:
                 'a': ['2020-01-01T00:00:00', '2020-01-02T00:00:00'],
                 'c': [1, 2],
                 'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
+                'a#b.nan_component': ['None', 'None'],
             })
         }
         instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
         instance._dtype = np.dtype('O')
         instance._diff_column_name = 'a#b'
+        instance._nan_column_name = 'a#b.nan_component'
         instance._is_datetime = True
         instance._original_data_columns = {'table': ['a', 'b', 'c']}
         instance._dtypes = {

--- a/tests/unit/cag/test_inequality.py
+++ b/tests/unit/cag/test_inequality.py
@@ -1,4 +1,4 @@
-"""Unit tests for Inequality CAG pattern."""
+"""Unit tests for Inequality CAG constraint."""
 
 import re
 from datetime import datetime
@@ -65,7 +65,7 @@ class TestInequality:
 
     @patch('sdv.cag.inequality._validate_table_and_column_names')
     def test__validate_pattern_with_metadata(self, validate_table_and_col_names_mock):
-        """Test validating the pattern with metadata."""
+        """Test validating the constraint with metadata."""
         # Setup
         instance = Inequality(low_column_name='low', high_column_name='high')
         metadata = Metadata.load_from_dict({

--- a/tests/unit/cag/test_inequality.py
+++ b/tests/unit/cag/test_inequality.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 from sdv.cag import Inequality
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.metadata import Metadata
 
 
@@ -113,7 +113,7 @@ class TestInequality:
             "Column 'high' has an incompatible sdtype 'boolean'. The column "
             "sdtype must be either 'numerical' or 'datetime'."
         )
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_metadata(metadata)
 
     def test__validate_pattern_with_metadata_non_matching_sdtype(self):
@@ -139,7 +139,7 @@ class TestInequality:
         err_msg = re.escape(
             "Columns 'low' and 'high' must have the same sdtype. Found 'numerical' and 'datetime'."
         )
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_metadata(metadata)
 
     def test__validate_pattern_with_data(self):
@@ -164,7 +164,7 @@ class TestInequality:
 
         # Run and Assert
         err_msg = re.escape('The inequality requirement is not met for row indices: [1]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     def test__validate_pattern_with_data_multiple_rows(self):
@@ -196,7 +196,7 @@ class TestInequality:
         err_msg = re.escape(
             'The inequality requirement is not met for row indices: [1, 4, 6, 7, 8, +1 more]'
         )
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     def test__validate_pattern_with_data_nans(self):
@@ -227,7 +227,7 @@ class TestInequality:
 
         # Run and Assert
         err_msg = re.escape('The inequality requirement is not met for row indices: [2, 5]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     def test__validate_pattern_with_data_strict_boundaries_true(self):
@@ -262,7 +262,7 @@ class TestInequality:
 
         # Run and Assert
         err_msg = re.escape('The inequality requirement is not met for row indices: [2, 3, 5]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     def test__validate_pattern_with_data_datetime(self):
@@ -297,7 +297,7 @@ class TestInequality:
 
         # Run and Assert
         err_msg = re.escape('The inequality requirement is not met for row indices: [1]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     def test__validate_pattern_with_data_datetime_objects(self):
@@ -332,7 +332,7 @@ class TestInequality:
 
         # Run and Assert
         err_msg = re.escape('The inequality requirement is not met for row indices: [1]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     @patch('sdv.cag.inequality.match_datetime_precision')
@@ -397,7 +397,7 @@ class TestInequality:
 
         # Run and Assert
         err_msg = re.escape('The inequality requirement is not met for row indices: [0, 2]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     def test__get_updated_metadata(self):

--- a/tests/unit/cag/test_inequality.py
+++ b/tests/unit/cag/test_inequality.py
@@ -1,4 +1,4 @@
-"""Unit tests for Inequality CAG constraint."""
+"""Unit tests for Inequality constraint."""
 
 import re
 from datetime import datetime
@@ -64,7 +64,7 @@ class TestInequality:
         assert instance._operator == np.greater
 
     @patch('sdv.cag.inequality._validate_table_and_column_names')
-    def test__validate_pattern_with_metadata(self, validate_table_and_col_names_mock):
+    def test__validate_constraint_with_metadata(self, validate_table_and_col_names_mock):
         """Test validating the constraint with metadata."""
         # Setup
         instance = Inequality(low_column_name='low', high_column_name='high')
@@ -84,12 +84,12 @@ class TestInequality:
         })
 
         # Run
-        instance._validate_pattern_with_metadata(metadata)
+        instance._validate_constraint_with_metadata(metadata)
 
         # Assert
         validate_table_and_col_names_mock.assert_called_once()
 
-    def test__validate_pattern_with_metadata_incorrect_sdtype(self):
+    def test__validate_constraint_with_metadata_incorrect_sdtype(self):
         """Test it when the sdtype is not numerical or datetime."""
         # Setup
         instance = Inequality(low_column_name='low', high_column_name='high')
@@ -114,9 +114,9 @@ class TestInequality:
             "sdtype must be either 'numerical' or 'datetime'."
         )
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_metadata(metadata)
+            instance._validate_constraint_with_metadata(metadata)
 
-    def test__validate_pattern_with_metadata_non_matching_sdtype(self):
+    def test__validate_constraint_with_metadata_non_matching_sdtype(self):
         """Test it when the sdtypes are not the same."""
         # Setup
         instance = Inequality(low_column_name='low', high_column_name='high')
@@ -140,9 +140,9 @@ class TestInequality:
             "Columns 'low' and 'high' must have the same sdtype. Found 'numerical' and 'datetime'."
         )
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_metadata(metadata)
+            instance._validate_constraint_with_metadata(metadata)
 
-    def test__validate_pattern_with_data(self):
+    def test__validate_constraint_with_data(self):
         """Test it when the data is not valid."""
         # Setup
         instance = Inequality(low_column_name='low', high_column_name='high', table_name='table')
@@ -165,9 +165,9 @@ class TestInequality:
         # Run and Assert
         err_msg = re.escape('The inequality requirement is not met for row indices: [1]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
-    def test__validate_pattern_with_data_multiple_rows(self):
+    def test__validate_constraint_with_data_multiple_rows(self):
         """Test it when the data is not valid for over 5 rows."""
         # Setup
         instance = Inequality(low_column_name='low', high_column_name='high', table_name='table')
@@ -197,9 +197,9 @@ class TestInequality:
             'The inequality requirement is not met for row indices: [1, 4, 6, 7, 8, +1 more]'
         )
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
-    def test__validate_pattern_with_data_nans(self):
+    def test__validate_constraint_with_data_nans(self):
         """Test it when the data is not valid and contains nans."""
         # Setup
         instance = Inequality(low_column_name='low', high_column_name='high')
@@ -228,9 +228,9 @@ class TestInequality:
         # Run and Assert
         err_msg = re.escape('The inequality requirement is not met for row indices: [2, 5]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
-    def test__validate_pattern_with_data_strict_boundaries_true(self):
+    def test__validate_constraint_with_data_strict_boundaries_true(self):
         """Test it when the data is not valid and contains nans."""
         # Setup
         instance = Inequality(
@@ -263,9 +263,9 @@ class TestInequality:
         # Run and Assert
         err_msg = re.escape('The inequality requirement is not met for row indices: [2, 3, 5]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
-    def test__validate_pattern_with_data_datetime(self):
+    def test__validate_constraint_with_data_datetime(self):
         """Test it when the data is not valid and contains datetimes."""
         # Setup
         instance = Inequality(
@@ -298,9 +298,9 @@ class TestInequality:
         # Run and Assert
         err_msg = re.escape('The inequality requirement is not met for row indices: [1]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
-    def test__validate_pattern_with_data_datetime_objects(self):
+    def test__validate_constraint_with_data_datetime_objects(self):
         """Test it when the data is not valid and contains datetimes as objects."""
         # Setup
         instance = Inequality(
@@ -333,10 +333,10 @@ class TestInequality:
         # Run and Assert
         err_msg = re.escape('The inequality requirement is not met for row indices: [1]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
     @patch('sdv.cag.inequality.match_datetime_precision')
-    def test__validate_pattern_with_data_datetime_objects_missmatching_formats(
+    def test__validate_constraint_with_data_datetime_objects_missmatching_formats(
         self, mock_match_datetime_precision
     ):
         """Test it when the data is not valid with datetimes with missmatching formats."""
@@ -398,7 +398,7 @@ class TestInequality:
         # Run and Assert
         err_msg = re.escape('The inequality requirement is not met for row indices: [0, 2]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
     def test__get_updated_metadata(self):
         """Test the ``_get_updated_metadata`` method."""

--- a/tests/unit/cag/test_inequality.py
+++ b/tests/unit/cag/test_inequality.py
@@ -1,0 +1,973 @@
+"""Unit tests for Inequality CAG pattern."""
+
+import re
+from datetime import datetime
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sdv.cag import Inequality
+from sdv.cag._errors import PatternNotMetError
+from sdv.metadata import Metadata
+
+
+class TestInequality:
+    def test___init___incorrect_column_name(self):
+        """Test it raises an error if column_name is not a string."""
+        # Run and Assert
+        err_msg = '`low_column_name` and `high_column_name` must be strings.'
+        with pytest.raises(ValueError, match=err_msg):
+            Inequality(low_column_name=1, high_column_name='b')
+
+        with pytest.raises(ValueError, match=err_msg):
+            Inequality(low_column_name='a', high_column_name=1)
+
+    def test___init___incorrect_strict_boundaries(self):
+        """Test it raises an error if strict_boundaries is not a boolean."""
+        # Run and Assert
+        err_msg = '`strict_boundaries` must be a boolean.'
+        with pytest.raises(ValueError, match=err_msg):
+            Inequality(low_column_name='a', high_column_name='b', strict_boundaries=1)
+
+    def test___init___incorrect_table_name(self):
+        """Test it raises an error if table_name is not a string."""
+        # Run and Assert
+        err_msg = '`table_name` must be a string or None.'
+        with pytest.raises(ValueError, match=err_msg):
+            Inequality(low_column_name='a', high_column_name='b', table_name=1)
+
+    def test___init___(self):
+        """Test it initializes correctly."""
+        # Run
+        instance = Inequality(low_column_name='a', high_column_name='b')
+
+        # Asserts
+        assert instance._low_column_name == 'a'
+        assert instance._high_column_name == 'b'
+        assert instance._diff_column_name == 'a#b'
+        assert instance._operator == np.greater_equal
+        assert instance._dtype is None
+        assert instance._is_datetime is None
+        assert instance._nan_column_name is None
+        assert instance.table_name is None
+        assert instance._low_datetime_format is None
+        assert instance._high_datetime_format is None
+
+    def test___init___strict_boundaries_true(self):
+        """Test it initializes correctly when strict_boundaries is True."""
+        # Run
+        instance = Inequality(low_column_name='a', high_column_name='b', strict_boundaries=True)
+
+        # Assert
+        assert instance._operator == np.greater
+
+    @patch('sdv.cag.inequality._validate_table_and_column_names')
+    def test__validate_pattern_with_metadata(self, validate_table_and_col_names_mock):
+        """Test validating the pattern with metadata."""
+        # Setup
+        instance = Inequality(low_column_name='low', high_column_name='high')
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run
+        instance._validate_pattern_with_metadata(metadata)
+
+        # Assert
+        validate_table_and_col_names_mock.assert_called_once()
+
+    def test__validate_pattern_with_metadata_incorrect_sdtype(self):
+        """Test it when the sdtype is not numerical or datetime."""
+        # Setup
+        instance = Inequality(low_column_name='low', high_column_name='high')
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'boolean'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape(
+            "Column 'high' has an incompatible sdtype 'boolean'. The column "
+            "sdtype must be either 'numerical' or 'datetime'."
+        )
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_metadata(metadata)
+
+    def test__validate_pattern_with_metadata_non_matching_sdtype(self):
+        """Test it when the sdtypes are not the same."""
+        # Setup
+        instance = Inequality(low_column_name='low', high_column_name='high')
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'datetime'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape(
+            "Columns 'low' and 'high' must have the same sdtype. Found 'numerical' and 'datetime'."
+        )
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_metadata(metadata)
+
+    def test__validate_pattern_with_data(self):
+        """Test it when the data is not valid."""
+        # Setup
+        instance = Inequality(low_column_name='low', high_column_name='high', table_name='table')
+        data = {'table': pd.DataFrame({'low': [1, 2, 3], 'high': [4, 0, 6]})}
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape('The inequality requirement is not met for row indices: [1]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    def test__validate_pattern_with_data_multiple_rows(self):
+        """Test it when the data is not valid for over 5 rows."""
+        # Setup
+        instance = Inequality(low_column_name='low', high_column_name='high', table_name='table')
+        data = {
+            'table': pd.DataFrame({
+                'low': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                'high': [4, 0, 6, 4, 0, 6, 4, 0, 6, 4],
+            })
+        }
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape(
+            'The inequality requirement is not met for row indices: [1, 4, 6, 7, 8, +1 more]'
+        )
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    def test__validate_pattern_with_data_nans(self):
+        """Test it when the data is not valid and contains nans."""
+        # Setup
+        instance = Inequality(low_column_name='low', high_column_name='high')
+        data = {
+            'table': pd.DataFrame({
+                'low': [1, np.nan, 3, 4, None, 6, 8, 0],
+                'high': [4, 2, 2, 4, np.nan, -6, 10, float('nan')],
+                'col': [7, 8, 9, 10, 11, 12, 13, 14],
+            })
+        }
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape('The inequality requirement is not met for row indices: [2, 5]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    def test__validate_pattern_with_data_strict_boundaries_true(self):
+        """Test it when the data is not valid and contains nans."""
+        # Setup
+        instance = Inequality(
+            low_column_name='low',
+            high_column_name='high',
+            strict_boundaries=True,
+        )
+        data = {
+            'table': pd.DataFrame({
+                'low': [1, np.nan, 3, 4, None, 6, 8, 0],
+                'high': [4, 2, 2, 4, np.nan, -6, 10, float('nan')],
+                'col': [7, 8, 9, 10, 11, 12, 13, 14],
+            })
+        }
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape('The inequality requirement is not met for row indices: [2, 3, 5]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    def test__validate_pattern_with_data_datetime(self):
+        """Test it when the data is not valid and contains datetimes."""
+        # Setup
+        instance = Inequality(
+            low_column_name='low',
+            high_column_name='high',
+            strict_boundaries=True,
+        )
+        data = {
+            'table': pd.DataFrame({
+                'low': [datetime(2020, 5, 17), datetime(2021, 9, 1), np.nan],
+                'high': [datetime(2020, 5, 18), datetime(2020, 9, 2), datetime(2020, 9, 2)],
+                'col': [7, 8, 9],
+            })
+        }
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'datetime'},
+                        'high': {'sdtype': 'datetime'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape('The inequality requirement is not met for row indices: [1]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    def test__validate_pattern_with_data_datetime_objects(self):
+        """Test it when the data is not valid and contains datetimes as objects."""
+        # Setup
+        instance = Inequality(
+            low_column_name='low',
+            high_column_name='high',
+            strict_boundaries=True,
+        )
+        data = {
+            'table': pd.DataFrame({
+                'low': ['2020-5-17', '2021-9-1', np.nan],
+                'high': ['2020-5-18', '2020-9-2', '2020-9-2'],
+                'col': [7, 8, 9],
+            })
+        }
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'datetime'},
+                        'high': {'sdtype': 'datetime'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape('The inequality requirement is not met for row indices: [1]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    @patch('sdv.cag.inequality.match_datetime_precision')
+    def test__validate_pattern_with_data_datetime_objects_missmatching_formats(
+        self, mock_match_datetime_precision
+    ):
+        """Test it when the data is not valid with datetimes with missmatching formats."""
+        # Setup
+        instance = Inequality(
+            low_column_name='low',
+            high_column_name='high',
+            strict_boundaries=True,
+        )
+        data = {
+            'table': pd.DataFrame({
+                'low': [
+                    '2016-07-10 17:04:00',
+                    '2016-07-11 13:23:00',
+                    '2016-07-12 08:45:30',
+                    '2016-07-11 12:00:00',
+                    '2016-07-12 10:30:00',
+                ],
+                'high': [
+                    '2016-07-10',
+                    '2016-07-11',
+                    '2016-07-12',
+                    '2016-07-13',
+                    '2016-07-14',
+                ],
+                'col': [7, 8, 9, 10, 11],
+            })
+        }
+        low_return = np.array([
+            datetime(2020, 5, 18),
+            datetime(2020, 9, 2),
+            datetime(2020, 9, 2),
+            datetime(2020, 5, 18),
+            datetime(2020, 9, 2),
+        ])
+        high_return = np.array([
+            datetime(2020, 5, 17),
+            datetime(2021, 9, 1),
+            datetime(2020, 5, 17),
+            datetime(2021, 9, 1),
+            datetime(2021, 9, 1),
+        ])
+        mock_match_datetime_precision.return_value = (low_return, high_return)
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d %H:%M:%S'},
+                        'high': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape('The inequality requirement is not met for row indices: [0, 2]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    def test__get_updated_metadata(self):
+        """Test the ``_get_updated_metadata`` method."""
+        # Setup
+        instance = Inequality(low_column_name='low', high_column_name='high')
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']},
+                        {'type': 'relationship', 'column_names': ['low', 'col']},
+                        {'type': 'relationship', 'column_names': ['high', 'col']},
+                    ],
+                }
+            }
+        })
+
+        # Run
+        updated_metadata = instance._get_updated_metadata(metadata)
+
+        # Assert
+        expected_metadata_dict = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                        'low#high': {'sdtype': 'numerical'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'col']},
+                    ],
+                }
+            }
+        }).to_dict()
+        assert updated_metadata.to_dict() == expected_metadata_dict
+
+    def test__fit(self):
+        """Test it learns the correct attributes."""
+        # Setup
+        data = {'table': pd.DataFrame({'a': [1, 2, 4], 'b': [4, 5, 6]})}
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'a': {'sdtype': 'datetime', 'datetime_format': '%y %m, %d'},
+                        'b': {'sdtype': 'datetime', 'datetime_format': '%y %m %d'},
+                    },
+                }
+            }
+        })
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+
+        # Run
+        instance._fit(data, metadata)
+
+        # Assert
+        assert instance._is_datetime is True
+        assert instance._dtype == pd.Series([1]).dtype  # exact dtype (32 or 64) depends on OS
+        assert instance._low_datetime_format == '%y %m, %d'
+        assert instance._high_datetime_format == '%y %m %d'
+
+    @pytest.mark.parametrize(
+        'dtype',
+        ['float16', 'float32', 'float64', 'Float64', 'Float32', 'Int64', 'Int32', 'Int16', 'Int8'],
+    )
+    def test__fit_numerical(self, dtype):
+        """Test it for numerical columns."""
+        # Setup
+        table_data = {'table': pd.DataFrame({'a': [1, 2, 4], 'b': [4, 5, 6]}, dtype=dtype)}
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'a': {'sdtype': 'numerical'},
+                        'b': {'sdtype': 'numerical'},
+                    },
+                }
+            }
+        })
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+
+        # Run
+        instance._fit(table_data, metadata)
+
+        # Assert
+        assert instance._dtype == dtype
+        assert instance._is_datetime is False
+        assert instance._low_datetime_format is None
+        assert instance._high_datetime_format is None
+
+    def test__fit_datetime(self):
+        """Test it for datetime strings."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': pd.to_datetime(['2020-01-01']),
+                'b': pd.to_datetime(['2020-01-02']),
+            })
+        }
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'a': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+                        'b': {'sdtype': 'datetime'},
+                    },
+                }
+            }
+        })
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+
+        # Run
+        instance._fit(table_data, metadata)
+
+        # Assert
+        assert instance._dtype == np.dtype('<M8[ns]')
+        assert instance._is_datetime is True
+        assert instance._low_datetime_format == '%Y-%m-%d'
+        assert instance._high_datetime_format is None
+
+    def test__transform(self):
+        """Test it transforms the data correctly."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': [1, 2, 3],
+                'b': [4, 5, 6],
+                'c': [7, 8, 9],
+            })
+        }
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+        instance._diff_column_name = 'a#b'
+
+        # Run
+        out = instance._transform(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': [1, 2, 3],
+            'c': [7, 8, 9],
+            'a#b': [np.log(4)] * 3,
+        })
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test__transform_with_nans(self):
+        """Test it transforms the data correctly when it contains nans."""
+        # Setup
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+        instance._diff_column_name = 'a#b'
+
+        table_data_with_nans = {
+            'table': pd.DataFrame({
+                'a': [1, np.nan, 3, np.nan],
+                'b': [np.nan, 2, 4, np.nan],
+            })
+        }
+
+        table_data_without_nans = {'table': pd.DataFrame({'a': [1, 2, 3], 'b': [2, 3, 4]})}
+
+        # Run
+        output_with_nans = instance._transform(table_data_with_nans)
+        output_without_nans = instance._transform(table_data_without_nans)
+
+        # Assert
+        output_with_nans = output_with_nans['table']
+        output_without_nans = output_without_nans['table']
+        expected_output_with_nans = pd.DataFrame({
+            'a': [1.0, 2.0, 3.0, 2.0],
+            'a#b': [np.log(2)] * 4,
+            'a#b.nan_component': ['b', 'a', 'None', 'a, b'],
+        })
+
+        expected_output_without_nans = pd.DataFrame({
+            'a': [1, 2, 3],
+            'a#b': [np.log(2)] * 3,
+        })
+
+        pd.testing.assert_frame_equal(output_with_nans, expected_output_with_nans)
+        pd.testing.assert_frame_equal(output_without_nans, expected_output_without_nans)
+
+    def test_transform_existing_column_name(self):
+        """Test ``_transform`` method when the ``diff_column_name`` already exists in the table."""
+        # Setup
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+        table_data = {
+            'table': pd.DataFrame({
+                'a': [1, 2, 3],
+                'b': [4, 5, 6],
+                'a#b': ['c', 'd', 'e'],
+            })
+        }
+
+        # Run
+        output = instance._transform(table_data)
+
+        # Assert
+        output = output['table']
+        expected_column_name = ['a', 'a#b', 'a#b_']
+        assert list(output.columns) == expected_column_name
+
+    def test__transform_datetime(self):
+        """Test it transforms the data correctly when it contains datetimes."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': pd.to_datetime(['2020-01-01T00:00:00', '2020-01-02T00:00:00']),
+                'b': pd.to_datetime(['2020-01-01T00:00:01', '2020-01-02T00:00:01']),
+                'c': [1, 2],
+            })
+        }
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+        instance._diff_column_name = 'a#b'
+        instance._is_datetime = True
+
+        # Run
+        out = instance._transform(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': pd.to_datetime(['2020-01-01T00:00:00', '2020-01-02T00:00:00']),
+            'c': [1, 2],
+            'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
+        })
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test__transform_datetime_dtype_object(self):
+        """Test it transforms the data correctly when the dtype is object."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': ['2020-01-01T00:00:00', '2020-01-02T00:00:00'],
+                'b': ['2020-01-01T00:00:01', '2020-01-02T00:00:01'],
+                'c': [1, 2],
+            })
+        }
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+        instance._diff_column_name = 'a#b'
+        instance._is_datetime = True
+        instance._dtype = 'O'
+
+        # Run
+        out = instance._transform(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': ['2020-01-01T00:00:00', '2020-01-02T00:00:00'],
+            'c': [1, 2],
+            'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
+        })
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test_reverse_transform(self):
+        """Test it reverses the transformation correctly."""
+        # Setup
+        transformed = {
+            'table': pd.DataFrame({
+                'a': [1, 2, 3],
+                'c': [7, 8, 9],
+                'a#b': [np.log(4)] * 3,
+            })
+        }
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+        instance._dtype = pd.Series([1]).dtype  # exact dtype (32 or 64) depends on OS
+        instance._diff_column_name = 'a#b'
+        instance._original_data_columns = {'table': ['a', 'b', 'c']}
+        instance._dtypes = {
+            'table': {
+                'a': pd.Series([1]).dtype,
+                'b': pd.Series([1]).dtype,
+                'c': pd.Series([1]).dtype,
+            }
+        }
+
+        # Run
+        out = instance.reverse_transform(transformed)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': [1, 2, 3],
+            'b': [4, 5, 6],
+            'c': [7, 8, 9],
+        })
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test_reverse_transform_floats(self):
+        """Test it reverses the transformation correctly when the dtype is float."""
+        # Setup
+        transformed = {
+            'table': pd.DataFrame({
+                'a': [1.1, 2.2, 3.3],
+                'c': [7, 8, 9],
+                'a#b': [np.log(4)] * 3,
+            })
+        }
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+        instance._dtype = np.dtype('float')
+        instance._diff_column_name = 'a#b'
+        instance._original_data_columns = {'table': ['a', 'b', 'c']}
+        instance._dtypes = {
+            'table': {
+                'a': np.dtype('float'),
+                'b': np.dtype('float'),
+                'c': pd.Series([1]).dtype,
+            }
+        }
+
+        # Run
+        out = instance.reverse_transform(transformed)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': [1.1, 2.2, 3.3],
+            'b': [4.1, 5.2, 6.3],
+            'c': [7, 8, 9],
+        })
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test_reverse_transform_datetime(self):
+        """Test it reverses the transformation correctly when the dtype is datetime."""
+        # Setup
+        transformed = {
+            'table': pd.DataFrame({
+                'a': pd.to_datetime(['2020-01-01T00:00:00', '2020-01-02T00:00:00']),
+                'c': [1, 2],
+                'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
+            })
+        }
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+        instance._dtype = np.dtype('<M8[ns]')
+        instance._diff_column_name = 'a#b'
+        instance._is_datetime = True
+        instance._original_data_columns = {'table': ['a', 'b', 'c']}
+        instance._dtypes = {
+            'table': {
+                'a': np.dtype('<M8[ns]'),
+                'b': np.dtype('<M8[ns]'),
+                'c': pd.Series([1]).dtype,
+            }
+        }
+
+        # Run
+        out = instance.reverse_transform(transformed)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': pd.to_datetime(['2020-01-01T00:00:00', '2020-01-02T00:00:00']),
+            'b': pd.to_datetime(['2020-01-01T00:00:01', '2020-01-02T00:00:01']),
+            'c': [1, 2],
+        })
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test_reverse_transform_datetime_dtype_is_object(self):
+        """Test it reverses the transformation correctly when the dtype is object."""
+        # Setup
+        transformed = {
+            'table': pd.DataFrame({
+                'a': ['2020-01-01T00:00:00', '2020-01-02T00:00:00'],
+                'c': [1, 2],
+                'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
+            })
+        }
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+        instance._dtype = np.dtype('O')
+        instance._diff_column_name = 'a#b'
+        instance._is_datetime = True
+        instance._original_data_columns = {'table': ['a', 'b', 'c']}
+        instance._dtypes = {
+            'table': {
+                'a': np.dtype('O'),
+                'b': np.dtype('O'),
+                'c': pd.Series([1]).dtype,
+            }
+        }
+
+        # Run
+        out = instance.reverse_transform(transformed)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': ['2020-01-01T00:00:00', '2020-01-02T00:00:00'],
+            'b': [pd.Timestamp('2020-01-01 00:00:01'), pd.Timestamp('2020-01-02 00:00:01')],
+            'c': [1, 2],
+        })
+        expected_out['b'] = expected_out['b'].astype(np.dtype('O'))
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test__is_valid(self):
+        """Test it checks if the data is valid."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': [1, np.nan, 3, 4, None, 6, 8, 0],
+                'b': [4, 2, 2, 4, np.nan, -6, 10, float('nan')],
+                'c': [7, 8, 9, 10, 11, 12, 13, 14],
+            })
+        }
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+        instance._fitted = True
+
+        # Run
+        out = instance.is_valid(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = [True, True, False, True, True, False, True, True]
+        np.testing.assert_array_equal(expected_out, out)
+
+    def test_is_valid_strict_boundaries_true(self):
+        """Test it checks if the data is valid when strict boundaries are True."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': [1, np.nan, 3, 4, None, 6, 8, 0],
+                'b': [4, 2, 2, 4, np.nan, -6, 10, float('nan')],
+                'c': [7, 8, 9, 10, 11, 12, 13, 14],
+            })
+        }
+        instance = Inequality(
+            low_column_name='a',
+            high_column_name='b',
+            strict_boundaries=True,
+            table_name='table',
+        )
+        instance._fitted = True
+
+        # Run
+        out = instance.is_valid(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = [True, True, False, False, True, False, True, True]
+        np.testing.assert_array_equal(expected_out, out)
+
+    def test_is_valid_datetimes(self):
+        """Test it checks if the data is valid when it contains datetimes."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': [datetime(2020, 5, 17), datetime(2021, 9, 1), np.nan],
+                'b': [datetime(2020, 5, 18), datetime(2020, 9, 2), datetime(2020, 9, 2)],
+                'c': [7, 8, 9],
+            })
+        }
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+        instance._fitted = True
+
+        # Run
+        out = instance.is_valid(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = [True, False, True]
+        np.testing.assert_array_equal(expected_out, out)
+
+    def test_is_valid_datetime_objects(self):
+        """Test the ``is_valid`` method with datetimes that are as ``dtype`` object."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': ['2020-5-17', '2021-9-1', np.nan],
+                'b': ['2020-5-18', '2020-9-2', '2020-9-2'],
+                'c': [7, 8, 9],
+            })
+        }
+        instance = Inequality(low_column_name='a', high_column_name='b', table_name='table')
+        instance._is_datetime = True
+        instance._dtype = 'O'
+        instance._fitted = True
+
+        # Run
+        out = instance.is_valid(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = [True, False, True]
+        np.testing.assert_array_equal(expected_out, out)
+
+    @patch('sdv.cag.inequality.match_datetime_precision')
+    def test_is_valid_datetimes_miss_matching_datetime_formats(self, mock_match_datetime_precision):
+        """Test it validates the data when it contains datetimes with missmatching formats."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'SUBMISSION_TIMESTAMP': [
+                    '2016-07-10 17:04:00',
+                    '2016-07-11 13:23:00',
+                    '2016-07-12 08:45:30',
+                    '2016-07-11 12:00:00',
+                    '2016-07-12 10:30:00',
+                ],
+                'DUE_DATE': ['2016-07-10', '2016-07-11', '2016-07-12', '2016-07-13', '2016-07-14'],
+                'RANDOM_VALUE': [7, 8, 9, 10, 11],
+            })
+        }
+        instance = Inequality(
+            low_column_name='SUBMISSION_TIMESTAMP',
+            high_column_name='DUE_DATE',
+            table_name='table',
+        )
+        low_return = np.array([
+            datetime(2020, 5, 18),
+            datetime(2020, 9, 2),
+            datetime(2020, 9, 2),
+            datetime(2020, 5, 18),
+            datetime(2020, 9, 2),
+        ])
+        high_return = np.array([
+            datetime(2020, 5, 17),
+            datetime(2021, 9, 1),
+            datetime(2020, 5, 17),
+            datetime(2021, 9, 1),
+            datetime(2021, 9, 1),
+        ])
+        instance._dtype = 'O'
+        instance._is_datetime = True
+        instance._low_datetime_format = '%Y-%m-%d %H:%M:%S'
+        instance._high_datetime_format = '%Y-%m-%d'
+        mock_match_datetime_precision.return_value = (low_return, high_return)
+        instance._fitted = True
+
+        # Run
+        out = instance.is_valid(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = [False, True, False, True, True]
+        np.testing.assert_array_equal(expected_out, out)
+
+        expected_low = np.array(
+            [
+                '2016-07-10T17:04:00.000000000',
+                '2016-07-11T13:23:00.000000000',
+                '2016-07-12T08:45:30.000000000',
+                '2016-07-11T12:00:00.000000000',
+                '2016-07-12T10:30:00.000000000',
+            ],
+            dtype='datetime64[ns]',
+        )
+
+        expected_high = np.array(
+            [
+                '2016-07-10T00:00:00.000000000',
+                '2016-07-11T00:00:00.000000000',
+                '2016-07-12T00:00:00.000000000',
+                '2016-07-13T00:00:00.000000000',
+                '2016-07-14T00:00:00.000000000',
+            ],
+            dtype='datetime64[ns]',
+        )
+
+        call_low = mock_match_datetime_precision.call_args_list[0][1].pop('low')
+        call_high = mock_match_datetime_precision.call_args_list[0][1].pop('high')
+        np.testing.assert_array_equal(expected_low, call_low)
+        np.testing.assert_array_equal(expected_high, call_high)
+        expected_formats = {
+            'low_datetime_format': '%Y-%m-%d %H:%M:%S',
+            'high_datetime_format': '%Y-%m-%d',
+        }
+        assert expected_formats == mock_match_datetime_precision.call_args_list[0][1]

--- a/tests/unit/cag/test_one_hot_encoding.py
+++ b/tests/unit/cag/test_one_hot_encoding.py
@@ -1,4 +1,4 @@
-"""Unit tests for OneHotEncoding CAG pattern."""
+"""Unit tests for OneHotEncoding CAG constraint."""
 
 import re
 from unittest.mock import patch
@@ -41,7 +41,7 @@ class TestOneHotEncoding:
 
     @patch('sdv.cag.one_hot_encoding._validate_table_and_column_names')
     def test__validate_pattern_with_metadata(self, validate_table_and_col_names_mock):
-        """Test validating the pattern with metadata."""
+        """Test validating the constraint with metadata."""
         # Setup
         instance = OneHotEncoding(column_names=['low', 'middle', 'high'])
         metadata = Metadata.load_from_dict({

--- a/tests/unit/cag/test_one_hot_encoding.py
+++ b/tests/unit/cag/test_one_hot_encoding.py
@@ -1,0 +1,168 @@
+"""Unit tests for OneHotEncoding CAG pattern."""
+
+import re
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sdv.cag import OneHotEncoding
+from sdv.cag._errors import PatternNotMetError
+from sdv.metadata import Metadata
+
+
+class TestOneHotEncoding:
+    def test___init___incorrect_column_name(self):
+        """Test it raises an error if column_name is not a string."""
+        # Run and Assert
+        err_msg = '`column_names` must be a list of strings.'
+        with pytest.raises(ValueError, match=err_msg):
+            OneHotEncoding(column_names=1)
+
+        with pytest.raises(ValueError, match=err_msg):
+            OneHotEncoding(column_names=['a', 1])
+
+    def test___init___incorrect_table_name(self):
+        """Test it raises an error if table_name is not a string."""
+        # Run and Assert
+        err_msg = '`table_name` must be a string or None.'
+        with pytest.raises(ValueError, match=err_msg):
+            OneHotEncoding(column_names=['a', 'b', 'c'], table_name=1)
+
+    def test___init___(self):
+        """Test it initializes correctly."""
+        # Run
+        instance = OneHotEncoding(column_names=['a', 'b', 'c'])
+
+        # Asserts
+        assert instance._column_names == ['a', 'b', 'c']
+        assert instance.table_name is None
+
+    @patch('sdv.cag.one_hot_encoding._validate_table_and_column_names')
+    def test__validate_pattern_with_metadata(self, validate_table_and_col_names_mock):
+        """Test validating the pattern with metadata."""
+        # Setup
+        instance = OneHotEncoding(column_names=['low', 'middle', 'high'])
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'middle': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'numerical'},
+                    },
+                }
+            }
+        })
+
+        # Run
+        instance._validate_pattern_with_metadata(metadata)
+
+        # Assert
+        validate_table_and_col_names_mock.assert_called_once()
+
+    def test__validate_pattern_with_data(self):
+        """Test it when the data is not valid."""
+        # Setup
+        instance = OneHotEncoding(column_names=['a', 'b', 'c'])
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'a': {'sdtype': 'numerical'},
+                        'b': {'sdtype': 'numerical'},
+                        'c': {'sdtype': 'numerical'},
+                    },
+                }
+            }
+        })
+
+        # Row of all zeros
+        data = {'table': pd.DataFrame({'a': [1, 0, 0], 'b': [0, 0, 0], 'c': [0, 0, 1]})}
+        err_msg = re.escape('The one hot encoding requirement is not met for row indices: [1]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+        # Row with two 1s
+        data = {'table': pd.DataFrame({'a': [1, 0, 0], 'b': [0, 1, 1], 'c': [1, 0, 0]})}
+        err_msg = re.escape('The one hot encoding requirement is not met for row indices: [0]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+        # Invalid number
+        data = {'table': pd.DataFrame({'a': [1, 0, 0], 'b': [0, 2, 0], 'c': [0, 0, 1]})}
+        err_msg = re.escape('The one hot encoding requirement is not met for row indices: [1]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+        # Nans
+        data = {'table': pd.DataFrame({'a': [1, 0, 0], 'b': [0, 1, np.nan], 'c': [0, None, 1]})}
+        err_msg = re.escape('The one hot encoding requirement is not met for row indices: [1, 2]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    def test__fit(self):
+        """Test it runs."""
+        # Setup
+        instance = OneHotEncoding(column_names=['a', 'b', 'c'])
+
+        # Run
+        instance._fit({}, Metadata())
+
+    def test__transform(self):
+        """Test it returns the data unchanged."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': [1, 2, 3],
+                'b': [4, 5, 6],
+                'c': [7, 8, 9],
+            })
+        }
+        instance = OneHotEncoding(column_names=['a', 'b', 'c'])
+
+        # Run
+        out = instance._transform(table_data)
+
+        # Assert
+        pd.testing.assert_frame_equal(out['table'], table_data['table'])
+
+    def test_reverse_transform(self):
+        """Test it reverses the transformation correctly."""
+        # Setup
+        instance = OneHotEncoding(column_names=['a', 'b'], table_name='table')
+        instance._original_data_columns = {'table': ['a', 'b', 'c']}
+        instance._dtypes = {'table': {'a': np.dtype('float'), 'b': np.dtype('float')}}
+
+        # Run
+        table_data = pd.DataFrame({'a': [0.1, 0.5, 0.8], 'b': [0.8, 0.1, 0.9], 'c': [1, 2, 3]})
+        out = instance.reverse_transform({'table': table_data})
+
+        # Assert
+        expected_out = pd.DataFrame({'a': [0.0, 1.0, 0.0], 'b': [1.0, 0.0, 1.0], 'c': [1, 2, 3]})
+        pd.testing.assert_frame_equal(expected_out, out['table'])
+
+    def test_is_valid(self):
+        """Test it checks if the data is valid."""
+        # Setup
+        instance = OneHotEncoding(column_names=['a', 'b', 'c'], table_name='table')
+        instance._fitted = True
+
+        # Run
+        table_data = pd.DataFrame({
+            'a': [1.0, 1.0, 0.0, 0.5, 1.0],
+            'b': [0.0, 1.0, 0.0, 0.5, 0.0],
+            'c': [0.0, 2.0, 0.0, 0.0, np.nan],
+            'd': [1, 2, 3, 4, 5],
+        })
+        data = {'table': table_data, 'table2': table_data}
+        out = instance.is_valid(data)
+
+        # Assert
+        expected_out = {
+            'table': pd.Series([True, False, False, False, False]),
+            'table2': pd.Series([True, True, True, True, True]),
+        }
+        for table, series in out.items():
+            pd.testing.assert_series_equal(expected_out[table], series)

--- a/tests/unit/cag/test_one_hot_encoding.py
+++ b/tests/unit/cag/test_one_hot_encoding.py
@@ -1,4 +1,4 @@
-"""Unit tests for OneHotEncoding CAG constraint."""
+"""Unit tests for OneHotEncoding constraint."""
 
 import re
 from unittest.mock import patch
@@ -40,7 +40,7 @@ class TestOneHotEncoding:
         assert instance.table_name is None
 
     @patch('sdv.cag.one_hot_encoding._validate_table_and_column_names')
-    def test__validate_pattern_with_metadata(self, validate_table_and_col_names_mock):
+    def test__validate_constraint_with_metadata(self, validate_table_and_col_names_mock):
         """Test validating the constraint with metadata."""
         # Setup
         instance = OneHotEncoding(column_names=['low', 'middle', 'high'])
@@ -57,12 +57,12 @@ class TestOneHotEncoding:
         })
 
         # Run
-        instance._validate_pattern_with_metadata(metadata)
+        instance._validate_constraint_with_metadata(metadata)
 
         # Assert
         validate_table_and_col_names_mock.assert_called_once()
 
-    def test__validate_pattern_with_data(self):
+    def test__validate_constraint_with_data(self):
         """Test it when the data is not valid."""
         # Setup
         instance = OneHotEncoding(column_names=['a', 'b', 'c'])
@@ -82,25 +82,25 @@ class TestOneHotEncoding:
         data = {'table': pd.DataFrame({'a': [1, 0, 0], 'b': [0, 0, 0], 'c': [0, 0, 1]})}
         err_msg = re.escape('The one hot encoding requirement is not met for row indices: [1]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
         # Row with two 1s
         data = {'table': pd.DataFrame({'a': [1, 0, 0], 'b': [0, 1, 1], 'c': [1, 0, 0]})}
         err_msg = re.escape('The one hot encoding requirement is not met for row indices: [0]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
         # Invalid number
         data = {'table': pd.DataFrame({'a': [1, 0, 0], 'b': [0, 2, 0], 'c': [0, 0, 1]})}
         err_msg = re.escape('The one hot encoding requirement is not met for row indices: [1]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
         # Nans
         data = {'table': pd.DataFrame({'a': [1, 0, 0], 'b': [0, 1, np.nan], 'c': [0, None, 1]})}
         err_msg = re.escape('The one hot encoding requirement is not met for row indices: [1, 2]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
     def test__fit(self):
         """Test it runs."""

--- a/tests/unit/cag/test_one_hot_encoding.py
+++ b/tests/unit/cag/test_one_hot_encoding.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 from sdv.cag import OneHotEncoding
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.metadata import Metadata
 
 
@@ -81,25 +81,25 @@ class TestOneHotEncoding:
         # Row of all zeros
         data = {'table': pd.DataFrame({'a': [1, 0, 0], 'b': [0, 0, 0], 'c': [0, 0, 1]})}
         err_msg = re.escape('The one hot encoding requirement is not met for row indices: [1]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
         # Row with two 1s
         data = {'table': pd.DataFrame({'a': [1, 0, 0], 'b': [0, 1, 1], 'c': [1, 0, 0]})}
         err_msg = re.escape('The one hot encoding requirement is not met for row indices: [0]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
         # Invalid number
         data = {'table': pd.DataFrame({'a': [1, 0, 0], 'b': [0, 2, 0], 'c': [0, 0, 1]})}
         err_msg = re.escape('The one hot encoding requirement is not met for row indices: [1]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
         # Nans
         data = {'table': pd.DataFrame({'a': [1, 0, 0], 'b': [0, 1, np.nan], 'c': [0, None, 1]})}
         err_msg = re.escape('The one hot encoding requirement is not met for row indices: [1, 2]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     def test__fit(self):

--- a/tests/unit/cag/test_range.py
+++ b/tests/unit/cag/test_range.py
@@ -10,7 +10,7 @@ import pandas as pd
 import pytest
 
 from sdv.cag import Range
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.metadata import Metadata
 
 
@@ -145,7 +145,7 @@ class TestRange:
             "Column 'high' has an incompatible sdtype 'boolean'. The column "
             "sdtype must be either 'numerical' or 'datetime'."
         )
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_metadata(metadata)
 
     def test__validate_pattern_with_metadata_non_matching_sdtype(self):
@@ -177,7 +177,7 @@ class TestRange:
             "Columns 'low', 'middle' and 'high' must have the same sdtype. "
             "Found 'numerical', 'datetime' and 'datetime'."
         )
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_metadata(metadata)
 
     def test__validate_pattern_with_data(self):
@@ -208,7 +208,7 @@ class TestRange:
 
         # Run and Assert
         err_msg = re.escape('The range requirement is not met for row indices: [1]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     def test__validate_pattern_with_data_multiple_rows(self):
@@ -247,7 +247,7 @@ class TestRange:
         err_msg = re.escape(
             'The range requirement is not met for row indices: [1, 4, 6, 7, 8, +1 more]'
         )
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     def test__validate_pattern_with_data_nans(self):
@@ -284,7 +284,7 @@ class TestRange:
 
         # Run and Assert
         err_msg = re.escape('The range requirement is not met for row indices: [2, 3, 5]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     def test__validate_pattern_with_data_strict_boundaries_false(self):
@@ -322,7 +322,7 @@ class TestRange:
 
         # Run and Assert
         err_msg = re.escape('The range requirement is not met for row indices: [2, 5]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     def test__validate_pattern_with_data_datetime(self):
@@ -360,7 +360,7 @@ class TestRange:
 
         # Run and Assert
         err_msg = re.escape('The range requirement is not met for row indices: [1]')
-        with pytest.raises(PatternNotMetError, match=err_msg):
+        with pytest.raises(ConstraintNotMetError, match=err_msg):
             instance._validate_pattern_with_data(data, metadata)
 
     def test__get_updated_metadata(self):

--- a/tests/unit/cag/test_range.py
+++ b/tests/unit/cag/test_range.py
@@ -1,0 +1,949 @@
+"""Unit tests for Range CAG pattern."""
+
+import operator
+import re
+from datetime import datetime
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sdv.cag import Range
+from sdv.cag._errors import PatternNotMetError
+from sdv.metadata import Metadata
+
+
+class TestRange:
+    def test___init___incorrect_column_name(self):
+        """Test it raises an error if column_name is not a string."""
+        # Run and Assert
+        err_msg = '`low_column_name`, `middle_column_name` and `high_column_name` must be strings.'
+        with pytest.raises(ValueError, match=err_msg):
+            Range(low_column_name=1, middle_column_name='b', high_column_name='c')
+
+        with pytest.raises(ValueError, match=err_msg):
+            Range(low_column_name='a', middle_column_name=1, high_column_name='c')
+
+        with pytest.raises(ValueError, match=err_msg):
+            Range(low_column_name='a', middle_column_name='b', high_column_name=1)
+
+    def test___init___incorrect_strict_boundaries(self):
+        """Test it raises an error if strict_boundaries is not a boolean."""
+        # Run and Assert
+        err_msg = '`strict_boundaries` must be a boolean.'
+        with pytest.raises(ValueError, match=err_msg):
+            Range(
+                low_column_name='a',
+                middle_column_name='b',
+                high_column_name='c',
+                strict_boundaries=1,
+            )
+
+    def test___init___incorrect_table_name(self):
+        """Test it raises an error if table_name is not a string."""
+        # Run and Assert
+        err_msg = '`table_name` must be a string or None.'
+        with pytest.raises(ValueError, match=err_msg):
+            Range(
+                low_column_name='a',
+                middle_column_name='b',
+                high_column_name='c',
+                table_name=1,
+            )
+
+    def test___init___(self):
+        """Test it initializes correctly."""
+        # Run
+        instance = Range(low_column_name='a', middle_column_name='b', high_column_name='c')
+
+        # Asserts
+        assert instance._low_column_name == 'a'
+        assert instance._middle_column_name == 'b'
+        assert instance._high_column_name == 'c'
+        assert instance._low_diff_column_name == 'a#b'
+        assert instance._high_diff_column_name == 'b#c'
+        assert instance._operator == operator.lt
+        assert instance._dtype is None
+        assert instance._is_datetime is None
+        assert instance._nan_column_name is None
+        assert instance.table_name is None
+        assert instance._low_datetime_format is None
+        assert instance._middle_datetime_format is None
+        assert instance._high_datetime_format is None
+
+    def test___init___strict_boundaries_false(self):
+        """Test it initializes correctly when strict_boundaries is False."""
+        # Run
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            strict_boundaries=False,
+        )
+
+        # Assert
+        assert instance._operator == operator.le
+
+    @patch('sdv.cag.range._validate_table_and_column_names')
+    def test__validate_pattern_with_metadata(self, validate_table_and_col_names_mock):
+        """Test validating the pattern with metadata."""
+        # Setup
+        instance = Range(
+            low_column_name='low',
+            middle_column_name='middle',
+            high_column_name='high',
+        )
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'middle': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run
+        instance._validate_pattern_with_metadata(metadata)
+
+        # Assert
+        validate_table_and_col_names_mock.assert_called_once()
+
+    def test__validate_pattern_with_metadata_incorrect_sdtype(self):
+        """Test it when the sdtype is not numerical or datetime."""
+        # Setup
+        instance = Range(
+            low_column_name='low',
+            middle_column_name='middle',
+            high_column_name='high',
+        )
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'middle': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'boolean'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape(
+            "Column 'high' has an incompatible sdtype 'boolean'. The column "
+            "sdtype must be either 'numerical' or 'datetime'."
+        )
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_metadata(metadata)
+
+    def test__validate_pattern_with_metadata_non_matching_sdtype(self):
+        """Test it when the sdtypes are not the same."""
+        # Setup
+        instance = Range(
+            low_column_name='low',
+            middle_column_name='middle',
+            high_column_name='high',
+        )
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'middle': {'sdtype': 'datetime'},
+                        'high': {'sdtype': 'datetime'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape(
+            "Columns 'low', 'middle' and 'high' must have the same sdtype. "
+            "Found 'numerical', 'datetime' and 'datetime'."
+        )
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_metadata(metadata)
+
+    def test__validate_pattern_with_data(self):
+        """Test it when the data is not valid."""
+        # Setup
+        instance = Range(
+            low_column_name='low',
+            middle_column_name='middle',
+            high_column_name='high',
+            table_name='table',
+        )
+        data = {'table': pd.DataFrame({'low': [1, 2, 3], 'middle': [4, -1, 6], 'high': [7, 8, 9]})}
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'middle': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape('The range requirement is not met for row indices: [1]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    def test__validate_pattern_with_data_multiple_rows(self):
+        """Test it when the data is not valid for over 5 rows."""
+        # Setup
+        instance = Range(
+            low_column_name='low',
+            middle_column_name='middle',
+            high_column_name='high',
+            table_name='table',
+        )
+        data = {
+            'table': pd.DataFrame({
+                'low': [1, 2, 3, 4, 5, 6, 10, 12, 9, 10],
+                'middle': [4, 0, 6, 7, 8, 9, 10, 11, 9, -13],
+                'high': [7, 0, 7, 10, -1, 12, 13, 14, 9, 16],
+            })
+        }
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'middle': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape(
+            'The range requirement is not met for row indices: [1, 4, 6, 7, 8, +1 more]'
+        )
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    def test__validate_pattern_with_data_nans(self):
+        """Test it when the data is not valid and contains nans."""
+        # Setup
+        instance = Range(
+            low_column_name='low',
+            middle_column_name='middle',
+            high_column_name='high',
+        )
+        data = {
+            'table': pd.DataFrame({
+                'low': [np.nan, np.nan, 3, 4, None, 6, 8, 0],
+                'middle': [np.nan, 2, 2, 4, np.nan, -6, 10, float('nan')],
+                'high': [np.nan, 8, 9, 10, 11, 12, 13, 14],
+                'col': [7, 8, 9, 10, 11, 12, 13, 14],
+            })
+        }
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'middle': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape('The range requirement is not met for row indices: [2, 3, 5]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    def test__validate_pattern_with_data_strict_boundaries_false(self):
+        """Test it when the data is not valid and contains nans."""
+        # Setup
+        instance = Range(
+            low_column_name='low',
+            middle_column_name='middle',
+            high_column_name='high',
+            strict_boundaries=False,
+        )
+        data = {
+            'table': pd.DataFrame({
+                'low': [1, np.nan, 3, 4, None, 6, 8, 0],
+                'middle': [4, 2, 2, 4, np.nan, -6, 10, float('nan')],
+                'high': [4, 2, 2, 4, np.nan, -6, 10, float('nan')],
+                'col': [7, 8, 9, 10, 11, 12, 13, 14],
+            })
+        }
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'middle': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape('The range requirement is not met for row indices: [2, 5]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    def test__validate_pattern_with_data_datetime(self):
+        """Test it when the data is not valid and contains datetimes."""
+        # Setup
+        instance = Range(
+            low_column_name='low',
+            middle_column_name='middle',
+            high_column_name='high',
+            strict_boundaries=True,
+        )
+        data = {
+            'table': pd.DataFrame({
+                'low': [datetime(2020, 5, 17), datetime(2021, 9, 1), np.nan],
+                'middle': [datetime(2020, 5, 17, 12, 0, 0), datetime(2021, 9, 1), np.nan],
+                'high': [datetime(2020, 5, 18), datetime(2020, 9, 2), datetime(2020, 9, 2)],
+                'col': [7, 8, 9],
+            })
+        }
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'datetime'},
+                        'middle': {'sdtype': 'datetime'},
+                        'high': {'sdtype': 'datetime'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']}
+                    ],
+                }
+            }
+        })
+
+        # Run and Assert
+        err_msg = re.escape('The range requirement is not met for row indices: [1]')
+        with pytest.raises(PatternNotMetError, match=err_msg):
+            instance._validate_pattern_with_data(data, metadata)
+
+    def test__get_updated_metadata(self):
+        """Test the ``_get_updated_metadata`` method."""
+        # Setup
+        instance = Range(
+            low_column_name='low',
+            middle_column_name='middle',
+            high_column_name='high',
+        )
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'middle': {'sdtype': 'numerical'},
+                        'high': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'high']},
+                        {'type': 'relationship', 'column_names': ['low', 'col']},
+                        {'type': 'relationship', 'column_names': ['high', 'col']},
+                        {'type': 'relationship', 'column_names': ['middle', 'col']},
+                        {'type': 'relationship', 'column_names': ['middle', 'high']},
+                        {'type': 'relationship', 'column_names': ['low', 'middle']},
+                    ],
+                }
+            }
+        })
+
+        # Run
+        updated_metadata = instance._get_updated_metadata(metadata)
+
+        # Assert
+        expected_metadata_dict = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'low': {'sdtype': 'numerical'},
+                        'col': {'sdtype': 'id'},
+                        'low#middle': {'sdtype': 'numerical'},
+                        'middle#high': {'sdtype': 'numerical'},
+                    },
+                    'column_relationships': [
+                        {'type': 'relationship', 'column_names': ['low', 'col']},
+                    ],
+                }
+            }
+        }).to_dict()
+        assert updated_metadata.to_dict() == expected_metadata_dict
+
+    def test__fit(self):
+        """Test it learns the correct attributes."""
+        # Setup
+        table_data = {'table': pd.DataFrame({'a': [1, 2, 4], 'b': [4, 5, 6], 'c': [7, 8, 9]})}
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'a': {'sdtype': 'datetime', 'datetime_format': '%y %m, %d'},
+                        'b': {'sdtype': 'datetime', 'datetime_format': '%y %m %d'},
+                        'c': {'sdtype': 'datetime', 'datetime_format': '%y %m %d %H:%M:%S'},
+                    },
+                }
+            }
+        })
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+
+        # Run
+        instance._fit(table_data, metadata)
+
+        # Assert
+        assert instance._is_datetime is True
+        assert instance._dtype == pd.Series([1]).dtype  # exact dtype (32 or 64) depends on OS
+        assert instance._low_datetime_format == '%y %m, %d'
+        assert instance._middle_datetime_format == '%y %m %d'
+        assert instance._high_datetime_format == '%y %m %d %H:%M:%S'
+        assert instance._low_diff_column_name == 'a#b'
+        assert instance._high_diff_column_name == 'b#c'
+
+    @pytest.mark.parametrize('dtype', ['Float64', 'Float32', 'Int64', 'Int32', 'Int16', 'Int8'])
+    def test__fit_numerical(self, dtype):
+        """Test it for numerical columns."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame(
+                {'a': [1, 2, 4], 'b': [4, 5, 6], 'c': [7, 8, 9]},
+                dtype=dtype,
+            )
+        }
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'a': {'sdtype': 'numerical'},
+                        'b': {'sdtype': 'numerical'},
+                        'c': {'sdtype': 'numerical'},
+                    },
+                }
+            }
+        })
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+
+        # Run
+        instance._fit(table_data, metadata)
+
+        # Assert
+        assert instance._dtype == dtype
+        assert instance._is_datetime is False
+        assert instance._low_datetime_format is None
+        assert instance._high_datetime_format is None
+        assert instance._low_diff_column_name == 'a#b'
+        assert instance._high_diff_column_name == 'b#c'
+
+    def test__fit_datetime(self):
+        """Test it for datetime strings."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': pd.to_datetime(['2020-01-01']),
+                'b': pd.to_datetime(['2020-01-02']),
+                'c': pd.to_datetime(['2020-01-03']),
+            })
+        }
+        metadata = Metadata.load_from_dict({
+            'tables': {
+                'table': {
+                    'columns': {
+                        'a': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
+                        'b': {'sdtype': 'datetime'},
+                        'c': {'sdtype': 'datetime'},
+                    },
+                }
+            }
+        })
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+
+        # Run
+        instance._fit(table_data, metadata)
+
+        # Assert
+        assert instance._dtype == np.dtype('<M8[ns]')
+        assert instance._is_datetime is True
+        assert instance._low_datetime_format == '%Y-%m-%d'
+        assert instance._middle_datetime_format is None
+        assert instance._high_datetime_format is None
+        assert instance._low_diff_column_name == 'a#b'
+        assert instance._high_diff_column_name == 'b#c'
+
+    def test__transform(self):
+        """Test it transforms the data correctly."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': [1, 2, 3],
+                'b': [4, 5, 6],
+                'c': [7, 8, 9],
+                'col': [7, 8, 9],
+            })
+        }
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+
+        # Run
+        out = instance._transform(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': [1, 2, 3],
+            'col': [7, 8, 9],
+            'a#b': [np.log(4)] * 3,
+            'b#c': [np.log(4)] * 3,
+        })
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test__transform_with_nans(self):
+        """Test it transforms the data correctly when it contains nans."""
+        # Setup
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+
+        table_data_with_nans = {
+            'table': pd.DataFrame({
+                'a': [1, np.nan, 3, np.nan],
+                'b': [np.nan, 2, 4, np.nan],
+                'c': [np.nan, 3, 5, np.nan],
+            })
+        }
+
+        table_data_without_nans = {
+            'table': pd.DataFrame({
+                'a': [1, 2, 3],
+                'b': [2, 3, 4],
+                'c': [3, 4, 5],
+            })
+        }
+
+        # Run
+        output_with_nans = instance._transform(table_data_with_nans)
+        output_without_nans = instance._transform(table_data_without_nans)
+
+        # Assert
+        output_with_nans = output_with_nans['table']
+        output_without_nans = output_without_nans['table']
+        expected_output_with_nans = pd.DataFrame({
+            'a': [1.0, 2.0, 3.0, 2.0],
+            'a#b': [np.log(2)] * 4,
+            'b#c': [np.log(2)] * 4,
+            'a#b#c.nan_component': ['b, c', 'a', 'None', 'a, b, c'],
+        })
+
+        expected_output_without_nans = pd.DataFrame({
+            'a': [1, 2, 3],
+            'a#b': [np.log(2)] * 3,
+            'b#c': [np.log(2)] * 3,
+        })
+        pd.testing.assert_frame_equal(output_with_nans, expected_output_with_nans)
+        pd.testing.assert_frame_equal(output_without_nans, expected_output_without_nans)
+
+    def test_transform_existing_column_name(self):
+        """Test ``_transform`` method when the ``diff_column_name`` already exists in the table."""
+        # Setup
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+        instance._low_diff_column_name = 'a#b_'
+        table_data = {
+            'table': pd.DataFrame({
+                'a': [1, 2, 3],
+                'b': [4, 5, 6],
+                'c': [7, 8, 9],
+                'col': [7, 8, 9],
+                'a#b': ['c', 'd', 'e'],
+            })
+        }
+
+        # Run
+        output = instance._transform(table_data)
+
+        # Assert
+        output = output['table']
+        expected_column_name = ['a', 'col', 'a#b', 'a#b_', 'b#c']
+        assert list(output.columns) == expected_column_name
+
+    def test__transform_datetime(self):
+        """Test it transforms the data correctly when it contains datetimes."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': pd.to_datetime(['2020-01-01T00:00:00', '2020-01-02T00:00:00']),
+                'b': pd.to_datetime(['2020-01-01T00:00:01', '2020-01-02T00:00:01']),
+                'c': pd.to_datetime(['2020-01-01T00:00:02', '2020-01-02T00:00:02']),
+                'col': [7, 8],
+            })
+        }
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+        instance._is_datetime = True
+
+        # Run
+        out = instance._transform(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': pd.to_datetime(['2020-01-01T00:00:00', '2020-01-02T00:00:00']),
+            'col': [7, 8],
+            'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
+            'b#c': [np.log(1_000_000_001), np.log(1_000_000_001)],
+        })
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test__transform_datetime_dtype_object(self):
+        """Test it transforms the data correctly when the dtype is object."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': ['2020-01-01T00:00:00', '2020-01-02T00:00:00'],
+                'b': ['2020-01-01T00:00:01', '2020-01-02T00:00:01'],
+                'c': ['2020-01-01T00:00:02', '2020-01-02T00:00:02'],
+                'col': [1, 2],
+            })
+        }
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+        instance._is_datetime = True
+        instance._dtype = 'O'
+
+        # Run
+        out = instance._transform(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': ['2020-01-01T00:00:00', '2020-01-02T00:00:00'],
+            'col': [1, 2],
+            'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
+            'b#c': [np.log(1_000_000_001), np.log(1_000_000_001)],
+        })
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test_reverse_transform(self):
+        """Test it reverses the transformation correctly."""
+        # Setup
+        transformed = {
+            'table': pd.DataFrame({
+                'a': [1, 2, 3],
+                'col': [7, 8, 9],
+                'a#b': [np.log(4)] * 3,
+                'b#c': [np.log(4)] * 3,
+            })
+        }
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+        instance._dtype = pd.Series([1]).dtype  # exact dtype (32 or 64) depends on OS
+        instance._original_data_columns = {'table': ['a', 'b', 'c', 'col']}
+        instance._dtypes = {
+            'table': {
+                'a': pd.Series([1]).dtype,
+                'b': pd.Series([1]).dtype,
+                'c': pd.Series([1]).dtype,
+                'col': pd.Series([1]).dtype,
+            }
+        }
+
+        # Run
+        out = instance.reverse_transform(transformed)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': [1, 2, 3],
+            'b': [4, 5, 6],
+            'c': [7, 8, 9],
+            'col': [7, 8, 9],
+        })
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test_reverse_transform_floats(self):
+        """Test it reverses the transformation correctly when the dtype is float."""
+        # Setup
+        transformed = {
+            'table': pd.DataFrame({
+                'a': [1.1, 2.2, 3.3],
+                'col': [7, 8, 9],
+                'a#b': [np.log(4)] * 3,
+                'b#c': [np.log(4)] * 3,
+            })
+        }
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+        instance._dtype = np.dtype('float')
+        instance._original_data_columns = {'table': ['a', 'b', 'c', 'col']}
+        instance._dtypes = {
+            'table': {
+                'a': np.dtype('float'),
+                'b': np.dtype('float'),
+                'c': np.dtype('float'),
+                'col': pd.Series([1]).dtype,
+            }
+        }
+
+        # Run
+        out = instance.reverse_transform(transformed)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': [1.1, 2.2, 3.3],
+            'b': [4.1, 5.2, 6.3],
+            'c': [7.1, 8.2, 9.3],
+            'col': [7, 8, 9],
+        })
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test_reverse_transform_datetime(self):
+        """Test it reverses the transformation correctly when the dtype is datetime."""
+        # Setup
+        transformed = {
+            'table': pd.DataFrame({
+                'a': pd.to_datetime(['2020-01-01T00:00:00', '2020-01-02T00:00:00']),
+                'col': [1, 2],
+                'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
+                'b#c': [np.log(1_000_000_001), np.log(1_000_000_001)],
+            })
+        }
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+        instance._dtype = np.dtype('<M8[ns]')
+        instance._is_datetime = True
+        instance._original_data_columns = {'table': ['a', 'b', 'c', 'col']}
+        instance._dtypes = {
+            'table': {
+                'a': np.dtype('<M8[ns]'),
+                'b': np.dtype('<M8[ns]'),
+                'c': np.dtype('<M8[ns]'),
+                'col': pd.Series([1]).dtype,
+            }
+        }
+
+        # Run
+        out = instance.reverse_transform(transformed)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': pd.to_datetime(['2020-01-01T00:00:00', '2020-01-02T00:00:00']),
+            'b': pd.to_datetime(['2020-01-01T00:00:01', '2020-01-02T00:00:01']),
+            'c': pd.to_datetime(['2020-01-01T00:00:02', '2020-01-02T00:00:02']),
+            'col': [1, 2],
+        })
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test_reverse_transform_datetime_dtype_is_object(self):
+        """Test it reverses the transformation correctly when the dtype is object."""
+        # Setup
+        transformed = {
+            'table': pd.DataFrame({
+                'a': ['2020-01-01T00:00:00', '2020-01-02T00:00:00'],
+                'col': [1, 2],
+                'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
+                'b#c': [np.log(1_000_000_001), np.log(1_000_000_001)],
+            })
+        }
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+        instance._dtype = np.dtype('O')
+        instance._is_datetime = True
+        instance._original_data_columns = {'table': ['a', 'b', 'c', 'col']}
+        instance._dtypes = {
+            'table': {
+                'a': np.dtype('O'),
+                'b': np.dtype('O'),
+                'c': np.dtype('O'),
+                'col': pd.Series([1]).dtype,
+            }
+        }
+
+        # Run
+        out = instance.reverse_transform(transformed)
+
+        # Assert
+        out = out['table']
+        expected_out = pd.DataFrame({
+            'a': ['2020-01-01T00:00:00', '2020-01-02T00:00:00'],
+            'b': [pd.Timestamp('2020-01-01 00:00:01'), pd.Timestamp('2020-01-02 00:00:01')],
+            'c': [pd.Timestamp('2020-01-01 00:00:02'), pd.Timestamp('2020-01-02 00:00:02')],
+            'col': [1, 2],
+        })
+        expected_out['b'] = expected_out['b'].astype(np.dtype('O'))
+        expected_out['c'] = expected_out['c'].astype(np.dtype('O'))
+        pd.testing.assert_frame_equal(out, expected_out)
+
+    def test_is_valid(self):
+        """Test it checks if the data is valid."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': [1, np.nan, 3, 4, None, 6, 8, 0],
+                'b': [4, 2, 2, 4, np.nan, -6, 10, float('nan')],
+                'c': [7, 8, 9, 10, 11, 12, 13, 14],
+                'col': [7, 8, 9, 10, 11, 12, 13, 14],
+            })
+        }
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+        instance._fitted = True
+
+        # Run
+        out = instance.is_valid(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = [True, True, False, False, True, False, True, True]
+        np.testing.assert_array_equal(expected_out, out)
+
+    def test_is_valid_strict_boundaries_true(self):
+        """Test it checks if the data is valid when strict boundaries are False."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': [1, np.nan, 3, 3, None, 6, 8, 0],
+                'b': [4, 2, 2, 4, np.nan, -6, 10, float('nan')],
+                'c': [7, 8, 9, 10, 11, 12, 13, 14],
+                'col': [7, 8, 9, 10, 11, 12, 13, 14],
+            })
+        }
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            strict_boundaries=False,
+            table_name='table',
+        )
+        instance._fitted = True
+
+        # Run
+        out = instance.is_valid(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = [True, True, False, True, True, False, True, True]
+        np.testing.assert_array_equal(expected_out, out)
+
+    def test_is_valid_datetimes(self):
+        """Test it checks if the data is valid when it contains datetimes."""
+        # Setup
+        table_data = {
+            'table': pd.DataFrame({
+                'a': [datetime(2020, 5, 17), datetime(2021, 9, 1), np.nan],
+                'b': [datetime(2020, 5, 18), datetime(2020, 9, 2), datetime(2020, 9, 2)],
+                'c': [datetime(2020, 5, 29), datetime(2021, 9, 3), np.nan],
+                'col': [7, 8, 9],
+            })
+        }
+        instance = Range(
+            low_column_name='a',
+            middle_column_name='b',
+            high_column_name='c',
+            table_name='table',
+        )
+        instance._fitted = True
+
+        # Run
+        out = instance.is_valid(table_data)
+
+        # Assert
+        out = out['table']
+        expected_out = [True, False, True]
+        np.testing.assert_array_equal(expected_out, out)

--- a/tests/unit/cag/test_range.py
+++ b/tests/unit/cag/test_range.py
@@ -1,4 +1,4 @@
-"""Unit tests for Range CAG pattern."""
+"""Unit tests for Range CAG constraint."""
 
 import operator
 import re
@@ -87,7 +87,7 @@ class TestRange:
 
     @patch('sdv.cag.range._validate_table_and_column_names')
     def test__validate_pattern_with_metadata(self, validate_table_and_col_names_mock):
-        """Test validating the pattern with metadata."""
+        """Test validating the constraint with metadata."""
         # Setup
         instance = Range(
             low_column_name='low',

--- a/tests/unit/cag/test_range.py
+++ b/tests/unit/cag/test_range.py
@@ -1,4 +1,4 @@
-"""Unit tests for Range CAG constraint."""
+"""Unit tests for Range constraint."""
 
 import operator
 import re
@@ -86,7 +86,7 @@ class TestRange:
         assert instance._operator == operator.le
 
     @patch('sdv.cag.range._validate_table_and_column_names')
-    def test__validate_pattern_with_metadata(self, validate_table_and_col_names_mock):
+    def test__validate_constraint_with_metadata(self, validate_table_and_col_names_mock):
         """Test validating the constraint with metadata."""
         # Setup
         instance = Range(
@@ -111,12 +111,12 @@ class TestRange:
         })
 
         # Run
-        instance._validate_pattern_with_metadata(metadata)
+        instance._validate_constraint_with_metadata(metadata)
 
         # Assert
         validate_table_and_col_names_mock.assert_called_once()
 
-    def test__validate_pattern_with_metadata_incorrect_sdtype(self):
+    def test__validate_constraint_with_metadata_incorrect_sdtype(self):
         """Test it when the sdtype is not numerical or datetime."""
         # Setup
         instance = Range(
@@ -146,9 +146,9 @@ class TestRange:
             "sdtype must be either 'numerical' or 'datetime'."
         )
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_metadata(metadata)
+            instance._validate_constraint_with_metadata(metadata)
 
-    def test__validate_pattern_with_metadata_non_matching_sdtype(self):
+    def test__validate_constraint_with_metadata_non_matching_sdtype(self):
         """Test it when the sdtypes are not the same."""
         # Setup
         instance = Range(
@@ -178,9 +178,9 @@ class TestRange:
             "Found 'numerical', 'datetime' and 'datetime'."
         )
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_metadata(metadata)
+            instance._validate_constraint_with_metadata(metadata)
 
-    def test__validate_pattern_with_data(self):
+    def test__validate_constraint_with_data(self):
         """Test it when the data is not valid."""
         # Setup
         instance = Range(
@@ -209,9 +209,9 @@ class TestRange:
         # Run and Assert
         err_msg = re.escape('The range requirement is not met for row indices: [1]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
-    def test__validate_pattern_with_data_multiple_rows(self):
+    def test__validate_constraint_with_data_multiple_rows(self):
         """Test it when the data is not valid for over 5 rows."""
         # Setup
         instance = Range(
@@ -248,9 +248,9 @@ class TestRange:
             'The range requirement is not met for row indices: [1, 4, 6, 7, 8, +1 more]'
         )
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
-    def test__validate_pattern_with_data_nans(self):
+    def test__validate_constraint_with_data_nans(self):
         """Test it when the data is not valid and contains nans."""
         # Setup
         instance = Range(
@@ -285,9 +285,9 @@ class TestRange:
         # Run and Assert
         err_msg = re.escape('The range requirement is not met for row indices: [2, 3, 5]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
-    def test__validate_pattern_with_data_strict_boundaries_false(self):
+    def test__validate_constraint_with_data_strict_boundaries_false(self):
         """Test it when the data is not valid and contains nans."""
         # Setup
         instance = Range(
@@ -323,9 +323,9 @@ class TestRange:
         # Run and Assert
         err_msg = re.escape('The range requirement is not met for row indices: [2, 5]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
-    def test__validate_pattern_with_data_datetime(self):
+    def test__validate_constraint_with_data_datetime(self):
         """Test it when the data is not valid and contains datetimes."""
         # Setup
         instance = Range(
@@ -361,7 +361,7 @@ class TestRange:
         # Run and Assert
         err_msg = re.escape('The range requirement is not met for row indices: [1]')
         with pytest.raises(ConstraintNotMetError, match=err_msg):
-            instance._validate_pattern_with_data(data, metadata)
+            instance._validate_constraint_with_data(data, metadata)
 
     def test__get_updated_metadata(self):
         """Test the ``_get_updated_metadata`` method."""

--- a/tests/unit/constraints/test_tabular.py
+++ b/tests/unit/constraints/test_tabular.py
@@ -1829,6 +1829,15 @@ class TestInequality:
 
 
 class TestScalarInequality:
+    def test__deprecation_warning(self):
+        """Test that a deprecation warning is thrown when used."""
+        deprecation_msg = re.escape(
+            'Warning: The `ScalarInequality` constraint is deprecated. '
+            'Please use the `enforce_min_max_values` parameter instead.'
+        )
+        with pytest.warns(FutureWarning, match=deprecation_msg):
+            ScalarInequality('column_name', '<', 10)
+
     def test__validate_inputs(self):
         """Test the ``ScalarInequality._validate_inputs`` method.
 
@@ -2511,6 +2520,15 @@ class TestScalarInequality:
 
 
 class TestPositive:
+    def test__deprecation_warning(self):
+        """Test that a deprecation warning is thrown when used."""
+        deprecation_msg = re.escape(
+            'Warning: The `Positive` constraint is deprecated. '
+            'Please use the `enforce_min_max_values` parameter instead.'
+        )
+        with pytest.warns(FutureWarning, match=deprecation_msg):
+            Positive('column_name')
+
     def test__validate_inputs(self):
         """Test the ``Positive._validate_inputs`` method.
 
@@ -2641,6 +2659,15 @@ class TestPositive:
 
 
 class TestNegative:
+    def test__deprecation_warning(self):
+        """Test that a deprecation warning is thrown when used."""
+        deprecation_msg = re.escape(
+            'Warning: The `Negative` constraint is deprecated. '
+            'Please use the `enforce_min_max_values` parameter instead.'
+        )
+        with pytest.warns(FutureWarning, match=deprecation_msg):
+            Negative('column_name')
+
     def test__validate_inputs(self):
         """Test the ``Negative._validate_inputs`` method.
 
@@ -3328,6 +3355,15 @@ class TestRange:
 
 
 class TestScalarRange:
+    def test__deprecation_warning(self):
+        """Test that a deprecation warning is thrown when used."""
+        deprecation_msg = re.escape(
+            'Warning: The `ScalarRange` constraint is deprecated. '
+            'Please use the `enforce_min_max_values` parameter instead.'
+        )
+        with pytest.warns(FutureWarning, match=deprecation_msg):
+            ScalarRange('column_name', 0, 10)
+
     def test__validate_inputs(self):
         """Test the ``ScalarRange._validate_inputs`` method.
 

--- a/tests/unit/lite/test_single_table.py
+++ b/tests/unit/lite/test_single_table.py
@@ -63,12 +63,11 @@ class TestSingleTablePreset:
             locales=['en_US', 'fr_CA'],
         )
 
-    @patch('sdv.single_table.base.DataProcessor')
-    def test_get_parameters(self, mock_data_processor):
+    def test_get_parameters(self):
         """Test that it returns every ``init`` parameter without the ``metadata``."""
         # Setup
-        metadata = Mock()
-        metadata.get_column_names.return_value = []
+        metadata = SingleTableMetadata()
+        metadata.add_column('key', sdtype='id')
         instance = SingleTablePreset(metadata, name='FAST_ML')
 
         # Run
@@ -77,15 +76,12 @@ class TestSingleTablePreset:
         # Assert
         assert parameters == {'name': 'FAST_ML', 'locales': ['en_US']}
 
-    @patch('sdv.single_table.base.DataProcessor')
-    def test_get_metadata(self, mock_data_processor):
+    def test_get_metadata(self):
         """Test that it returns the ``metadata`` object."""
         # Setup
-        metadata = Mock(spec=SingleTableMetadata)
+        metadata = SingleTableMetadata()
+        metadata.add_column('key', sdtype='id')
         metadata._updated = False
-        metadata.columns = {}
-        metadata.get_column_names.return_value = []
-        metadata.to_dict.return_value = {'METADATA_SPEC_VERSION': 'SINGLE_TABLE_V1'}
         instance = SingleTablePreset(metadata, 'FAST_ML')
 
         # Run
@@ -286,7 +282,9 @@ class TestSingleTablePreset:
     def test___repr__(self):
         """Test that a string of format 'SingleTablePreset(name=<name>)' is returned"""
         # Setup
-        instance = SingleTablePreset(metadata=SingleTableMetadata(), name='FAST_ML')
+        metadata = SingleTableMetadata()
+        metadata.add_column('key', sdtype='id')
+        instance = SingleTablePreset(metadata=metadata, name='FAST_ML')
 
         # Run
         res = repr(instance)

--- a/tests/unit/metadata/test_multi_table.py
+++ b/tests/unit/metadata/test_multi_table.py
@@ -1400,13 +1400,13 @@ class TestMultiTableMetadata:
         # Run and Assert
         error_msg = re.escape(
             'The provided data does not match the metadata:\n'
-            "Table: 'nesreca'\n"
+            'Errors in nesreca:\n'
             "Error: Invalid values found for numerical column 'nesreca_val': ['0', '1', '2', "
             "'+ 7 more']."
-            "\n\nTable: 'oseba'\n"
+            '\n\nErrors in oseba:\n'
             "Error: Invalid values found for numerical column 'oseba_val': ['0', '1', '2', "
             "'+ 7 more']."
-            "\n\nTable: 'upravna_enota'\n"
+            '\n\nErrors in upravna_enota:\n'
             "Error: Invalid values found for numerical column 'upravna_val': ['0', '1', '2', "
             "'+ 7 more']."
         )

--- a/tests/unit/metadata/test_single_table.py
+++ b/tests/unit/metadata/test_single_table.py
@@ -74,7 +74,7 @@ class TestSingleTableMetadata:
                 "Invalid values '(anonymization, order_by)' for phone_number column 'phone'."
             ),
         ),
-    ]  # noqa: JS102
+    ]
 
     @pytest.fixture
     def data(self):

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -1406,33 +1406,6 @@ class TestBaseMultiTableSynthesizer:
         output_oseba = instance._table_synthesizers['oseba'].get_constraints()
         assert output_oseba == []
 
-    @pytest.mark.skip('Old-style constraints are deprecated')
-    def test_get_constraints(self):
-        """Test a list of constraints is returned by the method."""
-        # Setup
-        metadata = get_multi_table_metadata()
-        instance = BaseMultiTableSynthesizer(metadata)
-        metadata.add_column('positive_int', 'nesreca', sdtype='numerical')
-        metadata.add_column('negative_int', 'oseba', sdtype='numerical')
-        positive_constraint = {
-            'constraint_class': 'Positive',
-            'table_name': 'nesreca',
-            'constraint_parameters': {'column_name': 'nesreca_val', 'strict_boundaries': True},
-        }
-        negative_constraint = {
-            'constraint_class': 'Negative',
-            'table_name': 'oseba',
-            'constraint_parameters': {'column_name': 'oseba_val', 'strict_boundaries': False},
-        }
-        constraints = [positive_constraint, negative_constraint]
-        instance.add_constraints(constraints)
-
-        # Run
-        output = instance.get_constraints()
-
-        # Assert
-        assert output == constraints
-
     @patch('sdv.multi_table.base._validate_constraints')
     def test_add_constraints(self, validate_constraints_mock):
         """Test adding constraint to the synthesizer."""
@@ -1487,7 +1460,7 @@ class TestBaseMultiTableSynthesizer:
         assert instance.constraints == [constraint1, constraint2]
 
     @patch('sdv.multi_table.base.deepcopy')
-    def test_get_cag(self, copy_mock):
+    def test_get_constraints(self, copy_mock):
         """Test getting data constraints from the synthesizer."""
         # Setup
         instance = Mock()
@@ -1496,9 +1469,9 @@ class TestBaseMultiTableSynthesizer:
         constraint2 = Mock()
 
         # Run
-        no_constraints = BaseMultiTableSynthesizer.get_cag(instance)
+        no_constraints = BaseMultiTableSynthesizer.get_constraints(instance)
         instance.constraints = [constraint1, constraint2]
-        constraints = BaseMultiTableSynthesizer.get_cag(instance)
+        constraints = BaseMultiTableSynthesizer.get_constraints(instance)
 
         # Assert
         assert no_constraints == []

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 
 from sdv import version
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.errors import (
     InvalidDataError,
     NotFittedError,
@@ -428,7 +428,7 @@ class TestBaseMultiTableSynthesizer:
         cag_mock_2 = Mock()
         cag_mock_2.is_valid.return_value = {table_name: pd.Series([True])}
         cag_mock_2.table_name = table_name
-        instance.patterns = [cag_mock_1, cag_mock_2]
+        instance.constraints = [cag_mock_1, cag_mock_2]
         copy_mock.return_value = [cag_mock_1, cag_mock_2]
 
         # Run
@@ -450,11 +450,11 @@ class TestBaseMultiTableSynthesizer:
         cag_mock_1 = Mock()
         cag_mock_1.table_name = table_name
         cag_mock_1.is_valid.return_value = {table_name: pd.Series([False])}
-        instance.patterns = [cag_mock_1]
+        instance.constraints = [cag_mock_1]
         msg = f"Table '{table_name}': The mock requirement is not met for row indices: 0."
 
         # Run and Assert
-        with pytest.raises(PatternNotMetError, match=msg):
+        with pytest.raises(ConstraintNotMetError, match=msg):
             instance.validate_cag(synthetic_data)
 
     def test_validate(self):

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -1523,8 +1523,8 @@ class TestBaseMultiTableSynthesizer:
         patterns_metadata = BaseMultiTableSynthesizer.get_metadata(instance)
 
         # Assert
-        assert no_patterns_metadata == metadata
-        assert patterns_metadata == metadata
+        assert no_patterns_metadata.to_dict() == metadata.to_dict()
+        assert patterns_metadata.to_dict() == metadata.to_dict()
 
     def test_get_metadata_modified(self):
         """Test getting the modified metadata from the synthesizer."""
@@ -1537,7 +1537,7 @@ class TestBaseMultiTableSynthesizer:
         returned_metadata = BaseMultiTableSynthesizer.get_metadata(instance, 'modified')
 
         # Assert
-        assert returned_metadata == metadata
+        assert returned_metadata.to_dict() == metadata.to_dict()
 
     def test_get_metadata_bad_keyword(self):
         """Test passing a bad keyword to ``get_metadata``."""

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -489,13 +489,13 @@ class TestBaseMultiTableSynthesizer:
         # Run and Assert
         error_msg = re.escape(
             'The provided data does not match the metadata:\n'
-            "Table: 'nesreca'\n"
+            'Errors in nesreca:\n'
             "Error: Invalid values found for numerical column 'nesreca_val': ['0', '1', '2', "
             "'+ 7 more']."
-            "\n\nTable: 'oseba'\n"
+            '\n\nErrors in oseba:\n'
             "Error: Invalid values found for numerical column 'oseba_val': ['0', '1', '2', "
             "'+ 7 more']."
-            "\n\nTable: 'upravna_enota'\n"
+            '\n\nErrors in upravna_enota:\n'
             "Error: Invalid values found for numerical column 'upravna_val': ['0', '1', '2', "
             "'+ 7 more']."
         )
@@ -651,8 +651,9 @@ class TestBaseMultiTableSynthesizer:
         # Run
         error_msg = re.escape(
             'The provided data does not match the metadata:\n'
-            "The columns ['col1'] are not present in the metadata.\n\n"
-            "The metadata columns ['id_nesreca', 'nesreca_val', 'upravna_enota'] "
+            'Errors in nesreca:\n'
+            "Error: The columns ['col1'] are not present in the metadata.\n"
+            "Error: The metadata columns ['id_nesreca', 'nesreca_val', 'upravna_enota'] "
             'are not present in the data.'
         )
 

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -1387,6 +1387,7 @@ class TestBaseMultiTableSynthesizer:
         output_oseba = instance._table_synthesizers['oseba'].get_constraints()
         assert output_oseba == []
 
+    @pytest.mark.skip('Old-style constraints are deprecated')
     def test_get_constraints(self):
         """Test a list of constraints is returned by the method."""
         # Setup
@@ -1500,8 +1501,8 @@ class TestBaseMultiTableSynthesizer:
         constraints_metadata = BaseMultiTableSynthesizer.get_metadata(instance)
 
         # Assert
-        assert no_constraints_metadata == metadata
-        assert constraints_metadata == metadata
+        assert no_constraints_metadata.to_dict() == metadata.to_dict()
+        assert constraints_metadata.to_dict() == metadata.to_dict()
 
     def test_get_metadata_modified(self):
         """Test getting the modified metadata from the synthesizer."""

--- a/tests/unit/multi_table/test_hma.py
+++ b/tests/unit/multi_table/test_hma.py
@@ -118,8 +118,8 @@ class TestHMASynthesizer:
 
         # Assert
         get_distributions_mock.assert_called_once()
-        for pattern in key_phrases:
-            match = re.search(pattern, captured.out + captured.err)
+        for constraint in key_phrases:
+            match = re.search(constraint, captured.out + captured.err)
             assert match is not None
 
         # Run
@@ -127,8 +127,8 @@ class TestHMASynthesizer:
         captured = capsys.readouterr()
 
         # Assert that small amount of columns don't trigger the message
-        for pattern in key_phrases:
-            match = re.search(pattern, captured.out + captured.err)
+        for constraint in key_phrases:
+            match = re.search(constraint, captured.out + captured.err)
             assert match is None
 
     def test__get_extension_foreign_key_only(self):

--- a/tests/unit/sequential/test_par.py
+++ b/tests/unit/sequential/test_par.py
@@ -82,7 +82,7 @@ class TestPARSynthesizer:
             == metadata._convert_to_single_table().to_dict()
         )
         assert isinstance(synthesizer._context_synthesizer, GaussianCopulaSynthesizer)
-        assert synthesizer._context_synthesizer.metadata.columns == {
+        assert synthesizer._context_synthesizer._get_table_metadata().columns == {
             'gender': {'sdtype': 'categorical'},
             'name': {'sdtype': 'id'},
         }

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -2271,7 +2271,7 @@ class TestBaseSingleTableSynthesizer:
             constraint_mock, 'custom'
         )
 
-    def test_add_constraint_warning(self):
+    def test_add_constraints_warning(self):
         """Test a warning is raised when the synthesizer had already been fitted."""
         # Setup
         metadata = Metadata()

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -353,7 +353,7 @@ class TestBaseSingleTableSynthesizer:
         result = instance.get_metadata()
 
         # Assert
-        assert result == metadata
+        assert result.to_dict() == metadata.to_dict()
 
     def test_auto_assign_transformers(self):
         """Test that the ``DataProcessor.prepare_for_fitting`` is being called."""

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -2283,6 +2283,7 @@ class TestBaseSingleTableSynthesizer:
         with pytest.warns(UserWarning, match=warn_msg):
             instance.add_constraints([])
 
+    @pytest.mark.skip('Old-style constraints are deprecated')
     def test_get_constraints(self):
         """Test a list of constraints is returned by the method."""
         # Setup

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -138,16 +138,16 @@ class TestBaseSingleTableSynthesizer:
         """Test the ``_validate_regex_format`` method."""
         # Setup
         instance = Mock()
-        single_table_metadata = Mock()
-        single_table_metadata.get_column_names.return_value = ['id_1', 'id_2']
         metadata = Mock()
-        metadata._convert_to_single_table.return_value = single_table_metadata
+        metadata.get_column_names.return_value = ['id_1', 'id_2']
 
         columns = {
             'id_1': {'sdtype': 'id', 'regex_format': '[0-9]+'},
             'id_2': {'sdtype': 'id', 'regex_format': '[a-z]{3}'},
         }
-        single_table_metadata.columns = columns
+        metadata.tables = {}
+        metadata.tables['table_1'] = Mock()
+        metadata.tables['table_1'].columns = columns
 
         instance.metadata = metadata
         instance._table_name = 'table_1'

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -18,7 +18,7 @@ from rdt.transformers import (
 )
 
 from sdv import version
-from sdv.cag._errors import PatternNotMetError
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.constraints.errors import AggregateConstraintsError
 from sdv.errors import (
     ConstraintsNotMetError,
@@ -2406,7 +2406,7 @@ class TestBaseSingleTableSynthesizer:
             }
 
     def test_validate_cag(self):
-        """Test the ``_validate_cag`` method with multiple patterns."""
+        """Test the ``_validate_cag`` method with multiple constraints."""
         # Setup
         synthetic_data = pd.DataFrame()
         transformed_data = pd.DataFrame()
@@ -2415,7 +2415,7 @@ class TestBaseSingleTableSynthesizer:
         cag_mock_1 = Mock()
         cag_mock_1.transform.return_value = transformed_data
         cag_mock_2 = Mock()
-        instance._chained_patterns = [cag_mock_1, cag_mock_2]
+        instance._chained_constraints = [cag_mock_1, cag_mock_2]
 
         # Run
         instance.validate_cag(synthetic_data)
@@ -2434,9 +2434,9 @@ class TestBaseSingleTableSynthesizer:
         instance = BaseSingleTableSynthesizer(original_metadata)
         cag_mock_1 = Mock()
         cag_mock_1.is_valid.return_value = pd.Series([False, False])
-        instance._chained_patterns = [cag_mock_1]
+        instance._chained_constraints = [cag_mock_1]
         msg = 'The mock requirement is not met for row indices: 0, 1.'
 
         # Run and Assert
-        with pytest.raises(PatternNotMetError, match=msg):
+        with pytest.raises(ConstraintNotMetError, match=msg):
             instance.validate_cag(synthetic_data)

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -486,6 +486,7 @@ class TestBaseSingleTableSynthesizer:
         instance._fitted = True
         instance._store_and_convert_original_cols.return_value = False
         data = pd.DataFrame({'name': ['John', 'Doe', 'John Doe']})
+        instance._transform_helper.return_value = data
 
         # Run
         BaseSingleTableSynthesizer.preprocess(instance, data)
@@ -1053,6 +1054,8 @@ class TestBaseSingleTableSynthesizer:
         instance._data_processor.reverse_transform.return_value = data
         instance._data_processor.filter_valid.return_value = data
         instance._data_processor._hyper_transformer._input_columns = []
+        instance._reject_sampling_patterns = []
+        instance._chained_patterns = []
 
         # Run
         sampled, num_valid = BaseSingleTableSynthesizer._sample_rows(instance, 3)
@@ -1080,6 +1083,8 @@ class TestBaseSingleTableSynthesizer:
         instance._filter_conditions.return_value = data[data.name == 'John Doe']
         conditions = {'salary': 80.0}
         transformed_conditions = {'salary': 80.0}
+        instance._reject_sampling_patterns = []
+        instance._chained_patterns = []
 
         # Run
         sampled, num_valid = BaseSingleTableSynthesizer._sample_rows(
@@ -1111,6 +1116,8 @@ class TestBaseSingleTableSynthesizer:
         instance._data_processor._hyper_transformer._input_columns = []
         instance._data_processor.filter_valid = lambda x: x
         instance._data_processor.reverse_transform.return_value = data
+        instance._reject_sampling_patterns = []
+        instance._chained_patterns = []
 
         # Run
         sampled, num_valid = BaseSingleTableSynthesizer._sample_rows(
@@ -1137,6 +1144,8 @@ class TestBaseSingleTableSynthesizer:
         instance._data_processor.reverse_transform.return_value = data
         instance._data_processor._hyper_transformer._input_columns = []
         instance._filter_conditions.return_value = data[data.name == 'John Doe']
+        instance._reject_sampling_patterns = []
+        instance._chained_patterns = []
         conditions = {'salary': 80.0}
         transformed_conditions = {'salary': 80.0}
         instance._sample.side_effect = [NotImplementedError, pd.DataFrame()]
@@ -1684,6 +1693,7 @@ class TestBaseSingleTableSynthesizer:
         )
         instance.get_metadata.return_value._constraints = False
         instance._sample_with_progress_bar.return_value = pd.DataFrame({'col': [1, 2, 3]})
+        instance._reverse_transform_helper.return_value = pd.DataFrame({'col': [1, 2, 3]})
 
         # Run
         with catch_sdv_logs(caplog, logging.INFO, logger='SingleTableSynthesizer'):

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -1100,8 +1100,8 @@ class TestBaseSingleTableSynthesizer:
         instance._data_processor.reverse_transform.return_value = data
         instance._data_processor.filter_valid.return_value = data
         instance._data_processor._hyper_transformer._input_columns = []
-        instance._reject_sampling_patterns = []
-        instance._chained_patterns = []
+        instance._reject_sampling_constraints = []
+        instance._chained_constraints = []
 
         # Run
         sampled, num_valid = BaseSingleTableSynthesizer._sample_rows(instance, 3)
@@ -1129,8 +1129,8 @@ class TestBaseSingleTableSynthesizer:
         instance._filter_conditions.return_value = data[data.name == 'John Doe']
         conditions = {'salary': 80.0}
         transformed_conditions = {'salary': 80.0}
-        instance._reject_sampling_patterns = []
-        instance._chained_patterns = []
+        instance._reject_sampling_constraints = []
+        instance._chained_constraints = []
 
         # Run
         sampled, num_valid = BaseSingleTableSynthesizer._sample_rows(
@@ -1162,8 +1162,8 @@ class TestBaseSingleTableSynthesizer:
         instance._data_processor._hyper_transformer._input_columns = []
         instance._data_processor.filter_valid = lambda x: x
         instance._data_processor.reverse_transform.return_value = data
-        instance._reject_sampling_patterns = []
-        instance._chained_patterns = []
+        instance._reject_sampling_constraints = []
+        instance._chained_constraints = []
 
         # Run
         sampled, num_valid = BaseSingleTableSynthesizer._sample_rows(
@@ -1190,8 +1190,8 @@ class TestBaseSingleTableSynthesizer:
         instance._data_processor.reverse_transform.return_value = data
         instance._data_processor._hyper_transformer._input_columns = []
         instance._filter_conditions.return_value = data[data.name == 'John Doe']
-        instance._reject_sampling_patterns = []
-        instance._chained_patterns = []
+        instance._reject_sampling_constraints = []
+        instance._chained_constraints = []
         conditions = {'salary': 80.0}
         transformed_conditions = {'salary': 80.0}
         instance._sample.side_effect = [NotImplementedError, pd.DataFrame()]
@@ -2282,37 +2282,6 @@ class TestBaseSingleTableSynthesizer:
         warn_msg = "For these constraints to take effect, please refit the synthesizer using 'fit'."
         with pytest.warns(UserWarning, match=warn_msg):
             instance.add_constraints([])
-
-    def test_add_constraints(self):
-        """Test a list of constraints can be added to the synthesizer."""
-        # Setup
-        metadata = Metadata()
-        metadata.add_table('table')
-        metadata.add_column('col', 'table', sdtype='numerical')
-        instance = BaseSingleTableSynthesizer(metadata)
-        positive_constraint = {
-            'constraint_class': 'Positive',
-            'constraint_parameters': {'column_name': 'col', 'strict_boundaries': True},
-        }
-        negative_constraint = {
-            'constraint_class': 'Negative',
-            'constraint_parameters': {'column_name': 'col', 'strict_boundaries': False},
-        }
-
-        # Run
-        instance.add_constraints([positive_constraint, negative_constraint])
-        output = instance.get_constraints()
-
-        # Assert
-        positive_constraint = {
-            'constraint_class': 'Positive',
-            'constraint_parameters': {'column_name': 'col', 'strict_boundaries': True},
-        }
-        negative_constraint = {
-            'constraint_class': 'Negative',
-            'constraint_parameters': {'column_name': 'col', 'strict_boundaries': False},
-        }
-        assert output == [positive_constraint, negative_constraint]
 
     def test_get_constraints(self):
         """Test a list of constraints is returned by the method."""

--- a/tests/unit/single_table/test_copulas.py
+++ b/tests/unit/single_table/test_copulas.py
@@ -535,7 +535,11 @@ class TestGaussianCopulaSynthesizer:
         """Test that it returns a list with columns that are from the metadata."""
         # Seutp
         instance = Mock()
-        instance.metadata.columns = {'a_value': object(), 'n_value': object(), 'b_value': object()}
+        instance._get_table_metadata.return_value.columns = {
+            'a_value': object(),
+            'n_value': object(),
+            'b_value': object(),
+        }
         columns = ['a', 'a_value.is_null', '__b_value', '__a_value__b_value', 'n_value']
 
         # Run

--- a/tests/unit/single_table/test_ctgan.py
+++ b/tests/unit/single_table/test_ctgan.py
@@ -273,6 +273,8 @@ class TestCTGANSynthesizer:
         """
         # Setup
         metadata = Metadata()
+        metadata.add_table('table')
+        metadata.add_column('id', 'table', sdtype='numerical')
         single_metadata = metadata._convert_to_single_table()
         instance = CTGANSynthesizer(single_metadata)
         processed_data = Mock()
@@ -282,11 +284,11 @@ class TestCTGANSynthesizer:
 
         # Assert
         mock_category_validate.assert_called_once_with(processed_data)
-        mock_detect_discrete_columns.assert_called_once_with(
-            single_metadata,
-            processed_data,
-            instance._data_processor._hyper_transformer.field_transformers,
-        )
+        mock_detect_discrete_columns.assert_called_once()
+        args = mock_detect_discrete_columns.call_args[0]
+        assert isinstance(args[0], Metadata)
+        assert args[1] == processed_data
+        assert args[2] == instance._data_processor._hyper_transformer.field_transformers
         mock_ctgan.assert_called_once_with(
             batch_size=500,
             cuda=True,
@@ -475,6 +477,8 @@ class TestTVAESynthesizer:
         """
         # Setup
         metadata = Metadata()
+        metadata.add_table('table')
+        metadata.add_column('id', 'table', sdtype='numerical')
         single_metadata = metadata._convert_to_single_table()
         instance = TVAESynthesizer(single_metadata)
         processed_data = Mock()
@@ -484,11 +488,11 @@ class TestTVAESynthesizer:
 
         # Assert
         mock_category_validate.assert_called_once_with(processed_data)
-        mock_detect_discrete_columns.assert_called_once_with(
-            single_metadata,
-            processed_data,
-            instance._data_processor._hyper_transformer.field_transformers,
-        )
+        mock_detect_discrete_columns.assert_called_once()
+        args = mock_detect_discrete_columns.call_args[0]
+        assert isinstance(args[0], Metadata)
+        assert args[1] == processed_data
+        assert args[2] == instance._data_processor._hyper_transformer.field_transformers
         mock_tvae.assert_called_once_with(
             batch_size=500,
             compress_dims=(128, 128),

--- a/tests/unit/test__utils.py
+++ b/tests/unit/test__utils.py
@@ -675,6 +675,7 @@ def test_generate_synthesizer_id(mock_version, mock_uuid):
     mock_version.public = '1.0.0'
     mock_uuid.uuid4.return_value = '92aff11e-9a56-49d1-a280-990d1231a5f5'
     metadata = SingleTableMetadata()
+    metadata.add_column('key', sdtype='id')
     synthesizer = BaseSingleTableSynthesizer(metadata)
 
     # Run

--- a/tests/unit/test__utils.py
+++ b/tests/unit/test__utils.py
@@ -737,8 +737,8 @@ def test_get_possible_chars_handles_max_repeat(mock_get_chars):
     assert possible_chars == [str(i) for i in range(1, 10)]
 
 
-def test_get_possible_chars_num_subpatterns():
-    """Test that only characters for first x subpatterns are returned."""
+def test_get_possible_chars_num_subconstraints():
+    """Test that only characters for first x subconstraints are returned."""
     # Setup
     regex = 'HID_[0-9]{3}_[a-z]{3}'
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -132,3 +132,14 @@ def catch_sdv_logs(caplog, level, logger):
     finally:
         logger.setLevel(orig_level)
         logger.removeHandler(caplog.handler)
+
+
+def run_pattern(pattern, data, metadata):
+    """Run a pattern."""
+    pattern.validate(data, metadata)
+    updated_metadata = pattern.get_updated_metadata(metadata)
+    pattern.fit(data, metadata)
+    transformed = pattern.transform(data)
+    reverse_transformed = pattern.reverse_transform(transformed)
+
+    return updated_metadata, transformed, reverse_transformed

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -134,12 +134,12 @@ def catch_sdv_logs(caplog, level, logger):
         logger.removeHandler(caplog.handler)
 
 
-def run_pattern(pattern, data, metadata):
-    """Run a pattern."""
-    pattern.validate(data, metadata)
-    updated_metadata = pattern.get_updated_metadata(metadata)
-    pattern.fit(data, metadata)
-    transformed = pattern.transform(data)
-    reverse_transformed = pattern.reverse_transform(transformed)
+def run_pattern(constraint, data, metadata):
+    """Run a constraint."""
+    constraint.validate(data, metadata)
+    updated_metadata = constraint.get_updated_metadata(metadata)
+    constraint.fit(data, metadata)
+    transformed = constraint.transform(data)
+    reverse_transformed = constraint.reverse_transform(transformed)
 
     return updated_metadata, transformed, reverse_transformed

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,6 +19,21 @@ class DataFrameMatcher:
         return True
 
 
+class DataFrameDictMatcher:
+    """Match a given dictionary of pandas DataFrames in a mock function call."""
+
+    def __init__(self, data):
+        self.data = data
+
+    def __eq__(self, other):
+        """Assert the data keys match, then use pandas to assert the values are equal."""
+        assert self.data.keys() == other.keys()
+        for key in self.data:
+            pd.testing.assert_frame_equal(self.data[key], other[key])
+
+        return True
+
+
 class SeriesMatcher:
     """Match a given Pandas Series in a mock function call."""
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -134,7 +134,7 @@ def catch_sdv_logs(caplog, level, logger):
         logger.removeHandler(caplog.handler)
 
 
-def run_pattern(constraint, data, metadata):
+def run_constraint(constraint, data, metadata):
     """Run a constraint."""
     constraint.validate(data, metadata)
     updated_metadata = constraint.get_updated_metadata(metadata)


### PR DESCRIPTION
Resolve #2492
CU-86b4ut5ed

I tried to follow the issue carefully and rename everything appropriately, but feel free to double-check terms like 'pattern', 'cag pattern', etc...
Should `valide_cag()` be renamed `validate_constraint()` also?
