### PR TITLE
`get_constraints` for multi-table does not return single-table constraints

### DIFF
--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -240,6 +240,9 @@ class BaseMultiTableSynthesizer:
             else:
                 constraints.append(deepcopy(constraint))
 
+        for table_name, synthesizer in self._table_synthesizers.items():
+            constraints += synthesizer.get_constraints()
+
         return constraints
 
     def validate_constraints(self, synthetic_data):

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -1563,6 +1563,14 @@ class TestBaseMultiTableSynthesizer:
         constraint2 = Mock()
         custom_constraint = Mock()
         constraint3 = ProgrammableConstraintHarness(custom_constraint)
+        constraint4 = Mock()
+        constraint5 = Mock()
+        instance._table_synthesizers = {
+            'table1': Mock(),
+            'table2': Mock(),
+        }
+        instance._table_synthesizers['table1'].get_constraints = Mock(return_value=[constraint4])
+        instance._table_synthesizers['table2'].get_constraints = Mock(return_value=[constraint5])
 
         # Run
         no_constraints = BaseMultiTableSynthesizer.get_constraints(instance)
@@ -1576,6 +1584,8 @@ class TestBaseMultiTableSynthesizer:
             copy_mock.return_value,
             copy_mock.return_value,
             copy_mock.return_value,
+            constraint4,
+            constraint5,
         ]
 
     def test_get_metadata_original(self):


### PR DESCRIPTION
Resolve #2559

<img width="882" alt="Screenshot 2025-05-30 at 11 46 50" src="https://github.com/user-attachments/assets/5f3099c1-324a-44b6-af6d-229cdfedf81d" />
