### PR TITLE
Add backwards compatibility for deprecated programmable constraint

### DIFF
--- a/sdv/cag/__init__.py
+++ b/sdv/cag/__init__.py
@@ -7,6 +7,7 @@ from sdv.cag.range import Range
 from sdv.cag.one_hot_encoding import OneHotEncoding
 from sdv.cag.programmable_constraint import (
     ProgrammableConstraint,
+    SingleTableProgrammableConstraint,
 )
 
 __all__ = (
@@ -16,4 +17,5 @@ __all__ = (
     'Range',
     'OneHotEncoding',
     'ProgrammableConstraint',
+    'SingleTableProgrammableConstraint',
 )

--- a/sdv/cag/programmable_constraint.py
+++ b/sdv/cag/programmable_constraint.py
@@ -3,6 +3,7 @@
 import inspect
 from copy import deepcopy
 
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.cag.base import BaseConstraint
 
 
@@ -130,6 +131,12 @@ class ProgrammableConstraint:
         return synthetic_data
 
 
+class SingleTableProgrammableConstraint(ProgrammableConstraint):
+    """Single table variant of the base programmable constraint class."""
+
+    _is_single_table = True
+
+
 class ProgrammableConstraintHarness(BaseConstraint):
     """Constraint interface class for programmable constraints."""
 
@@ -138,6 +145,10 @@ class ProgrammableConstraintHarness(BaseConstraint):
         self.programmable_constraint = programmable_constraint
         self.table_name = getattr(self.programmable_constraint, 'table_name', None)
         self._is_single_table = self.programmable_constraint._is_single_table
+
+    @property
+    def _is_programmable_single_table_constraint(self):
+        return isinstance(self.programmable_constraint, SingleTableProgrammableConstraint)
 
     def get_constraint_dict(self):
         """Return the constraint as a serialiazable dict.
@@ -170,9 +181,21 @@ class ProgrammableConstraintHarness(BaseConstraint):
         }
 
     def _validate_constraint_with_metadata(self, metadata):
+        if self._is_programmable_single_table_constraint and len(metadata.tables) != 1:
+            if getattr(self.programmable_constraint, 'table_name', None) is None:
+                raise ConstraintNotMetError(
+                    'SingleTableProgrammableConstraint cannot be used with multi-table metadata '
+                    'if the `table_name` attribute has not been set. Please set the table name '
+                    'attribute to the target table, or use the ProgrammableContraint '
+                    'base class instead.'
+                )
+
         self.programmable_constraint.validate(metadata)
 
     def _validate_constraint_with_data(self, data, metadata):
+        if self._is_programmable_single_table_constraint:
+            data = data[self._get_single_table_name(metadata)]
+
         self.programmable_constraint.validate_input_data(data)
 
     def _get_updated_metadata(self, metadata):
@@ -180,13 +203,41 @@ class ProgrammableConstraintHarness(BaseConstraint):
         return self.programmable_constraint.get_updated_metadata(metadata)
 
     def _fit(self, data, metadata):
+        if self._is_programmable_single_table_constraint:
+            data = data[self._table_name]
+
         self.programmable_constraint.fit(data, metadata)
 
     def _transform(self, data):
-        return self.programmable_constraint.transform(data)
+        if self._is_programmable_single_table_constraint:
+            data = data[self._table_name]
+
+        transformed = self.programmable_constraint.transform(data)
+
+        if self._is_programmable_single_table_constraint:
+            return {self._table_name: transformed}
+
+        return transformed
 
     def _reverse_transform(self, data):
-        return self.programmable_constraint.reverse_transform(data)
+        if self._is_programmable_single_table_constraint:
+            data = data[self._table_name]
+
+        reverse_transformed = self.programmable_constraint.reverse_transform(data)
+
+        if self._is_programmable_single_table_constraint:
+            return {self._table_name: reverse_transformed}
+
+        return reverse_transformed
 
     def _is_valid(self, data, metadata):
-        return self.programmable_constraint.is_valid(data)
+        if self._is_programmable_single_table_constraint:
+            table_name = self._get_single_table_name(metadata)
+            data = data[table_name]
+
+        is_valid = self.programmable_constraint.is_valid(data)
+
+        if self._is_programmable_single_table_constraint:
+            return {table_name: is_valid}
+
+        return is_valid

--- a/sdv/cag/programmable_constraint.py
+++ b/sdv/cag/programmable_constraint.py
@@ -10,7 +10,7 @@ from sdv.cag.base import BaseConstraint
 class ProgrammableConstraint:
     """Base class to create programmable constraints."""
 
-    _is_single_table = True
+    _is_single_table = False
 
     @classmethod
     def load_constraint_from_dict(cls, parameters):

--- a/tests/integration/cag/test_base.py
+++ b/tests/integration/cag/test_base.py
@@ -6,7 +6,11 @@ import sdv.cag
 def test_all_available_constraints_included_in_constraint_test_list(constraints_as_dicts):
     """Test that all available constraints are included in the test list."""
     # Setup
-    skipped_cag_module_classes = ['ProgrammableConstraint', 'ConstraintList']
+    skipped_cag_module_classes = [
+        'ProgrammableConstraint',
+        'SingleTableProgrammableConstraint',
+        'ConstraintList',
+    ]
     available_constraints = inspect.getmembers(sdv.cag, lambda x: inspect.isclass(x))
 
     available_constraints = {

--- a/tests/integration/cag/test_programmable_constraint.py
+++ b/tests/integration/cag/test_programmable_constraint.py
@@ -13,6 +13,8 @@ from sdv.single_table import GaussianCopulaSynthesizer
 class IfTrueThenZero(ProgrammableConstraint):
     """Custom constraint that ensures that if a flag column is True."""
 
+    _is_single_table = True
+
     def __init__(self, target_column, flag_column, table_name=None):
         self.target_column = target_column
         self.flag_column = flag_column
@@ -64,6 +66,8 @@ class IfTrueThenZero(ProgrammableConstraint):
 @pytest.fixture
 def programmable_constraint():
     class MyConstraint(ProgrammableConstraint):
+        _is_single_table = True
+
         def __init__(self, column_names, table_name=None):
             self.column_names = column_names
             self.table_name = table_name
@@ -214,7 +218,7 @@ def test_end_to_end_deprecated_programmable_single_table_constraint(
     assert isinstance(constraints[0], deprecated_single_table_programmable_constraint)
 
 
-def test_end_to_end_simple_constraint_with_no_fit(programmable_constraint):
+def test_end_to_end_simple_constraint_with_no_fit():
     """Test using a programmable constraint without a fit method."""
     # Setup
     data, metadata = download_demo('single_table', 'fake_hotel_guests')
@@ -277,12 +281,3 @@ def test_get_updated_metadata_is_passed_metadata_copy(programmable_constraint):
     })
     expected_modified_metadata.add_column('has_rewards#room_type', sdtype='categorical')
     assert updated_metadata.to_dict() == expected_modified_metadata.to_dict()
-
-
-def test_single_table_programmable_constraint_backwards_compatible():
-    """Test that old-style SingleTableProgrammableConstraints still work."""
-    # Setup
-
-    # Run
-
-    # Assert

--- a/tests/integration/cag/test_programmable_constraint.py
+++ b/tests/integration/cag/test_programmable_constraint.py
@@ -3,14 +3,14 @@
 import pandas as pd
 import pytest
 
-from sdv.cag import FixedCombinations, ProgrammableConstraint
+from sdv.cag import FixedCombinations, ProgrammableConstraint, SingleTableProgrammableConstraint
 from sdv.datasets.demo import download_demo
 from sdv.metadata import Metadata
 from sdv.multi_table import HMASynthesizer
 from sdv.single_table import GaussianCopulaSynthesizer
 
 
-class SingleTableIfTrueThenZero(ProgrammableConstraint):
+class IfTrueThenZero(ProgrammableConstraint):
     """Custom constraint that ensures that if a flag column is True."""
 
     def __init__(self, target_column, flag_column, table_name=None):
@@ -100,6 +100,55 @@ def programmable_constraint():
     return MyConstraint
 
 
+@pytest.fixture
+def deprecated_single_table_programmable_constraint():
+    """Old-style SingleTableProgrammableConstraint for backwards compatability tests."""
+
+    class MyConstraint(SingleTableProgrammableConstraint):
+        def __init__(self, column_names, table_name):
+            self.column_names = column_names
+            self.table_name = table_name
+            self._joint_column = '#'.join(self.column_names)
+            self._combinations = None
+            self._fitted = False
+
+        def _get_single_table_name(self, metadata):
+            # Have to define this so that we can re-use existing methods on the constraint
+            return self.table_name
+
+        def validate(self, metadata):
+            FixedCombinations._validate_constraint_with_metadata(self, metadata)
+
+        def validate_input_data(self, data):
+            return
+
+        def fit(self, data, metadata):
+            self.metadata = metadata
+            data = {self.table_name: data}
+            FixedCombinations._fit(self, data, metadata)
+            self._fitted = True
+
+        def transform(self, data):
+            data = {self.table_name: data}
+            transformed = FixedCombinations._transform(self, data)
+            return transformed[self.table_name]
+
+        def get_updated_metadata(self, metadata):
+            return FixedCombinations._get_updated_metadata(self, metadata)
+
+        def reverse_transform(self, transformed_data):
+            transformed_data = {self.table_name: transformed_data}
+            reverse_transformed = FixedCombinations._reverse_transform(self, transformed_data)
+            return reverse_transformed[self.table_name]
+
+        def is_valid(self, synthetic_data):
+            synthetic_data = {self.table_name: synthetic_data}
+            is_valid = FixedCombinations._is_valid(self, synthetic_data, self.metadata)
+            return is_valid[self.table_name]
+
+    return MyConstraint
+
+
 def test_end_to_end_programmable_constraint_multi_table(programmable_constraint):
     """Test using a programmable constraint with a multi table synthesizer end-to-end."""
     data, metadata = download_demo('multi_table', 'fake_hotels')
@@ -143,12 +192,34 @@ def test_end_to_end_programmable_constraint_single_table(programmable_constraint
     assert isinstance(constraints[0], programmable_constraint)
 
 
+def test_end_to_end_deprecated_programmable_single_table_constraint(
+    deprecated_single_table_programmable_constraint,
+):
+    """Test using a deprecated single table programmable constraint end-to-end."""
+    data, metadata = download_demo('single_table', 'fake_hotel_guests')
+    my_constraint = deprecated_single_table_programmable_constraint(
+        column_names=['has_rewards', 'room_type'], table_name='fake_hotel_guests'
+    )
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    synthesizer.add_constraints([my_constraint])
+
+    # Run
+    synthesizer.fit(data)
+    sampled_data = synthesizer.sample(1000)
+    constraints = synthesizer.get_constraints()
+
+    # Assert
+    original_combinations = set(zip(data['has_rewards'], data['room_type']))
+    assert set(zip(sampled_data['has_rewards'], sampled_data['room_type'])) == original_combinations
+    assert isinstance(constraints[0], deprecated_single_table_programmable_constraint)
+
+
 def test_end_to_end_simple_constraint_with_no_fit(programmable_constraint):
     """Test using a programmable constraint without a fit method."""
     # Setup
     data, metadata = download_demo('single_table', 'fake_hotel_guests')
     synthesizer = GaussianCopulaSynthesizer(metadata)
-    custom_constraint = SingleTableIfTrueThenZero(
+    custom_constraint = IfTrueThenZero(
         target_column='amenities_fee',
         flag_column='has_rewards',
         table_name=metadata._get_single_table_name(),
@@ -206,3 +277,12 @@ def test_get_updated_metadata_is_passed_metadata_copy(programmable_constraint):
     })
     expected_modified_metadata.add_column('has_rewards#room_type', sdtype='categorical')
     assert updated_metadata.to_dict() == expected_modified_metadata.to_dict()
+
+
+def test_single_table_programmable_constraint_backwards_compatible():
+    """Test that old-style SingleTableProgrammableConstraints still work."""
+    # Setup
+
+    # Run
+
+    # Assert

--- a/tests/integration/sequential/test_par_programmable_constraints.py
+++ b/tests/integration/sequential/test_par_programmable_constraints.py
@@ -11,6 +11,8 @@ from sdv.sequential import PARSynthesizer
 class SimpleCustomConstraint(ProgrammableConstraint):
     """Simple custom constraint for testing."""
 
+    _is_single_table = True
+
     def __init__(self, column_name):
         self.column_name = column_name
         self.table_name = None
@@ -56,6 +58,8 @@ class SimpleCustomConstraint(ProgrammableConstraint):
 
 class ConditionalConstraint(ProgrammableConstraint):
     """Constraint that enforces conditional logic between columns."""
+
+    _is_single_table = True
 
     def __init__(self, flag_column, target_column):
         self.flag_column = flag_column
@@ -225,6 +229,8 @@ def test_constraint_with_context_columns(sample_sequential_data, sample_metadata
     synthesizer = PARSynthesizer(sample_metadata, context_columns=['has_condition'], epochs=1)
 
     class BooleanConstraint(ProgrammableConstraint):
+        _is_single_table = True
+
         def __init__(self, column_name):
             self.column_name = column_name
 

--- a/tests/integration/single_table/custom_constraints.py
+++ b/tests/integration/single_table/custom_constraints.py
@@ -1,9 +1,11 @@
 import pandas as pd
 
-from sdv.cag import ProgrammableConstraint
+from sdv.cag import ProgrammableConstraint, SingleTableProgrammableConstraint
 
 
 class MyConstraint(ProgrammableConstraint):
+    _is_single_table = True
+
     def __init__(self, column_names, table_name):
         self.column_names = column_names
         self.table_name = table_name
@@ -39,6 +41,8 @@ class MyConstraint(ProgrammableConstraint):
 
 
 class IfTrueThenZero(ProgrammableConstraint):
+    _is_single_table = True
+
     def __init__(self, column_names, table_name):
         self.column_names = column_names
         self.table_name = table_name
@@ -50,9 +54,9 @@ class IfTrueThenZero(ProgrammableConstraint):
         table_data = data[self.table_name]
         boolean_column = self.column_names[0]
         numerical_column = self.column_names[1]
-        typical_value = data[numerical_column].median()
-        table_data[numerical_column] = data[numerical_column].mask(
-            data[boolean_column], typical_value
+        typical_value = table_data[numerical_column].median()
+        table_data[numerical_column] = table_data[numerical_column].mask(
+            table_data[boolean_column], typical_value
         )
         data[self.table_name] = table_data
 
@@ -87,37 +91,30 @@ class IfTrueThenZero(ProgrammableConstraint):
         return is_valid
 
 
-class SingleTableIfTrueThenZero(ProgrammableConstraint):
+class SingleTableIfTrueThenZero(SingleTableProgrammableConstraint):
     def __init__(self, column_names):
         self.column_names = column_names
 
     def fit(self, data, metadata):
-        self.table_name = metadata._get_single_table_name()
         return
 
     def transform(self, data):
         """Transform the data if amenities fee is to be applied."""
-        table_data = data[self.table_name]
         boolean_column = self.column_names[0]
         numerical_column = self.column_names[1]
-        typical_value = table_data[numerical_column].median()
-        table_data[numerical_column] = table_data[numerical_column].mask(
-            table_data[boolean_column], typical_value
-        )
+        typical_value = data[numerical_column].median()
+        data[numerical_column] = data[numerical_column].mask(data[boolean_column], typical_value)
 
-        data[self.table_name] = table_data
         return data
 
     def reverse_transform(self, transformed_data):
         """Reverse the data if amenities fee is to be applied."""
-        transformed_table = transformed_data[self.table_name]
         boolean_column = self.column_names[0]
         numerical_column = self.column_names[1]
-        transformed_table[numerical_column] = transformed_table[numerical_column].mask(
-            transformed_table[boolean_column], 0.0
+        transformed_data[numerical_column] = transformed_data[numerical_column].mask(
+            transformed_data[boolean_column], 0.0
         )
 
-        transformed_data[self.table_name] = transformed_table
         return transformed_data
 
     def get_updated_metadata(self, metadata):
@@ -125,14 +122,9 @@ class SingleTableIfTrueThenZero(ProgrammableConstraint):
 
     def is_valid(self, synthetic_data):
         """Validate that if ``has_rewards`` amenities fee is 0."""
-        is_valid = {
-            table: pd.Series(True, index=synthetic_data[table].index) for table in synthetic_data
-        }
-        synthetic_table = synthetic_data[self.table_name]
         boolean_column = self.column_names[0]
         numerical_column = self.column_names[1]
-        true_values = (synthetic_table[boolean_column]) & (synthetic_table[numerical_column] == 0.0)
-        false_values = ~synthetic_table[boolean_column]
+        true_values = (synthetic_data[boolean_column]) & (synthetic_data[numerical_column] == 0.0)
+        false_values = ~synthetic_data[boolean_column]
 
-        is_valid[self.table_name] = (true_values) | (false_values)
-        return is_valid
+        return (true_values) | (false_values)

--- a/tests/integration/single_table/test_copulas.py
+++ b/tests/integration/single_table/test_copulas.py
@@ -22,7 +22,10 @@ from sdv.evaluation.single_table import evaluate_quality, get_column_pair_plot, 
 from sdv.metadata.metadata import Metadata
 from sdv.sampling import Condition
 from sdv.single_table import GaussianCopulaSynthesizer
-from tests.integration.single_table.custom_constraints import SingleTableIfTrueThenZero
+from tests.integration.single_table.custom_constraints import (
+    IfTrueThenZero,
+    SingleTableIfTrueThenZero,
+)
 
 
 def test_synthesize_table_gaussian_copula(tmp_path):
@@ -128,7 +131,16 @@ def test_synthesize_table_gaussian_copula(tmp_path):
     assert real_data.shape[1] == simulated_synthetic_data.shape[1]
 
 
-def test_adding_constraints(tmp_path):
+@pytest.mark.parametrize(
+    'programmable_constraint',
+    [
+        IfTrueThenZero(
+            column_names=['has_rewards', 'amenities_fee'], table_name='fake_hotel_guests'
+        ),
+        SingleTableIfTrueThenZero(column_names=['has_rewards', 'amenities_fee']),
+    ],
+)
+def test_adding_constraints(tmp_path, programmable_constraint):
     """End to end test for adding constraints to a ``BaseSingleTableSynthesizer``.
 
     The following functionalities are being tested:
@@ -161,8 +173,7 @@ def test_adding_constraints(tmp_path):
     assert all(~violations)
 
     # Load custom constraint class
-    rewards_member_no_fee = SingleTableIfTrueThenZero(column_names=['has_rewards', 'amenities_fee'])
-    synthesizer.add_constraints([rewards_member_no_fee])
+    synthesizer.add_constraints([programmable_constraint])
 
     # Re-Fit the model
     synthesizer.preprocess(real_data)

--- a/tests/unit/cag/test_programmable_constraint.py
+++ b/tests/unit/cag/test_programmable_constraint.py
@@ -6,9 +6,11 @@ from unittest.mock import Mock, patch
 import pandas as pd
 import pytest
 
+from sdv.cag._errors import ConstraintNotMetError
 from sdv.cag.programmable_constraint import (
     ProgrammableConstraint,
     ProgrammableConstraintHarness,
+    SingleTableProgrammableConstraint,
 )
 from sdv.metadata import Metadata
 
@@ -98,6 +100,35 @@ class TestProgrammableConstraintHarness:
         # Assert
         programmable_constraint.validate.assert_called_once_with(metadata)
 
+    def test__validate_constraint_with_metadata(self):
+        """Test that it errors if SingleTableProgrammableConstraint used with multi-table."""
+        # Setup
+        single_table_metadata = Metadata().load_from_dict({
+            'tables': {'table': {'columns': {'col_A': {'sdtype': 'numerical'}}}}
+        })
+        multi_table_metadata = Metadata().load_from_dict({
+            'tables': {
+                'table1': {'columns': {'col_A': {'sdtype': 'numerical'}}},
+                'table2': {
+                    'columns': {'col_B': {'sdtype': 'categorical'}},
+                },
+            }
+        })
+        programmable_constraint = SingleTableProgrammableConstraint()
+        programmable_constraint.validate = Mock()
+        instance = ProgrammableConstraintHarness(programmable_constraint)
+        expected_err = re.escape(
+            'SingleTableProgrammableConstraint cannot be used with multi-table metadata '
+            'if the `table_name` attribute has not been set. Please set the table name '
+            'attribute to the target table, or use the ProgrammableContraint '
+            'base class instead.'
+        )
+
+        # Run and Assert
+        instance._validate_constraint_with_metadata(single_table_metadata)
+        with pytest.raises(ConstraintNotMetError, match=expected_err):
+            instance._validate_constraint_with_metadata(multi_table_metadata)
+
     def test__validate_constraint_with_data(self):
         """Test the ``_validate_constraint_with_data`` method."""
         # Setup
@@ -116,6 +147,25 @@ class TestProgrammableConstraintHarness:
 
         # Assert
         programmable_constraint.validate_input_data.assert_called_once_with(data)
+
+    def test__validate_constraint_with_data_backwards_compatible(self):
+        """Test method is backwards compatible with SingleTableProgrammableConstraint."""
+        # Setup
+        metadata = Metadata().load_from_dict({
+            'tables': {
+                'table': {'columns': {'col_A': {'sdtype': 'numerical'}}},
+            }
+        })
+        data = {'table': pd.DataFrame({'col_A': range(5)})}
+        programmable_constraint = SingleTableProgrammableConstraint()
+        programmable_constraint.validate_input_data = Mock()
+        instance = ProgrammableConstraintHarness(programmable_constraint)
+
+        # Run
+        instance._validate_constraint_with_data(data, metadata)
+
+        # Assert
+        programmable_constraint.validate_input_data.assert_called_once_with(data['table'])
 
     @patch('sdv.cag.programmable_constraint.deepcopy')
     def test__get_updated_metadata(self, mock_deepcopy):
@@ -158,6 +208,27 @@ class TestProgrammableConstraintHarness:
         programmable_constraint.fit.assert_called_once_with(data, metadata)
         instance._fit_constraint_column_formatters.assert_called_once_with(data)
 
+    def test__fit_backwards_compatible(self):
+        """Test backwards compatiblity with SingleTableProgrammableConstraint."""
+        # Setup
+        metadata = Metadata().load_from_dict({
+            'tables': {'table': {'columns': {'col_A': {'sdtype': 'numerical'}}}}
+        })
+        data = {'table': pd.DataFrame({'col_A': range(5)})}
+        programmable_constraint = SingleTableProgrammableConstraint()
+        programmable_constraint.fit = Mock()
+        programmable_constraint.get_updated_metadata = Mock(return_value=metadata)
+        instance = ProgrammableConstraintHarness(programmable_constraint)
+        instance._fit_constraint_column_formatters = Mock()
+        instance._table_name = 'table'
+
+        # Run
+        instance.fit(data, metadata)
+
+        # Assert
+        programmable_constraint.fit.assert_called_once_with(data['table'], metadata)
+        instance._fit_constraint_column_formatters.assert_called_once_with(data)
+
     def test__transform(self):
         """Test the ``_transform`` method."""
         # Setup
@@ -171,6 +242,22 @@ class TestProgrammableConstraintHarness:
 
         # Assert
         programmable_constraint.transform.assert_called_once_with(data)
+
+    def test__transform_backwards_compatible(self):
+        """Test the method is backwards compatible with SingleTableProgrammableConstraint."""
+        # Setup
+        data = {'table': pd.DataFrame({'col_A': range(5)})}
+        programmable_constraint = SingleTableProgrammableConstraint()
+        programmable_constraint.transform = Mock(return_value=data['table'])
+        instance = ProgrammableConstraintHarness(programmable_constraint)
+        instance._table_name = 'table'
+
+        # Run
+        transformed = instance._transform(data)
+
+        # Assert
+        programmable_constraint.transform.assert_called_once_with(data['table'])
+        assert transformed == {'table': data['table']}
 
     def test__reverse_transform(self):
         """Test the ``_reverse_transform`` method."""
@@ -186,6 +273,22 @@ class TestProgrammableConstraintHarness:
         # Assert
         programmable_constraint.reverse_transform.assert_called_once_with(data)
 
+    def test__reverse_transform_backwards_compatible(self):
+        """Test the method is backwards compatible with SingleTableProgrammableConstraint."""
+        # Setup
+        data = {'table': pd.DataFrame({'col_A': range(5)})}
+        programmable_constraint = SingleTableProgrammableConstraint()
+        programmable_constraint.reverse_transform = Mock(return_value=data['table'])
+        instance = ProgrammableConstraintHarness(programmable_constraint)
+        instance._table_name = 'table'
+
+        # Run
+        reverse_transformed = instance._reverse_transform(data)
+
+        # Assert
+        programmable_constraint.reverse_transform.assert_called_once_with(data['table'])
+        assert reverse_transformed == {'table': data['table']}
+
     def test__is_valid(self):
         """Test the ``_is_valid`` method."""
         # Setup
@@ -200,6 +303,23 @@ class TestProgrammableConstraintHarness:
 
         # Assert
         programmable_constraint.is_valid.assert_called_once_with(data)
+
+    def test__is_valid_backwards_compatability(self):
+        """Test the method is backwards compatible with SingleTableProgrammableConstraint."""
+        # Setup
+        data = {'table': pd.DataFrame({'col_A': range(5)})}
+        programmable_constraint = SingleTableProgrammableConstraint()
+        programmable_constraint.is_valid = Mock(return_value=data['table'])
+        instance = ProgrammableConstraintHarness(programmable_constraint)
+        instance._get_single_table_name = Mock(return_value='table')
+        metadata = Mock()
+
+        # Run
+        is_valid = instance._is_valid(data, metadata)
+
+        # Assert
+        programmable_constraint.is_valid.assert_called_once_with(data['table'])
+        assert is_valid == {'table': data['table']}
 
     def test_get_constraint_dict_errors_missing_attribute(self):
         """Test getting the constraint dict errors if attribute is missing."""

--- a/tests/unit/sequential/test_par.py
+++ b/tests/unit/sequential/test_par.py
@@ -157,13 +157,13 @@ class TestPARSynthesizer:
         synthesizer = PARSynthesizer(metadata=metadata, context_columns=['gender', 'measurement'])
 
         multi_table_programmable_constraint = ProgrammableConstraint()
-        multi_table_programmable_constraint._is_single_table = False
         multi_table_error_msg = re.escape(
             'Constraint `ProgrammableConstraint` is not compatible '
             'with the single table synthesizers.'
         )
 
         programmable_constraint = ProgrammableConstraint()
+        programmable_constraint._is_single_table = True
         constraint_1 = MockConstraint(column_names=['time'])
         constraint_2 = MockConstraint(column_names=['time', 'gender'])
         overlapping_error_msg = re.escape(

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -1376,6 +1376,7 @@ class TestBaseSynthesizer:
         instance._validate_constraints_single_table.side_effect = lambda constraint: constraint
         constraint3.get_updated_metadata.side_effect = [ConstraintNotMetError, None]
         constraint4 = ProgrammableConstraint()
+        constraint4._is_single_table = True
         mock_harness = Mock()
         mock_programmable_constraint_harness.return_value = mock_harness
 


### PR DESCRIPTION
Resolve #2909

This PR restores the `SingleTableProgrammableConstraint` class and adds checks in the harness to revert to the old behavior if the programmable constraint  is a `SingleTableProgrammableConstraint`. 