### PR TITLE
`ValueError` if conditionally sampling on a column dropped by constraints

### DIFF
--- a/sdv/cag/inequality.py
+++ b/sdv/cag/inequality.py
@@ -127,7 +127,7 @@ class Inequality(BasePattern):
         data = data[table_name]
         low, high = self._get_data(data)
         is_datetime = self._get_is_datetime(metadata, table_name)
-        if is_datetime and data[self._high_column_name].dtypes == 'O':
+        if is_datetime and data[self._low_column_name].dtypes == 'O':
             low_format = self._get_datetime_format(metadata, table_name, self._low_column_name)
             high_format = self._get_datetime_format(metadata, table_name, self._high_column_name)
             low = cast_to_datetime64(low, low_format)

--- a/sdv/cag/inequality.py
+++ b/sdv/cag/inequality.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_object_dtype
 
 from sdv._utils import _convert_to_timedelta, _create_unique_name
 from sdv.cag._errors import PatternNotMetError
@@ -127,7 +128,7 @@ class Inequality(BasePattern):
         data = data[table_name]
         low, high = self._get_data(data)
         is_datetime = self._get_is_datetime(metadata, table_name)
-        if is_datetime and data[self._low_column_name].dtypes == 'O':
+        if is_datetime and is_object_dtype(data[self._low_column_name]):
             low_format = self._get_datetime_format(metadata, table_name, self._low_column_name)
             high_format = self._get_datetime_format(metadata, table_name, self._high_column_name)
             low = cast_to_datetime64(low, low_format)
@@ -285,7 +286,7 @@ class Inequality(BasePattern):
             diff_column = _convert_to_timedelta(diff_column)
 
         low = table_data[self._low_column_name].to_numpy()
-        if self._is_datetime and self._dtype == 'O':
+        if self._is_datetime and is_object_dtype(self._dtype):
             low = cast_to_datetime64(low)
 
         table_data[self._high_column_name] = pd.Series(diff_column + low).astype(self._dtype)
@@ -310,7 +311,7 @@ class Inequality(BasePattern):
         is_valid = _get_is_valid_dict(data, table_name)
         table_data = data[table_name]
         low, high = self._get_data(table_data)
-        if self._is_datetime and self._dtype == 'O':
+        if self._is_datetime and is_object_dtype(self._dtype):
             low = cast_to_datetime64(low, self._low_datetime_format)
             high = cast_to_datetime64(high, self._high_datetime_format)
 

--- a/sdv/cag/range.py
+++ b/sdv/cag/range.py
@@ -4,6 +4,7 @@ import operator
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_object_dtype
 
 from sdv._utils import _convert_to_timedelta, _create_unique_name
 from sdv.cag._errors import PatternNotMetError
@@ -148,7 +149,7 @@ class Range(BasePattern):
         mid = table_data[self._middle_column_name]
         high = table_data[self._high_column_name]
 
-        if self._is_datetime and self._dtype == 'O':
+        if self._is_datetime and is_object_dtype(self._dtype):
             low = cast_to_datetime64(low, self._low_datetime_format)
             mid = cast_to_datetime64(mid, self._middle_datetime_format)
             high = cast_to_datetime64(high, self._high_datetime_format)
@@ -335,7 +336,7 @@ class Range(BasePattern):
             high_diff_column = _convert_to_timedelta(high_diff_column)
 
         low = table_data[self._low_column_name].to_numpy()
-        if self._is_datetime and self._dtype == 'O':
+        if self._is_datetime and is_object_dtype(self._dtype):
             low = cast_to_datetime64(low, self._low_datetime_format)
 
         middle = pd.Series(low_diff_column + low).astype(self._dtype)

--- a/sdv/constraints/utils.py
+++ b/sdv/constraints/utils.py
@@ -312,9 +312,6 @@ def get_lower_precision_format(primary_format, secondary_format):
         str:
             The datetime format string with the lower precision level.
     """
-    if primary_format is None or secondary_format is None:
-        return primary_format if secondary_format is None else secondary_format
-
     primary_level = get_datetime_format_precision(primary_format)
     secondary_level = get_datetime_format_precision(secondary_format)
     if primary_level >= secondary_level:

--- a/sdv/constraints/utils.py
+++ b/sdv/constraints/utils.py
@@ -312,6 +312,9 @@ def get_lower_precision_format(primary_format, secondary_format):
         str:
             The datetime format string with the lower precision level.
     """
+    if primary_format is None or secondary_format is None:
+        return primary_format if secondary_format is None else secondary_format
+
     primary_level = get_datetime_format_precision(primary_format)
     secondary_level = get_datetime_format_precision(secondary_format)
     if primary_level >= secondary_level:

--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -897,11 +897,13 @@ class DataProcessor:
                 }
                 missing_columns = [col for col in missing_columns if col not in conditions]
 
-            anonymized_data = self._hyper_transformer.create_anonymized_columns(
-                num_rows=num_rows, column_names=missing_columns
-            )
-            sampled_columns.extend(missing_columns)
-            reversed_data[anonymized_data.columns] = anonymized_data[anonymized_data.notna()]
+            if missing_columns:
+                anonymized_data = self._hyper_transformer.create_anonymized_columns(
+                    num_rows=num_rows, column_names=missing_columns
+                )
+                sampled_columns.extend(missing_columns)
+                reversed_data[anonymized_data.columns] = anonymized_data[anonymized_data.notna()]
+
             conditional_data = pd.DataFrame(missing_conditions, index=reversed_data.index)
             sampled_columns.extend(list(missing_conditions.keys()))
             reversed_data[conditional_data.columns] = conditional_data

--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -184,7 +184,7 @@ class BaseMultiTableSynthesizer:
         self._initialize_models()
 
     def get_cag(self):
-        """Get a list of constraint-augmented generation patterns applied to the synthesizer."""
+        """Get a copy of the list of constraints applied to the synthesizer."""
         if not hasattr(self, 'patterns'):
             return []
 

--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -170,14 +170,16 @@ class BaseMultiTableSynthesizer:
                 A list of CAG patterns to apply to the synthesizer.
         """
         metadata = self.metadata
+        added_patterns = []
         for pattern in patterns:
             if isinstance(pattern, ProgrammableConstraint):
                 pattern = ProgrammableConstraintHarness(pattern)
 
             metadata = pattern.get_updated_metadata(metadata)
+            added_patterns.append(pattern)
 
         self.metadata = metadata
-        self.patterns += patterns
+        self.patterns += added_patterns
         self._constraints_fitted = False
         self._initialize_models()
 

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -1300,6 +1300,19 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
 
         return sampled_data
 
+    def _transform_conditions_chained_constraints(self, condition_df):
+        try:
+            transformed_condition = self._validate_transform_constraints(condition_df)
+            transformed_condition = self._data_processor.transform(
+                transformed_condition, is_condition=True
+            )
+        except PatternNotMetError:
+            raise PatternNotMetError('Provided conditions are not valid for the given constraints.')
+        except Exception:
+            transformed_condition = self._data_processor.transform(condition_df, is_condition=True)
+
+        return transformed_condition
+
     def _sample_with_conditions(
         self, conditions, max_tries_per_batch, batch_size, progress_bar=None, output_file_path=None
     ):
@@ -1344,19 +1357,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
             condition = dict(zip(condition_columns, group))
             condition_df = dataframe.iloc[0].to_frame().T
             if hasattr(self, '_chained_patterns'):
-                try:
-                    transformed_condition = self._validate_transform_constraints(condition_df)
-                    transformed_condition = self._data_processor.transform(
-                        transformed_condition, is_condition=True
-                    )
-                except PatternNotMetError:
-                    raise PatternNotMetError(
-                        'Provided conditions are not valid for the given constraints.'
-                    )
-                except Exception:
-                    transformed_condition = self._data_processor.transform(
-                        condition_df, is_condition=True
-                    )
+                transformed_condition = self._transform_conditions_chained_constraints(condition_df)
             else:
                 try:
                     transformed_condition = self._data_processor.transform(

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -746,6 +746,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
             try:
                 self.metadata = pattern.get_updated_metadata(self.metadata)
                 self._chained_patterns.append(pattern)
+                self._constraints_fitted = False
             except PatternNotMetError as e:
                 LOGGER.info(
                     'Enforcing pattern %s using reject sampling.', pattern.__class__.__name__
@@ -1344,9 +1345,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
             condition_df = dataframe.iloc[0].to_frame().T
             if hasattr(self, '_chained_patterns'):
                 try:
-                    transformed_condition = self._validate_transform_constraints(
-                        condition_df
-                    )
+                    transformed_condition = self._validate_transform_constraints(condition_df)
                     transformed_condition = self._data_processor.transform(
                         transformed_condition, is_condition=True
                     )
@@ -1423,7 +1422,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
             if hasattr(self, '_original_metadata'):
                 if column not in self._original_metadata.tables[self._table_name].columns:
                     raise ValueError(
-                        f"Unexpected column name '{column}'."
+                        f"Unexpected column name '{column}'. "
                         'Use a column name that was present in the original data.'
                     )
                 if column == self._original_metadata.tables[self._table_name].primary_key:

--- a/tests/integration/cag/test_range.py
+++ b/tests/integration/cag/test_range.py
@@ -159,10 +159,11 @@ def test_range_pattern_integers(data, metadata, pattern):
             'A': {'sdtype': 'numerical'},
             'A#B': {'sdtype': 'numerical'},
             'B#C': {'sdtype': 'numerical'},
+            'A#B#C.nan_component': {'sdtype': 'categorical'},
         }
     }).to_dict()
     assert expected_updated_metadata == updated_metadata.to_dict()
-    assert list(transformed.columns) == ['A', 'A#B', 'B#C']
+    assert list(transformed.columns) == ['A', 'A#B', 'B#C', 'A#B#C.nan_component']
     pd.testing.assert_frame_equal(data, reverse_transformed)
 
 
@@ -184,6 +185,7 @@ def test_range_pattern_with_nans(metadata, pattern):
             'A': {'sdtype': 'numerical'},
             'A#B': {'sdtype': 'numerical'},
             'B#C': {'sdtype': 'numerical'},
+            'A#B#C.nan_component': {'sdtype': 'categorical'},
         }
     }).to_dict()
     assert expected_updated_metadata == updated_metadata.to_dict()
@@ -212,10 +214,11 @@ def test_range_pattern_datetime(data_datetime, metadata_datetime, pattern):
             'A': {'sdtype': 'datetime'},
             'A#B': {'sdtype': 'numerical'},
             'B#C': {'sdtype': 'numerical'},
+            'A#B#C.nan_component': {'sdtype': 'categorical'},
         }
     }).to_dict()
     assert expected_updated_metadata == updated_metadata.to_dict()
-    assert list(transformed.columns) == ['A', 'A#B', 'B#C']
+    assert list(transformed.columns) == ['A', 'A#B', 'B#C', 'A#B#C.nan_component']
 
     # Check that the timestamps are very close to each other
     for col in ['A', 'B', 'C']:
@@ -263,6 +266,7 @@ def test_range_pattern_datetime_nans(metadata_datetime, pattern):
             'A': {'sdtype': 'datetime'},
             'A#B': {'sdtype': 'numerical'},
             'B#C': {'sdtype': 'numerical'},
+            'A#B#C.nan_component': {'sdtype': 'categorical'},
         }
     }).to_dict()
     assert expected_updated_metadata == updated_metadata.to_dict()
@@ -308,6 +312,7 @@ def test_range_pattern_with_multi_table(
                     'A': {'sdtype': 'numerical'},
                     'A#B': {'sdtype': 'numerical'},
                     'B#C': {'sdtype': 'numerical'},
+                    'A#B#C.nan_component': {'sdtype': 'categorical'},
                 }
             },
             'table2': {
@@ -318,7 +323,7 @@ def test_range_pattern_with_multi_table(
         }
     }).to_dict()
     assert expected_updated_metadata == updated_metadata.to_dict()
-    assert list(transformed['table1'].columns) == ['A', 'A#B', 'B#C']
+    assert list(transformed['table1'].columns) == ['A', 'A#B', 'B#C', 'A#B#C.nan_component']
     assert set(data.keys()) == set(reverse_transformed.keys())
     for table_name, table in data.items():
         pd.testing.assert_frame_equal(table, reverse_transformed[table_name])
@@ -367,6 +372,7 @@ def test_range_multiple_patterns():
             'low#mid': {'sdtype': 'numerical'},
             'mid#high1': {'sdtype': 'numerical'},
             'high2': {'sdtype': 'numerical'},
+            'low#mid#high1.nan_component': {'sdtype': 'categorical'},
         }
     }).to_dict()
     assert expected_updated_metadata == updated_metadata.to_dict()
@@ -424,6 +430,8 @@ def test_range_multiple_patterns_different_mid_columns():
             'mid1#high1': {'sdtype': 'numerical'},
             'mid2#high2': {'sdtype': 'numerical'},
             'low#mid2': {'sdtype': 'numerical'},
+            'low#mid1#high1.nan_component': {'sdtype': 'categorical'},
+            'low#mid2#high2.nan_component': {'sdtype': 'categorical'},
         }
     }).to_dict()
     assert expected_updated_metadata == updated_metadata.to_dict()

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -244,15 +244,10 @@ class TestHMASynthesizer:
         # Setup
         parent_data, child_data, metadata = self.get_custom_constraint_data_and_metadata()
         synthesizer = HMASynthesizer(metadata)
-        constraint = {
-            'table_name': 'parent',
-            'constraint_class': 'MyConstraint',
-            'constraint_parameters': {'column_names': ['numerical_col']},
-        }
-        synthesizer.add_custom_constraint_class(MyConstraint, 'MyConstraint')
+        constraint = MyConstraint(column_names=['numerical_col'], table_name='parent')
 
         # Run
-        synthesizer.add_constraints(constraints=[constraint])
+        synthesizer.add_cag([constraint])
         processed_data = synthesizer.preprocess({'parent': parent_data, 'child': child_data})
 
         # Assert Processed Data
@@ -277,21 +272,11 @@ class TestHMASynthesizer:
         parent_data, child_data, metadata = self.get_custom_constraint_data_and_metadata()
         synthesizer = HMASynthesizer(metadata)
 
-        constraint_parent = {
-            'table_name': 'parent',
-            'constraint_class': 'MyConstraint',
-            'constraint_parameters': {'column_names': ['numerical_col']},
-        }
-
-        constraint_child = {
-            'table_name': 'child',
-            'constraint_class': 'MyConstraint',
-            'constraint_parameters': {'column_names': ['numerical_col_2']},
-        }
-        synthesizer.add_custom_constraint_class(MyConstraint, 'MyConstraint')
+        constraint_parent = MyConstraint(column_names=['numerical_col'], table_name='parent')
+        constraint_child = MyConstraint(column_names=['numerical_col_2'], table_name='child')
 
         # Run
-        synthesizer.add_constraints(constraints=[constraint_parent, constraint_child])
+        synthesizer.add_cag([constraint_parent, constraint_child])
         processed_data = synthesizer.preprocess({'parent': parent_data, 'child': child_data})
 
         # Assert Processed Data
@@ -312,37 +297,6 @@ class TestHMASynthesizer:
         assert all(sampled['parent']['numerical_col'] > 1)
         assert all(sampled['child']['numerical_col_2'] > 1)
         assert not all(sampled['child']['numerical_col'] > 1)
-
-    def test_hma_custom_constraint_loaded_from_file(self):
-        """Test an example of using a custom constraint loaded from a file."""
-        # Setup
-        parent_data, child_data, metadata = self.get_custom_constraint_data_and_metadata()
-        synthesizer = HMASynthesizer(metadata)
-        constraint = {
-            'table_name': 'parent',
-            'constraint_class': 'MyConstraint',
-            'constraint_parameters': {'column_names': ['numerical_col']},
-        }
-        synthesizer.load_custom_constraint_classes(
-            'tests/integration/single_table/custom_constraints.py', ['MyConstraint']
-        )
-
-        # Run
-        synthesizer.add_constraints(constraints=[constraint])
-        processed_data = synthesizer.preprocess({'parent': parent_data, 'child': child_data})
-
-        # Assert Processed Data
-        np.testing.assert_equal(
-            processed_data['parent']['numerical_col'].array,
-            (parent_data['numerical_col'] ** 2.0).array,
-        )
-
-        # Run - Fit the model
-        synthesizer.fit_processed_data(processed_data)
-
-        # Run - sample
-        sampled = synthesizer.sample(10)
-        assert all(sampled['parent']['numerical_col'] > 1)
 
     def test_hma_with_inequality_constraint(self):
         """Test that when new columns are created by the constraint this still works."""

--- a/tests/integration/single_table/custom_constraints.py
+++ b/tests/integration/single_table/custom_constraints.py
@@ -61,25 +61,52 @@ class MySingleTableConstraint(SingleTableProgrammableConstraint):
 
 
 class IfTrueThenZero(ProgrammableConstraint):
-    def __init__(self, column_names):
+    def __init__(self, column_names, table_name):
         self.column_names = column_names
+        self.table_name = table_name
 
     def fit(self, data, metadata):
         return
 
     def transform(self, data):
-        data[self.column_names] = data[self.column_names] ** 2
+        table_data = data[self.table_name]
+        boolean_column = self.column_names[0]
+        numerical_column = self.column_names[1]
+        typical_value = data[numerical_column].median()
+        table_data[numerical_column] = data[numerical_column].mask(
+            data[boolean_column], typical_value
+        )
+        data[self.table_name] = table_data
+
         return data
 
     def reverse_transform(self, transformed_data):
-        transformed_data[self.column_names] = transformed_data[self.column_names] // 2
+        table_data = transformed_data[self.table_name]
+        boolean_column = self.column_names[0]
+        numerical_column = self.column_names[1]
+        table_data[numerical_column] = table_data[numerical_column].mask(
+            table_data[boolean_column], 0.0
+        )
+        transformed_data[self.table_name] = table_data
+
         return transformed_data
 
     def get_updated_metadata(self, metadata):
         return metadata
 
     def is_valid(self, synthetic_data):
-        return pd.Series([value[0] > 1 for value in synthetic_data[self.column_names].to_numpy()])
+        is_valid = {
+            table_name: pd.Series([True] * len(table_data))
+            for table_name, table_data in synthetic_data.items()
+        }
+        table_data = synthetic_data[self.table_name]
+        boolean_column = self.column_names[0]
+        numerical_column = self.column_names[1]
+        true_values = (table_data[boolean_column]) & (table_data[numerical_column] == 0.0)
+        false_values = ~table_data[boolean_column]
+        is_valid[self.table_name] = (true_values) | (false_values)
+
+        return is_valid
 
 
 class SingleTableIfTrueThenZero(SingleTableProgrammableConstraint):

--- a/tests/integration/single_table/custom_constraints.py
+++ b/tests/integration/single_table/custom_constraints.py
@@ -1,57 +1,121 @@
 import pandas as pd
 
-from sdv.constraints import create_custom_constraint_class
+from sdv.cag import ProgrammableConstraint, SingleTableProgrammableConstraint
 
 
-def is_valid(column_names, data):
-    """Validate the constraint."""
-    return pd.Series([value[0] > 1 for value in data[column_names].to_numpy()])
+class MyConstraint(ProgrammableConstraint):
+    def __init__(self, column_names, table_name):
+        self.column_names = column_names
+        self.table_name = table_name
+
+    def fit(self, data, metadata):
+        return
+
+    def transform(self, data):
+        data[self.table_name][self.column_names] = data[self.table_name][self.column_names] ** 2
+        return data
+
+    def reverse_transform(self, transformed_data):
+        table_data = transformed_data[self.table_name]
+        table_data[self.column_names] = table_data[self.column_names] // 2
+        transformed_data[self.table_name] = table_data
+        return transformed_data
+
+    def get_updated_metadata(self, metadata):
+        return metadata
+
+    def is_valid(self, synthetic_data):
+        is_valid = {
+            table_name: pd.Series([True] * len(table_data))
+            for table_name, table_data in synthetic_data.items()
+        }
+        table_data = synthetic_data[self.table_name]
+        is_valid_table = pd.Series([
+            value[0] > 1 for value in table_data[self.column_names].to_numpy()
+        ])
+        is_valid[self.table_name] = is_valid_table
+
+        return is_valid
 
 
-def transform(column_names, data):
-    """Transform the constraint."""
-    data[column_names] = data[column_names] ** 2
-    return data
+class MySingleTableConstraint(SingleTableProgrammableConstraint):
+    def __init__(self, column_names):
+        self.column_names = column_names
+
+    def fit(self, data, metadata):
+        return
+
+    def transform(self, data):
+        data[self.column_names] = data[self.column_names] ** 2
+        return data
+
+    def reverse_transform(self, transformed_data):
+        transformed_data[self.column_names] = transformed_data[self.column_names] // 2
+        return transformed_data
+
+    def get_updated_metadata(self, metadata):
+        return metadata
+
+    def is_valid(self, synthetic_data):
+        return pd.Series([value[0] > 1 for value in synthetic_data[self.column_names].to_numpy()])
 
 
-def reverse_transform(column_names, data):
-    """Reverse transform the constraint."""
-    data[column_names] = data[column_names] // 2
-    return data
+class IfTrueThenZero(ProgrammableConstraint):
+    def __init__(self, column_names):
+        self.column_names = column_names
+
+    def fit(self, data, metadata):
+        return
+
+    def transform(self, data):
+        data[self.column_names] = data[self.column_names] ** 2
+        return data
+
+    def reverse_transform(self, transformed_data):
+        transformed_data[self.column_names] = transformed_data[self.column_names] // 2
+        return transformed_data
+
+    def get_updated_metadata(self, metadata):
+        return metadata
+
+    def is_valid(self, synthetic_data):
+        return pd.Series([value[0] > 1 for value in synthetic_data[self.column_names].to_numpy()])
 
 
-MyConstraint = create_custom_constraint_class(is_valid, transform, reverse_transform)
+class SingleTableIfTrueThenZero(SingleTableProgrammableConstraint):
+    def __init__(self, column_names):
+        self.column_names = column_names
 
+    def fit(self, data, metadata):
+        return
 
-def amenities_is_valid(column_names, data):
-    """Validate that if ``has_rewards`` amenities fee is 0."""
-    boolean_column = column_names[0]
-    numerical_column = column_names[1]
-    true_values = (data[boolean_column]) & (data[numerical_column] == 0.0)
-    false_values = ~data[boolean_column]
+    def transform(self, data):
+        """Transform the data if amenities fee is to be applied."""
+        boolean_column = self.column_names[0]
+        numerical_column = self.column_names[1]
+        typical_value = data[numerical_column].median()
+        data[numerical_column] = data[numerical_column].mask(data[boolean_column], typical_value)
 
-    return (true_values) | (false_values)
+        return data
 
+    def reverse_transform(self, transformed_data):
+        """Reverse the data if amenities fee is to be applied."""
+        boolean_column = self.column_names[0]
+        numerical_column = self.column_names[1]
+        transformed_data[numerical_column] = transformed_data[numerical_column].mask(
+            transformed_data[boolean_column], 0.0
+        )
 
-def amenities_transform(column_names, data):
-    """Transform the data if amenities fee is to be applied."""
-    boolean_column = column_names[0]
-    numerical_column = column_names[1]
-    typical_value = data[numerical_column].median()
-    data[numerical_column] = data[numerical_column].mask(data[boolean_column], typical_value)
+        return transformed_data
 
-    return data
+    def get_updated_metadata(self, metadata):
+        return metadata
 
+    def is_valid(self, synthetic_data):
+        """Validate that if ``has_rewards`` amenities fee is 0."""
+        boolean_column = self.column_names[0]
+        numerical_column = self.column_names[1]
+        true_values = (synthetic_data[boolean_column]) & (synthetic_data[numerical_column] == 0.0)
+        false_values = ~synthetic_data[boolean_column]
 
-def amenities_reverse_transform(column_names, data):
-    """Reverse the data if amenities fee is to be applied."""
-    boolean_column = column_names[0]
-    numerical_column = column_names[1]
-    data[numerical_column] = data[numerical_column].mask(data[boolean_column], 0.0)
-
-    return data
-
-
-IfTrueThenZero = create_custom_constraint_class(
-    amenities_is_valid, amenities_transform, amenities_reverse_transform
-)
+        return (true_values) | (false_values)

--- a/tests/integration/single_table/test_constraints.py
+++ b/tests/integration/single_table/test_constraints.py
@@ -499,7 +499,7 @@ def test_overlapping_constraint_logs(caplog, demo_data, demo_metadata):
     datetime_format = column_metadata['datetime_format']
     demo_metadata.add_column('billing_date', sdtype='datetime', datetime_format=datetime_format)
     demo_data['billing_date'] = pd.to_datetime(demo_data['checkout_date']) + pd.Timedelta(5, 'D')
-    demo_data['billing_date'] = demo_data['billing_date'].strftime(datetime_format)
+    demo_data['billing_date'] = demo_data['billing_date'].dt.strftime(datetime_format)
 
     synth = GaussianCopulaSynthesizer(demo_metadata)
 

--- a/tests/integration/single_table/test_constraints.py
+++ b/tests/integration/single_table/test_constraints.py
@@ -494,6 +494,7 @@ def test_overlapping_constraint_logs(caplog, demo_data, demo_metadata):
     information but not crash.
     """
     # Setup
+    demo_metadata = Metadata.load_from_dict(demo_metadata.to_dict())
     column_metadata = demo_metadata.tables['fake_hotel_guests'].columns['checkout_date']
     datetime_format = column_metadata['datetime_format']
     demo_metadata.add_column('billing_date', sdtype='datetime', datetime_format=datetime_format)

--- a/tests/integration/single_table/test_constraints.py
+++ b/tests/integration/single_table/test_constraints.py
@@ -8,13 +8,12 @@ import pandas as pd
 import pytest
 from copulas.multivariate.gaussian import GaussianMultivariate
 
-from sdv.constraints import Constraint, create_custom_constraint_class
-from sdv.constraints.errors import AggregateConstraintsError
+from sdv.cag import FixedCombinations, Inequality, Range
 from sdv.datasets.demo import download_demo
 from sdv.metadata.metadata import Metadata
 from sdv.sampling import Condition
 from sdv.single_table import GaussianCopulaSynthesizer
-from tests.integration.single_table.custom_constraints import MyConstraint
+from tests.integration.single_table.custom_constraints import MyConstraint, MySingleTableConstraint
 
 
 def _isinstance_side_effect(*args, **kwargs):
@@ -37,231 +36,53 @@ def demo_metadata():
     return DEMO_METADATA
 
 
-def test_fit_with_unique_constraint_on_data_with_only_index_column():
-    """Test that the ``fit`` method runs without error when metadata specifies unique constraint,
-    ``fit`` is called on data containing a column named index.
-
-    The ``fit`` method is expected to fit the model to data,
-    taking into account the metadata and the ``Unique`` constraint.
-
-    Setup:
-    - The model is passed the unique constraint and
-    the primary key column.
-
-    Input:
-    - Data, Unique constraint
-
-    Github Issue:
-    - Tests that https://github.com/sdv-dev/SDV/issues/616 does not occur
-    """
-    # Setup
-    test_df = pd.DataFrame({
-        'key': [
-            1,
-            2,
-            3,
-            4,
-            5,
-        ],
-        'index': [
-            'A',
-            'B',
-            'C',
-            'D',
-            'E',
-        ],
-    })
-
-    metadata = Metadata()
-    metadata.add_table('table')
-    metadata.add_column('key', 'table', sdtype='id')
-    metadata.add_column('index', 'table', sdtype='categorical')
-    metadata.set_primary_key('key', 'table')
-
-    model = GaussianCopulaSynthesizer(metadata)
-    constraint = {
-        'constraint_class': 'Unique',
-        'constraint_parameters': {'column_names': ['index']},
-    }
-    model.add_constraints([constraint])
-
-    # Run
-    model.fit(test_df)
-    samples = model.sample(2)
-
-    # Assert
-    assert len(samples) == 2
-    assert samples['index'].is_unique
-
-
-def test_fit_with_unique_constraint_on_data_which_has_index_column():
-    """Test that the ``fit`` method runs without error when metadata specifies unique constraint,
-    ``fit`` is called on data containing a column named index and other columns.
-
-    The ``fit`` method is expected to fit the model to data,
-    taking into account the metadata and the ``Unique`` constraint.
-
-    Setup:
-    - The model is passed the unique constraint and
-    the primary key column.
-    - The unique constraint is set on the ``test_column``
-
-    Input:
-    - Data, Unique constraint
-
-    Github Issue:
-    - Tests that https://github.com/sdv-dev/SDV/issues/616 does not occur
-    """
-    # Setup
-    test_df = pd.DataFrame({
-        'key': [
-            1,
-            2,
-            3,
-            4,
-            5,
-        ],
-        'index': [
-            'A',
-            'B',
-            'C',
-            'D',
-            'E',
-        ],
-        'test_column': [
-            'A1',
-            'B2',
-            'C3',
-            'D4',
-            'E5',
-        ],
-    })
-
-    metadata = Metadata()
-    metadata.add_table('table')
-    metadata.add_column('key', 'table', sdtype='id')
-    metadata.add_column('index', 'table', sdtype='categorical')
-    metadata.add_column('test_column', 'table', sdtype='categorical')
-    metadata.set_primary_key('key', 'table')
-
-    model = GaussianCopulaSynthesizer(metadata)
-    constraint = {
-        'constraint_class': 'Unique',
-        'constraint_parameters': {'column_names': ['test_column']},
-    }
-    model.add_constraints([constraint])
-
-    # Run
-    model.fit(test_df)
-    samples = model.sample(2)
-
-    # Assert
-    assert len(samples) == 2
-    assert samples['test_column'].is_unique
-
-
-def test_fit_with_unique_constraint_on_data_subset():
-    """Test that the ``fit`` method runs without error when metadata specifies unique constraint,
-    ``fit`` is called on a subset of the original data.
-
-    The ``fit`` method is expected to fit the model to the subset of data,
-    taking into account the metadata and the ``Unique`` constraint.
-
-    Setup:
-    - The model is passed a ``Unique`` constraint and is
-    matched to a subset of the specified data.
-    Subdividing the data results in missing indexes in the subset contained in the original data.
-
-    Input:
-    - Subset of data, unique constraint
-
-    Github Issue:
-    - Tests that https://github.com/sdv-dev/SDV/issues/610 does not occur
-    """
-    # Setup
-    test_df = pd.DataFrame({
-        'key': [
-            1,
-            2,
-            3,
-            4,
-            5,
-        ],
-        'test_column': [
-            'A',
-            'B',
-            'C',
-            'D',
-            'E',
-        ],
-    })
-
-    metadata = Metadata()
-    metadata.add_table('table')
-    metadata.add_column('key', 'table', sdtype='id')
-    metadata.add_column('test_column', 'table', sdtype='categorical')
-    metadata.set_primary_key('key', 'table')
-
-    test_df = test_df.iloc[[1, 3, 4]]
-    constraint = {
-        'constraint_class': 'Unique',
-        'constraint_parameters': {'column_names': ['test_column']},
-    }
-    model = GaussianCopulaSynthesizer(metadata)
-    model.add_constraints([constraint])
-
-    # Run
-    model.fit(test_df)
-    samples = model.sample(2)
-
-    # Assert
-    assert len(samples) == 2
-    assert samples['test_column'].is_unique
-
-
-def test_conditional_sampling_with_constraints():
+def test_conditional_sampling_with_constraints(demo_data, demo_metadata):
     """Test constraints with conditional sampling. GH#1737"""
     # Setup
-    data = pd.DataFrame(
-        data={
-            'A': [round(i, 2) for i in np.random.uniform(low=0, high=10, size=100)],
-            'B': [round(i) for i in np.random.uniform(low=0, high=10, size=100)],
-            'C': np.random.choice(['Yes', 'No', 'Maybe'], size=100),
-        }
+    column_metadata = demo_metadata.tables['fake_hotel_guests'].columns['checkin_date']
+    datetime_format = column_metadata['datetime_format']
+    constraint = Inequality(
+        low_column_name='checkin_date',
+        high_column_name='checkout_date',
     )
-
-    metadata = Metadata.load_from_dict({
-        'columns': {
-            'A': {'sdtype': 'numerical'},
-            'B': {'sdtype': 'numerical'},
-            'C': {'sdtype': 'categorical'},
-        }
-    })
-
-    synth = GaussianCopulaSynthesizer(metadata)
-
-    constraint = {
-        'constraint_class': 'ScalarRange',
-        'constraint_parameters': {
-            'column_name': 'B',
-            'low_value': 0,
-            'high_value': 10,
-            'strict_boundaries': False,
-        },
-    }
-
-    my_condition = Condition(num_rows=250, column_values={'B': 1})
+    synth = GaussianCopulaSynthesizer(demo_metadata)
+    my_condition = Condition(num_rows=250, column_values={'checkin_date': '04 Feb 2020'})
 
     # Run
-    synth.add_constraints([constraint])
-    synth.fit(data)
+    synth.add_cag([constraint])
+    synth.fit(demo_data)
     samples = synth.sample_from_conditions([my_condition])
 
     # Assert
-    assert samples.columns.tolist() == ['A', 'B', 'C']
-    assert samples['A'].between(0, 10).all()
-    assert samples['B'].unique() == [1]
-    assert samples['C'].isin(['Yes', 'No', 'Maybe']).all()
+    assert samples.columns.tolist() == demo_data.columns.to_list()
+    assert all(samples['checkin_date'] == '04 Feb 2020')
+    valid_dates = samples[['checkin_date', 'checkout_date']].dropna()
+    checkin_dates = pd.to_datetime(valid_dates['checkin_date'], format=datetime_format)
+    checkout_dates = pd.to_datetime(valid_dates['checkout_date'], format=datetime_format)
+    assert all(checkin_dates <= checkout_dates)
+
+
+def test_conditional_sampling_with_constraints_transforms_if_possible(demo_data, demo_metadata):
+    """Test constraints with conditional sampling. GH#1737"""
+    # Setup
+    constraint = Inequality(
+        low_column_name='checkin_date',
+        high_column_name='checkout_date',
+    )
+    synth = GaussianCopulaSynthesizer(demo_metadata)
+    my_condition = Condition(
+        num_rows=250, column_values={'checkin_date': '04 Feb 2020', 'checkout_date': '10 Feb 2020'}
+    )
+
+    # Run
+    synth.add_cag([constraint])
+    synth.fit(demo_data)
+    samples = synth.sample_from_conditions([my_condition])
+
+    # Assert
+    assert samples.columns.tolist() == demo_data.columns.to_list()
+    assert all(samples['checkin_date'] == '04 Feb 2020')
+    assert all(samples['checkout_date'] == '10 Feb 2020')
 
 
 @patch('sdv.single_table.base.isinstance')
@@ -301,11 +122,8 @@ def test_conditional_sampling_constraint_uses_reject_sampling(gm_mock, isinstanc
 
     model = GaussianCopulaSynthesizer(metadata)
 
-    constraint = {
-        'constraint_class': 'FixedCombinations',
-        'constraint_parameters': {'column_names': ['city', 'state']},
-    }
-    model.add_constraints([constraint])
+    constraint = FixedCombinations(column_names=['city', 'state'])
+    model.add_cag([constraint])
     sampled_numeric_data = [
         pd.DataFrame({'city#state': [0.1, 1, 0.75, 0.25, 0.25], 'age': [30, 30, 30, 30, 30]}),
         pd.DataFrame({'city#state': [0.75], 'age': [30]}),
@@ -330,8 +148,8 @@ def test_conditional_sampling_constraint_uses_reject_sampling(gm_mock, isinstanc
     pd.testing.assert_frame_equal(sampled_data, expected_data)
 
 
-def test_custom_constraints_from_file(tmpdir):
-    """Ensure the correct loading for a custom constraint class defined in another file."""
+def test_custom_constraints_from_object(tmpdir):
+    """Ensure the correct loading for a custom constraint class passed as an object."""
     data = pd.DataFrame({
         'primary_key': ['user-000', 'user-001', 'user-002'],
         'pii_col': ['223 Williams Rd', '75 Waltham St', '77 Mass Ave'],
@@ -344,16 +162,10 @@ def test_custom_constraints_from_file(tmpdir):
     synthesizer = GaussianCopulaSynthesizer(
         metadata, enforce_min_max_values=False, enforce_rounding=False
     )
-    synthesizer.load_custom_constraint_classes(
-        'tests/integration/single_table/custom_constraints.py', ['MyConstraint']
-    )
-    constraint = {
-        'constraint_class': 'MyConstraint',
-        'constraint_parameters': {'column_names': ['numerical_col']},
-    }
+    constraint = MyConstraint(column_names=['numerical_col'], table_name='table')
 
     # Run
-    synthesizer.add_constraints([constraint])
+    synthesizer.add_cag([constraint])
     processed_data = synthesizer.preprocess(data)
 
     # Assert Processed Data
@@ -373,7 +185,7 @@ def test_custom_constraints_from_file(tmpdir):
     assert all(loaded_sampled['numerical_col'] > 1)
 
 
-def test_custom_constraints_from_object(tmpdir):
+def test_single_table_custom_constraints_from_object(tmpdir):
     """Ensure the correct loading for a custom constraint class passed as an object."""
     data = pd.DataFrame({
         'primary_key': ['user-000', 'user-001', 'user-002'],
@@ -387,14 +199,10 @@ def test_custom_constraints_from_object(tmpdir):
     synthesizer = GaussianCopulaSynthesizer(
         metadata, enforce_min_max_values=False, enforce_rounding=False
     )
-    synthesizer.add_custom_constraint_class(MyConstraint, 'MyConstraint')
-    constraint = {
-        'constraint_class': 'MyConstraint',
-        'constraint_parameters': {'column_names': ['numerical_col']},
-    }
+    constraint = MySingleTableConstraint(column_names=['numerical_col'])
 
     # Run
-    synthesizer.add_constraints([constraint])
+    synthesizer.add_cag([constraint])
     processed_data = synthesizer.preprocess(data)
 
     # Assert Processed Data
@@ -417,23 +225,22 @@ def test_custom_constraints_from_object(tmpdir):
 def test_synthesizer_with_inequality_constraint(demo_data, demo_metadata):
     """Ensure that the ``Inequality`` constraint can sample from the model."""
     # Setup
+    column_metadata = demo_metadata.tables['fake_hotel_guests'].columns['checkin_date']
+    datetime_format = column_metadata['datetime_format']
     synthesizer = GaussianCopulaSynthesizer(demo_metadata)
-    checkin_lessthan_checkout = {
-        'constraint_class': 'Inequality',
-        'constraint_parameters': {
-            'low_column_name': 'checkin_date',
-            'high_column_name': 'checkout_date',
-        },
-    }
-
-    synthesizer.add_constraints([checkin_lessthan_checkout])
+    checkin_lessthan_checkout = Inequality(
+        low_column_name='checkin_date', high_column_name='checkout_date'
+    )
+    synthesizer.add_cag([checkin_lessthan_checkout])
     synthesizer.fit(demo_data)
 
     # Run and Assert
     sampled = synthesizer.sample(num_rows=500)
-    synthesizer.validate(sampled)
+    # synthesizer.validate(sampled) # TODO: add back in once validate has been fixed for constraints
     _sampled = sampled[~sampled['checkout_date'].isna()]
-    assert all(pd.to_datetime(_sampled['checkin_date']) < pd.to_datetime(_sampled['checkout_date']))
+    checkin_dates = pd.to_datetime(_sampled['checkin_date'], format=datetime_format)
+    checkout_dates = pd.to_datetime(_sampled['checkout_date'], format=datetime_format)
+    assert all(checkin_dates < checkout_dates)
 
 
 def test_inequality_constraint_with_datetimes_and_nones():
@@ -455,20 +262,15 @@ def test_inequality_constraint_with_datetimes_and_nones():
 
     metadata.validate()
     synth = GaussianCopulaSynthesizer(metadata)
-    synth.add_constraints([
-        {
-            'constraint_class': 'Inequality',
-            'constraint_parameters': {'low_column_name': 'A', 'high_column_name': 'B'},
-        }
-    ])
-    synth.validate(data)
+    synth.add_cag([Inequality(low_column_name='A', high_column_name='B')])
+    # synth.validate(data)  # TODO: add back in once validate has been fixed
 
     # Run
     synth.fit(data)
     sampled = synth.sample(10)
 
     # Assert
-    synth.validate(sampled)
+    # synth.validate(sampled)  # TODO: add back in once validate has been fixed
     expected_sampled = pd.DataFrame({
         'A': [
             '2020-01-02',
@@ -498,125 +300,6 @@ def test_inequality_constraint_with_datetimes_and_nones():
     pd.testing.assert_frame_equal(expected_sampled, sampled)
 
 
-def test_scalar_inequality_constraint_with_datetimes_and_nones():
-    """Test that the ``ScalarInequality`` constraint works with ``None`` and ``datetime``."""
-    # Setup
-    data = pd.DataFrame(
-        data={
-            'A': [None, None, '2020-01-02', '2020-03-04'],
-            'B': [None, '2021-03-04', '2021-12-31', None],
-        }
-    )
-
-    metadata = Metadata.load_from_dict({
-        'columns': {
-            'A': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
-            'B': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
-        }
-    })
-
-    metadata.validate()
-    synth = GaussianCopulaSynthesizer(metadata)
-    synth.add_constraints([
-        {
-            'constraint_class': 'ScalarInequality',
-            'constraint_parameters': {'column_name': 'A', 'relation': '>=', 'value': '2019-01-01'},
-        }
-    ])
-    synth.validate(data)
-
-    # Run
-    synth.fit(data)
-    sampled = synth.sample(5)
-
-    # Assert
-    synth.validate(sampled)
-    expected_sampled = pd.DataFrame({
-        'A': {
-            0: np.nan,
-            1: '2020-01-19',
-            2: np.nan,
-            3: np.nan,
-            4: '2020-01-31',
-        },
-        'B': {
-            0: np.nan,
-            1: np.nan,
-            2: np.nan,
-            3: np.nan,
-            4: '2021-06-06',
-        },
-    })
-    pd.testing.assert_frame_equal(expected_sampled, sampled)
-
-
-def test_scalar_range_constraint_with_datetimes_and_nones():
-    """Test that the ``ScalarRange`` constraint works with ``None`` and ``datetime``."""
-    # Setup
-    data = pd.DataFrame(
-        data={
-            'A': [None, None, '2020-01-02', '2020-03-04'],
-            'B': [None, '2021-03-04', '2021-12-31', None],
-        }
-    )
-
-    metadata = Metadata.load_from_dict({
-        'columns': {
-            'A': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
-            'B': {'sdtype': 'datetime', 'datetime_format': '%Y-%m-%d'},
-        }
-    })
-
-    metadata.validate()
-    synth = GaussianCopulaSynthesizer(metadata, default_distribution='truncnorm')
-    synth.add_constraints([
-        {
-            'constraint_class': 'ScalarRange',
-            'constraint_parameters': {
-                'column_name': 'A',
-                'low_value': '2019-10-30',
-                'high_value': '2020-03-04',
-                'strict_boundaries': False,
-            },
-        }
-    ])
-    synth.validate(data)
-
-    # Run
-    synth.fit(data)
-    sampled = synth.sample(10)
-
-    # Assert
-    synth.validate(sampled)
-    expected_sampled = pd.DataFrame({
-        'A': {
-            0: np.nan,
-            1: np.nan,
-            2: '2020-02-07',
-            3: np.nan,
-            4: '2020-02-29',
-            5: '2020-02-29',
-            6: np.nan,
-            7: np.nan,
-            8: '2020-01-26',
-            9: '2020-02-02',
-        },
-        'B': {
-            0: np.nan,
-            1: np.nan,
-            2: np.nan,
-            3: np.nan,
-            4: '2021-06-21',
-            5: np.nan,
-            6: '2021-09-28',
-            7: '2021-06-19',
-            8: np.nan,
-            9: np.nan,
-        },
-    })
-    pd.testing.assert_frame_equal(expected_sampled, sampled)
-
-
 def test_range_constraint_with_datetimes_and_nones():
     """Test that the ``Range`` constraint works with ``None`` and ``datetime``."""
     # Setup
@@ -638,18 +321,15 @@ def test_range_constraint_with_datetimes_and_nones():
 
     metadata.validate()
     synth = GaussianCopulaSynthesizer(metadata)
-    synth.add_constraints([
-        {
-            'constraint_class': 'Range',
-            'constraint_parameters': {
-                'low_column_name': 'A',
-                'middle_column_name': 'B',
-                'high_column_name': 'C',
-                'strict_boundaries': False,
-            },
-        }
+    synth.add_cag([
+        Range(
+            low_column_name='A',
+            middle_column_name='B',
+            high_column_name='C',
+            strict_boundaries=False,
+        )
     ])
-    synth.validate(data)
+    # synth.validate(data)  # TODO: Add back in once validate is fixed
 
     # Run
     synth.fit(data)
@@ -695,7 +375,7 @@ def test_range_constraint_with_datetimes_and_nones():
         ],
     })
     pd.testing.assert_frame_equal(expected_sampled, sampled)
-    synth.validate(sampled)
+    # synth.validate(sampled)  # TODO: add back in once validate has been fixed
 
 
 def test_inequality_constraint_all_possible_nans_configurations():
@@ -711,12 +391,7 @@ def test_inequality_constraint_all_possible_nans_configurations():
     })
 
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    synthesizer.add_constraints([
-        {
-            'constraint_class': 'Inequality',
-            'constraint_parameters': {'low_column_name': 'A', 'high_column_name': 'B'},
-        }
-    ])
+    synthesizer.add_cag([Inequality(low_column_name='A', high_column_name='B')])
 
     # Run
     synthesizer.fit(data)
@@ -751,17 +426,12 @@ def test_range_constraint_all_possible_nans_configurations():
     metadata = Metadata.load_from_dict(metadata_dict)
     synthesizer = GaussianCopulaSynthesizer(metadata)
 
-    my_constraint = {
-        'constraint_class': 'Range',
-        'constraint_parameters': {
-            'low_column_name': 'low',
-            'middle_column_name': 'middle',
-            'high_column_name': 'high',
-        },
-    }
+    my_constraint = Range(
+        low_column_name='low', middle_column_name='middle', high_column_name='high'
+    )
 
     # Run
-    synthesizer.add_constraints(constraints=[my_constraint])
+    synthesizer.add_cag([my_constraint])
     synthesizer.fit(data)
 
     s_data = synthesizer.sample(2000)
@@ -791,55 +461,6 @@ def test_range_constraint_all_possible_nans_configurations():
     assert any(~is_nan_low & ~is_nan_middle & ~is_nan_high)
 
 
-def test_custom_constraint_with_key():
-    """Test that a custom constraint can work with a primary key."""
-
-    # Setup
-    def is_valid(column_names, data):
-        return data['key'] == data['letter'] + '_' + data['number']
-
-    def transform(column_names, data):
-        new_data = data.drop(['letter', 'number'], axis=1)
-        return new_data
-
-    def reverse_transform(column_names, data):
-        columns = data['key'].str.split('_', expand=True)
-        data['letter'] = columns[0]
-        data['number'] = columns[1]
-        return data
-
-    custom_constraint = create_custom_constraint_class(
-        is_valid_fn=is_valid, transform_fn=transform, reverse_transform_fn=reverse_transform
-    )
-
-    data = pd.DataFrame({
-        'key': ['a_1', 'b_2', 'c_3'],
-        'letter': ['a', 'b', 'c'],
-        'number': ['1', '2', '3'],
-        'other': [7, 8, 9],
-    })
-    metadata = Metadata.detect_from_dataframes({'table': data})
-    metadata.update_column('key', 'table', sdtype='id', regex_format=r'\w_\d')
-    metadata.set_primary_key('key', 'table')
-    synth = GaussianCopulaSynthesizer(metadata)
-    synth.add_custom_constraint_class(custom_constraint, 'custom')
-
-    id_must_match = {
-        'constraint_class': 'custom',
-        'constraint_parameters': {
-            'column_names': ['letter', 'number'],
-        },
-    }
-    synth.add_constraints([id_must_match])
-
-    # Run
-    synth.fit(data)
-    sampled = synth.sample(100)
-
-    # Assert
-    synth.validate(sampled)
-
-
 def test_timezone_aware_constraints():
     """Test that constraints work with timezone aware datetime columns GH#1576."""
     # Setup
@@ -852,18 +473,13 @@ def test_timezone_aware_constraints():
     metadata.add_column('col1', 'table', sdtype='datetime')
     metadata.add_column('col2', 'table', sdtype='datetime')
 
-    my_constraint = {
-        'constraint_class': 'Inequality',
-        'constraint_parameters': {
-            'low_column_name': 'col1',
-            'high_column_name': 'col2',
-            'strict_boundaries': True,
-        },
-    }
+    my_constraint = Inequality(
+        low_column_name='col1', high_column_name='col2', strict_boundaries=True
+    )
 
     # Run
     synth = GaussianCopulaSynthesizer(metadata)
-    synth.add_constraints(constraints=[my_constraint])
+    synth.add_cag([my_constraint])
     synth.fit(data)
     samples = synth.sample(100)
 
@@ -871,96 +487,36 @@ def test_timezone_aware_constraints():
     assert all(samples['col1'] < samples['col2'])
 
 
-def test_custom_and_overlapping_constraint_errors(caplog, demo_data, demo_metadata):
-    """Test a synthesizer when constraints overlap or custom constraints raise an error.
+def test_overlapping_constraint_logs(caplog, demo_data, demo_metadata):
+    """Test a synthesizer when constraints overlap .
 
-    If a custom constraint raises an error, we want to log it but not crash. If one constraint
-    drops columns that another constraint needs, we also want to log this information but not
-    crash.
+    If one constraint drops columns that another constraint needs, we also want to log this
+    information but not crash.
     """
     # Setup
+    demo_metadata.add_column('billing_date', sdtype='datetime')
+    demo_data['billing_date'] = pd.to_datetime(demo_data['checkout_date']) + pd.Timedelta(5, 'D')
+
     synth = GaussianCopulaSynthesizer(demo_metadata)
 
-    def is_valid(column_names, data):
-        return ~pd.isna(data[column_names[0]])
-
-    def transform(column_names, data):
-        raise ValueError('Transform error')
-
-    def reverse_transform(column_names, data):
-        return data
-
-    custom_constraint = create_custom_constraint_class(
-        is_valid_fn=is_valid, transform_fn=transform, reverse_transform_fn=reverse_transform
+    checkin_checkout_constraint = Inequality(
+        low_column_name='checkin_date', high_column_name='checkout_date'
     )
-    synth.add_custom_constraint_class(custom_constraint, 'custom')
-    checkin_checkout_constraint = {
-        'constraint_class': 'Inequality',
-        'constraint_parameters': {
-            'low_column_name': 'checkin_date',
-            'high_column_name': 'checkout_date',
-        },
-    }
-    error_constraint = {
-        'constraint_class': 'custom',
-        'constraint_parameters': {
-            'column_names': ['room_rate'],
-        },
-    }
-    overlapped_constraint = {
-        'constraint_class': 'ScalarInequality',
-        'constraint_parameters': {
-            'column_name': 'checkout_date',
-            'relation': '>',
-            'value': '01 Jan 1990',
-        },
-    }
-    synth.add_constraints(
-        constraints=[checkin_checkout_constraint, error_constraint, overlapped_constraint]
+    overlapped_constraint = Inequality(
+        low_column_name='checkout_date', high_column_name='billing_date'
     )
 
     # Run
-    with caplog.at_level(logging.INFO, logger='sdv.data_processing.data_processor'):
-        synth.fit(demo_data)
+    with caplog.at_level(logging.INFO, logger='sdv.single_table.base'):
+        synth.add_cag([checkin_checkout_constraint, overlapped_constraint])
+
+    synth.fit(demo_data)
 
     # Assert
-    expected_logs = [
-        "Unable to transform ScalarInequality with columns ['checkout_date'] because they are not "
-        'all available in the data. This happens due to multiple, overlapping constraints.',
-        "Unable to transform CustomConstraint with columns ['room_rate'] due to an error in "
-        'transform: \nTransform error\nUsing the reject sampling approach instead.',
-    ]
+    expected_logs = ['Enforcing pattern Inequality using reject sampling.']
     log_messages = [record[2] for record in caplog.record_tuples]
     for log in expected_logs:
         assert log in log_messages
-
-
-def test_aggregate_constraint_errors(demo_data, demo_metadata):
-    """Test that if there are multiple constraint errors, they are raised together."""
-
-    # Setup
-    class BadConstraint(Constraint):
-        def __init__(self, column_name):
-            self.column_name = column_name
-
-        def _transform(self, table_data):
-            raise ValueError('Bad constraint')
-
-    synth = GaussianCopulaSynthesizer(demo_metadata)
-    bad_constraint1 = {
-        'constraint_class': 'BadConstraint',
-        'constraint_parameters': {'column_name': 'room_rate'},
-    }
-    bad_constraint2 = {
-        'constraint_class': 'BadConstraint',
-        'constraint_parameters': {'column_name': 'checkin_date'},
-    }
-    synth.add_constraints(constraints=[bad_constraint1, bad_constraint2])
-
-    # Run and Assert
-    message = '\nBad constraint\n\nBad constraint'
-    with pytest.raises(AggregateConstraintsError, match=message):
-        synth.fit(demo_data)
 
 
 def test_constraint_datetime_check():
@@ -985,27 +541,22 @@ def test_constraint_datetime_check():
         }
     })
 
-    my_constraint = {
-        'constraint_class': 'Inequality',
-        'constraint_parameters': {
-            'low_column_name': 'low_col',
-            'high_column_name': 'high_col',
-            'strict_boundaries': False,
-        },
-    }
+    my_constraint = Inequality(
+        low_column_name='low_col', high_column_name='high_col', strict_boundaries=False
+    )
 
     # Run
     metadata.validate()
     metadata.validate_data(data)
 
     synth = GaussianCopulaSynthesizer(metadata)
-    synth.add_constraints([my_constraint])
+    synth.add_cag([my_constraint])
     synth.fit(data['table'])
     samples = synth.sample(3)
 
     # Assert
     expected_dataframe = pd.DataFrame({
-        'low_col': ['18 Jul, 15', '09 Aug, 15', '24 Jun, 15'],
-        'high_col': ['05 Sep, 15', '26 Sep, 15', '12 Aug, 15'],
+        'low_col': ['13 Sep, 15', '19 Jan, 15', '02 Jun, 14'],
+        'high_col': ['23 Oct, 15', '09 Mar, 15', '12 Jul, 14'],
     })
     pd.testing.assert_frame_equal(samples, expected_dataframe)

--- a/tests/integration/single_table/test_constraints.py
+++ b/tests/integration/single_table/test_constraints.py
@@ -494,8 +494,11 @@ def test_overlapping_constraint_logs(caplog, demo_data, demo_metadata):
     information but not crash.
     """
     # Setup
-    demo_metadata.add_column('billing_date', sdtype='datetime')
+    column_metadata = demo_metadata.tables['fake_hotel_guests'].columns['checkout_date']
+    datetime_format = column_metadata['datetime_format']
+    demo_metadata.add_column('billing_date', sdtype='datetime', datetime_format=datetime_format)
     demo_data['billing_date'] = pd.to_datetime(demo_data['checkout_date']) + pd.Timedelta(5, 'D')
+    demo_data['billing_date'] = demo_data['billing_date'].strftime(datetime_format)
 
     synth = GaussianCopulaSynthesizer(demo_metadata)
 

--- a/tests/integration/single_table/test_constraints.py
+++ b/tests/integration/single_table/test_constraints.py
@@ -236,7 +236,7 @@ def test_synthesizer_with_inequality_constraint(demo_data, demo_metadata):
 
     # Run and Assert
     sampled = synthesizer.sample(num_rows=500)
-    # synthesizer.validate(sampled) # TODO: add back in once validate has been fixed for constraints
+    synthesizer.validate(sampled)
     _sampled = sampled[~sampled['checkout_date'].isna()]
     checkin_dates = pd.to_datetime(_sampled['checkin_date'], format=datetime_format)
     checkout_dates = pd.to_datetime(_sampled['checkout_date'], format=datetime_format)
@@ -263,14 +263,14 @@ def test_inequality_constraint_with_datetimes_and_nones():
     metadata.validate()
     synth = GaussianCopulaSynthesizer(metadata)
     synth.add_cag([Inequality(low_column_name='A', high_column_name='B')])
-    # synth.validate(data)  # TODO: add back in once validate has been fixed
+    synth.validate(data)
 
     # Run
     synth.fit(data)
     sampled = synth.sample(10)
 
     # Assert
-    # synth.validate(sampled)  # TODO: add back in once validate has been fixed
+    synth.validate(sampled)
     expected_sampled = pd.DataFrame({
         'A': [
             '2020-01-02',
@@ -329,7 +329,7 @@ def test_range_constraint_with_datetimes_and_nones():
             strict_boundaries=False,
         )
     ])
-    # synth.validate(data)  # TODO: Add back in once validate is fixed
+    synth.validate(data)
 
     # Run
     synth.fit(data)
@@ -375,7 +375,7 @@ def test_range_constraint_with_datetimes_and_nones():
         ],
     })
     pd.testing.assert_frame_equal(expected_sampled, sampled)
-    # synth.validate(sampled)  # TODO: add back in once validate has been fixed
+    synth.validate(sampled)
 
 
 def test_inequality_constraint_all_possible_nans_configurations():

--- a/tests/unit/cag/test_range.py
+++ b/tests/unit/cag/test_range.py
@@ -941,6 +941,8 @@ class TestRange:
                 'col': [7, 8, 9],
             })
         }
+        table_data['table']['a'] = table_data['table']['a'].dt.strftime('%d %b %Y')
+
         instance = Range(
             low_column_name='a',
             middle_column_name='b',
@@ -948,6 +950,9 @@ class TestRange:
             table_name='table',
         )
         instance._fitted = True
+        instance._low_datetime_format = '%d %b %Y'
+        instance._is_datetime = True
+        instance._dtype = 'O'
 
         # Run
         out = instance.is_valid(table_data)

--- a/tests/unit/cag/test_range.py
+++ b/tests/unit/cag/test_range.py
@@ -935,13 +935,12 @@ class TestRange:
         # Setup
         table_data = {
             'table': pd.DataFrame({
-                'a': [datetime(2020, 5, 17), datetime(2021, 9, 1), np.nan],
+                'a': ['2020-5-17', '2021-9-1', None],
                 'b': [datetime(2020, 5, 18), datetime(2020, 9, 2), datetime(2020, 9, 2)],
                 'c': [datetime(2020, 5, 29), datetime(2021, 9, 3), np.nan],
                 'col': [7, 8, 9],
             })
         }
-        table_data['table']['a'] = table_data['table']['a'].dt.strftime('%d %b %Y')
 
         instance = Range(
             low_column_name='a',
@@ -950,7 +949,7 @@ class TestRange:
             table_name='table',
         )
         instance._fitted = True
-        instance._low_datetime_format = '%d %b %Y'
+        instance._low_datetime_format = '%Y-%m-%d'
         instance._is_datetime = True
         instance._dtype = 'O'
 

--- a/tests/unit/cag/test_range.py
+++ b/tests/unit/cag/test_range.py
@@ -63,10 +63,10 @@ class TestRange:
         assert instance._high_column_name == 'c'
         assert instance._low_diff_column_name == 'a#b'
         assert instance._high_diff_column_name == 'b#c'
+        assert instance._nan_column_name == 'a#b#c.nan_component'
         assert instance._operator == operator.lt
         assert instance._dtype is None
         assert instance._is_datetime is None
-        assert instance._nan_column_name is None
         assert instance.table_name is None
         assert instance._low_datetime_format is None
         assert instance._middle_datetime_format is None
@@ -404,6 +404,7 @@ class TestRange:
                         'col': {'sdtype': 'id'},
                         'low#middle': {'sdtype': 'numerical'},
                         'middle#high': {'sdtype': 'numerical'},
+                        'low#middle#high.nan_component': {'sdtype': 'categorical'},
                     },
                     'column_relationships': [
                         {'type': 'relationship', 'column_names': ['low', 'col']},
@@ -554,6 +555,7 @@ class TestRange:
             'col': [7, 8, 9],
             'a#b': [np.log(4)] * 3,
             'b#c': [np.log(4)] * 3,
+            'a#b#c.nan_component': [None] * 3,
         })
         pd.testing.assert_frame_equal(out, expected_out)
 
@@ -601,6 +603,7 @@ class TestRange:
             'a': [1, 2, 3],
             'a#b': [np.log(2)] * 3,
             'b#c': [np.log(2)] * 3,
+            'a#b#c.nan_component': [None] * 3,
         })
         pd.testing.assert_frame_equal(output_with_nans, expected_output_with_nans)
         pd.testing.assert_frame_equal(output_without_nans, expected_output_without_nans)
@@ -630,7 +633,7 @@ class TestRange:
 
         # Assert
         output = output['table']
-        expected_column_name = ['a', 'col', 'a#b', 'a#b_', 'b#c']
+        expected_column_name = ['a', 'col', 'a#b', 'a#b_', 'b#c', 'a#b#c.nan_component']
         assert list(output.columns) == expected_column_name
 
     def test__transform_datetime(self):
@@ -662,6 +665,7 @@ class TestRange:
             'col': [7, 8],
             'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
             'b#c': [np.log(1_000_000_001), np.log(1_000_000_001)],
+            'a#b#c.nan_component': [None, None],
         })
         pd.testing.assert_frame_equal(out, expected_out)
 
@@ -695,6 +699,7 @@ class TestRange:
             'col': [1, 2],
             'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
             'b#c': [np.log(1_000_000_001), np.log(1_000_000_001)],
+            'a#b#c.nan_component': [None, None],
         })
         pd.testing.assert_frame_equal(out, expected_out)
 
@@ -707,6 +712,7 @@ class TestRange:
                 'col': [7, 8, 9],
                 'a#b': [np.log(4)] * 3,
                 'b#c': [np.log(4)] * 3,
+                'a#b#c.nan_component': [None] * 3,
             })
         }
         instance = Range(
@@ -748,6 +754,7 @@ class TestRange:
                 'col': [7, 8, 9],
                 'a#b': [np.log(4)] * 3,
                 'b#c': [np.log(4)] * 3,
+                'a#b#c.nan_component': [None] * 3,
             })
         }
         instance = Range(
@@ -789,6 +796,7 @@ class TestRange:
                 'col': [1, 2],
                 'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
                 'b#c': [np.log(1_000_000_001), np.log(1_000_000_001)],
+                'a#b#c.nan_component': [None] * 2,
             })
         }
         instance = Range(
@@ -831,6 +839,7 @@ class TestRange:
                 'col': [1, 2],
                 'a#b': [np.log(1_000_000_001), np.log(1_000_000_001)],
                 'b#c': [np.log(1_000_000_001), np.log(1_000_000_001)],
+                'a#b#c.nan_component': [None, None],
             })
         }
         instance = Range(

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -428,7 +428,7 @@ class TestBaseMultiTableSynthesizer:
         cag_mock_2.is_valid.return_value = {table_name: pd.Series([True])}
         cag_mock_2.table_name = table_name
         instance.patterns = [cag_mock_1, cag_mock_2]
-        copy_mock.return_value = [cag_mock_1, cag_mock_2]
+        copy_mock.side_effect = [cag_mock_1, cag_mock_2]
 
         # Run
         instance.validate_cag(synthetic_data)
@@ -1584,8 +1584,8 @@ class TestBaseMultiTableSynthesizer:
 
         # Assert
         assert no_patterns == []
-        copy_mock.assert_called_once_with([pattern1, pattern2])
-        assert patterns == copy_mock.return_value
+        copy_mock.assert_has_calls([call(pattern1), call(pattern2)])
+        assert patterns == [copy_mock.return_value, copy_mock.return_value]
 
     def test_get_metadata_original(self):
         """Test getting the original metadata from the synthesizer."""


### PR DESCRIPTION
Resolve #2519 

This PR also enables conditionally sampling columns that are dropped by the data processor by forcing the generated values to match the condition.

Also fixes the Range constraint erroring with NaN values and converts many tests that were using the old style constraints to the new style constraints.

Currently some tests are blocked by #2480