### PR TITLE
Allow single table ProgrammableConstraints with multi-table synthesizers if `table_name` is set

### DIFF
--- a/sdv/cag/programmable_constraint.py
+++ b/sdv/cag/programmable_constraint.py
@@ -137,15 +137,18 @@ class ProgrammableConstraintHarness(BaseConstraint):
     def __init__(self, programmable_constraint):
         super().__init__()
         self.programmable_constraint = programmable_constraint
-        self.table_name = None
+        self.table_name = getattr(self.programmable_constraint, 'table_name', None)
         self._is_single_table = self.programmable_constraint._is_single_table
 
     def _validate_constraint_with_metadata(self, metadata):
         if self.programmable_constraint._is_single_table and len(metadata.tables) != 1:
-            raise ConstraintNotMetError(
-                'SingleTableProgrammableConstraint cannot be used with multi-table metadata. '
-                'Please use the ProgrammableConstraint base class instead.'
-            )
+            if getattr(self.programmable_constraint, 'table_name', None) is None:
+                raise ConstraintNotMetError(
+                    'SingleTableProgrammableConstraint cannot be used with multi-table metadata '
+                    'if the `table_name` attribute has not been set. Please set the table name '
+                    'attribute to the target table, or use the ProgrammableContraint '
+                    'base class instead.'
+                )
 
         self.programmable_constraint.validate(metadata)
 

--- a/tests/unit/cag/test_programmable_constraint.py
+++ b/tests/unit/cag/test_programmable_constraint.py
@@ -115,8 +115,10 @@ class TestProgrammableConstraintHarness:
 
         # Run and Assert
         expected_msg = re.escape(
-            'SingleTableProgrammableConstraint cannot be used with multi-table metadata. '
-            'Please use the ProgrammableConstraint base class instead.'
+            'SingleTableProgrammableConstraint cannot be used with multi-table metadata '
+            'if the `table_name` attribute has not been set. Please set the table name '
+            'attribute to the target table, or use the ProgrammableContraint '
+            'base class instead.'
         )
         with pytest.raises(ConstraintNotMetError, match=expected_msg):
             instance._validate_constraint_with_metadata(metadata)


### PR DESCRIPTION
Required for datacebo/sdv-enterprise#2036