### PR TITLE
[Fix] Targeted sampling in SDV-Enterprise could not validate metadata or assign Transformers

### DIFF
--- a/sdv/data_processing/data_processor.py
+++ b/sdv/data_processing/data_processor.py
@@ -380,6 +380,7 @@ class DataProcessor:
             'range_is_nullable',
             'pii',
             'sdtype',
+            'range_values',
         ]
         parameters = {
             key: value for key, value in column_metadata.items() if key not in non_param_keys

--- a/sdv/metadata/_single_table.py
+++ b/sdv/metadata/_single_table.py
@@ -308,7 +308,7 @@ class _SingleTableMetadata:
         return False
 
     def _get_unexpected_kwargs(self, sdtype, **kwargs):
-        expected_kwargs = self._SDTYPE_KWARGS.get(sdtype, ['pii'])
+        expected_kwargs = self._SDTYPE_KWARGS.get(sdtype, ['pii', 'range_is_nullable'])
         unexpected_kwargs = set(kwargs) - set(expected_kwargs)
         if unexpected_kwargs:
             unexpected_kwargs = sorted(unexpected_kwargs)

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -698,6 +698,9 @@ class TestHMASynthesizer:
         # The metadata contains the `order_by` key for categorical which we don't support for 2.0
         metadata.tables['WorkOrderRouting'].columns['OperationSequence'] = {'sdtype': 'categorical'}
 
+        #The metadata contains the `order_by` key for categorical which we don't support for 2.0
+        metadata.tables['WorkOrderRouting'].columns['OperationSequence'] = {'sdtype': 'categorical'}
+
         # Run and Assert
         error_msg = (
             'HMASynthesizer is not designed to handle a schema with more than 5 tables or '

--- a/tests/integration/multi_table/test_hma.py
+++ b/tests/integration/multi_table/test_hma.py
@@ -698,9 +698,6 @@ class TestHMASynthesizer:
         # The metadata contains the `order_by` key for categorical which we don't support for 2.0
         metadata.tables['WorkOrderRouting'].columns['OperationSequence'] = {'sdtype': 'categorical'}
 
-        #The metadata contains the `order_by` key for categorical which we don't support for 2.0
-        metadata.tables['WorkOrderRouting'].columns['OperationSequence'] = {'sdtype': 'categorical'}
-
         # Run and Assert
         error_msg = (
             'HMASynthesizer is not designed to handle a schema with more than 5 tables or '


### PR DESCRIPTION
[SDV-Enterprise PR](https://github.com/datacebo/SDV-Enterprise/pull/2202)

The errors were:

```
sdv.metadata.errors.InvalidMetadataError: The metadata is not valid
E           
E           Table: table1
E           Invalid values '(range_is_nullable)' for email column 'pii_col'.
```

```
return transformer_class(**{**default_transformer_kwargs, **parameters})
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           TypeError: UniformEncoder.__init__() got an unexpected keyword argument 'range_values'
```