### PR TITLE
Add option for conditional sampling to keep extra columns during sampling

### DIFF
--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -1039,6 +1039,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
         float_rtol=0.01,
         progress_bar=None,
         output_file_path=None,
+        keep_extra_columns=False,
     ):
         sampled = []
         batch_size = batch_size if num_rows > batch_size else num_rows
@@ -1051,6 +1052,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                 float_rtol=float_rtol,
                 progress_bar=progress_bar,
                 output_file_path=output_file_path,
+                keep_extra_columns=keep_extra_columns,
             )
             sampled.append(sampled_rows)
 
@@ -1068,6 +1070,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
         graceful_reject_sampling=True,
         progress_bar=None,
         output_file_path=None,
+        keep_extra_columns=False,
     ):
         batch_size = batch_size or len(dataframe)
         sampled_rows = self._sample_in_batches(
@@ -1079,6 +1082,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
             float_rtol=float_rtol,
             progress_bar=progress_bar,
             output_file_path=output_file_path,
+            keep_extra_columns=keep_extra_columns,
         )
 
         if len(sampled_rows) > 0:
@@ -1210,7 +1214,13 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
         return transformed_condition
 
     def _sample_with_conditions(
-        self, conditions, max_tries_per_batch, batch_size, progress_bar=None, output_file_path=None
+        self,
+        conditions,
+        max_tries_per_batch,
+        batch_size,
+        progress_bar=None,
+        output_file_path=None,
+        keep_extra_columns=False,
     ):
         """Sample rows with conditions.
 
@@ -1225,6 +1235,8 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                 The progress bar to update.
             output_file_path (str or None):
                 The file to periodically write sampled rows to. Defaults to None.
+            keep_extra_columns (bool):
+                Whether to keep extra columns from the sampled data. Defaults to False.
 
         Returns:
             pandas.DataFrame:
@@ -1281,6 +1293,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                     batch_size=batch_size,
                     progress_bar=progress_bar,
                     output_file_path=output_file_path,
+                    keep_extra_columns=keep_extra_columns,
                 )
                 all_sampled_rows.append(sampled_rows)
             else:
@@ -1300,6 +1313,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                         batch_size=batch_size,
                         progress_bar=progress_bar,
                         output_file_path=output_file_path,
+                        keep_extra_columns=keep_extra_columns,
                     )
                     all_sampled_rows.append(sampled_rows)
 

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -1863,6 +1863,7 @@ class TestBaseSingleTableSynthesizer:
             float_rtol=0.02,
             progress_bar='progress_bar',
             output_file_path='output_file_path',
+            keep_extra_columns=False,
         )
         assert expected_call == instance._sample_batch.call_args_list[0]
         assert expected_call == instance._sample_batch.call_args_list[1]
@@ -1904,6 +1905,7 @@ class TestBaseSingleTableSynthesizer:
             float_rtol=0.01,
             progress_bar=None,
             output_file_path=None,
+            keep_extra_columns=False,
         )
 
     def test__conditionally_sample_rows_no_rows_sampled_error(self):
@@ -2385,6 +2387,7 @@ class TestBaseSingleTableSynthesizer:
             'batch_size': 10,
             'progress_bar': None,
             'output_file_path': None,
+            'keep_extra_columns': False,
         }
         assert second_call_kwargs == {
             'condition': {'name': 'Johanna'},
@@ -2393,6 +2396,7 @@ class TestBaseSingleTableSynthesizer:
             'batch_size': 10,
             'progress_bar': None,
             'output_file_path': None,
+            'keep_extra_columns': False,
         }
 
     def test__transform_conditions_chained_constraints_no_transformed_conditions(self):


### PR DESCRIPTION
Add `keep_extra_columns` argument to conditional sampling logic for [multi-table conditional sampling](https://github.com/datacebo/SDV-Enterprise/issues/1446)