### PR TITLE
[Fix] Rename output_file_path to output_folder_path for sample_from_conditions() and sample_remaining_columns()

### DIFF
--- a/sdv/multi_table/base.py
+++ b/sdv/multi_table/base.py
@@ -38,6 +38,7 @@ from sdv.errors import (
 from sdv.logging import disable_single_table_logger, get_sdv_logger
 from sdv.metadata.metadata import Metadata
 from sdv.single_table.copulas import GaussianCopulaSynthesizer
+from sdv.single_table.utils import validate_folder_path_with_table_names
 
 SYNTHESIZER_LOGGER = get_sdv_logger('MultiTableSynthesizer')
 
@@ -767,7 +768,8 @@ class BaseMultiTableSynthesizer:
                 'sampling synthetic data.'
             )
 
-        if table_name not in self.get_metadata().tables:
+        table_names = list(self.get_metadata().tables)
+        if table_name not in table_names:
             raise SynthesizerInputError(f"Table '{table_name}' does not exist in the metadata.")
 
         _validate_positive_integer('num_rows', num_rows)
@@ -782,6 +784,8 @@ class BaseMultiTableSynthesizer:
                 f"Invalid parameter for 'output_folder_path' ({output_folder_path}). "
                 'Please provide a valid string path.'
             )
+
+        validate_folder_path_with_table_names(output_folder_path, table_names)
 
     def _sample_in_batches(
         self,

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -995,8 +995,12 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
             num_sampled = min(len(sampled), batch_size)
             if num_increase > 0:
                 if output_file_path:
-                    append_kwargs = {'mode': 'a', 'header': False}
-                    append_kwargs = append_kwargs if os.path.getsize(output_file_path) > 0 else {}
+                    append_kwargs = (
+                        {'mode': 'a', 'header': False}
+                        if os.path.exists(output_file_path)
+                        and os.path.getsize(output_file_path) > 0
+                        else {}
+                    )
                     sampled.head(num_sampled).tail(num_increase).to_csv(
                         output_file_path,
                         index=False,

--- a/sdv/single_table/base.py
+++ b/sdv/single_table/base.py
@@ -51,7 +51,12 @@ from sdv.metadata._single_table import _SingleTableMetadata
 from sdv.metadata.errors import InvalidMetadataError
 from sdv.metadata.metadata import Metadata
 from sdv.sampling import Condition, DataFrameCondition
-from sdv.single_table.utils import check_num_rows, handle_sampling_error, validate_file_path
+from sdv.single_table.utils import (
+    check_num_rows,
+    handle_sampling_error,
+    validate_file_path,
+    validate_folder_path_with_table_names,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1209,12 +1214,9 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
         has_batches = batch_size is not None and batch_size != num_rows
         show_progress_bar = has_constraints or has_batches
 
-        output_file_path = None
-        if output_folder_path is not None:
-            output_folder = Path(output_folder_path)
-            output_folder.mkdir(parents=True, exist_ok=True)
-            output_file_path = str(output_folder / f'{table_name}.csv')
-
+        output_file_path = validate_folder_path_with_table_names(
+            output_folder_path, [self._table_name]
+        )[0]
         sampled_table_data = self._sample_with_progress_bar(
             num_rows,
             max_tries_per_batch,
@@ -1396,7 +1398,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
             self._validate_conditions_unseen_columns(condition_dataframe)
 
     def sample_from_conditions(
-        self, conditions, max_tries_per_batch=100, batch_size=None, output_file_path=None
+        self, conditions, max_tries_per_batch=100, batch_size=None, output_folder_path=None
     ):
         """Sample rows from this table with the given conditions.
 
@@ -1409,8 +1411,8 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                 Number of times to retry sampling until the batch size is met. Defaults to 100.
             batch_size (int):
                 The batch size to use per sampling call.
-            output_file_path (str or None):
-                The file to periodically write sampled rows to. Defaults to None.
+            output_folder_path (str or None):
+                The folder to periodically write sampled rows to. Defaults to None.
 
         Returns:
             pandas.DataFrame:
@@ -1425,7 +1427,9 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                     * no rows could be generated.
         """
         self._validate_fit_before_sample()
-        output_file_path = validate_file_path(output_file_path)
+        output_file_path = validate_folder_path_with_table_names(
+            output_folder_path, [self._table_name]
+        )[0]
         sample_timestamp = datetime.datetime.now()
 
         num_rows = functools.reduce(
@@ -1479,7 +1483,7 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
         self._validate_conditions_unseen_columns(conditions)
 
     def sample_remaining_columns(
-        self, known_columns, max_tries_per_batch=100, batch_size=None, output_file_path=None
+        self, known_columns, max_tries_per_batch=100, batch_size=None, output_folder_path=None
     ):
         """Sample remaining rows from already known columns.
 
@@ -1492,8 +1496,8 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                 Number of times to retry sampling until the batch size is met. Defaults to 100.
             batch_size (int):
                 The batch size to use per sampling call.
-            output_file_path (str or None):
-                The file to periodically write sampled rows to. Defaults to None.
+            output_folder_path (str or None):
+                The folder to periodically write sampled rows to. Defaults to None.
 
         Returns:
             pandas.DataFrame:
@@ -1507,7 +1511,9 @@ class BaseSingleTableSynthesizer(BaseSynthesizer):
                     * any of the conditions' columns are not valid.
                     * no rows could be generated.
         """
-        output_file_path = validate_file_path(output_file_path)
+        output_file_path = validate_folder_path_with_table_names(
+            output_folder_path, [self._table_name]
+        )[0]
 
         known_columns = known_columns.copy()
         self._validate_known_columns(known_columns)

--- a/sdv/single_table/utils.py
+++ b/sdv/single_table/utils.py
@@ -186,6 +186,45 @@ def validate_file_path(output_file_path):
     return output_path
 
 
+def validate_folder_path_with_table_names(output_folder_path, table_names):
+    """Validate the output folder and return the output paths for each table.
+
+    Args:
+        output_folder_path (str):
+            The path to the output folder.
+        table_names (list[str]):
+            A list of table names for which to generate output file paths.
+    """
+    if output_folder_path == DISABLE_TMP_FILE:
+        # Temporary way of disabling the output file feature, used by HMA1.
+        return None
+
+    if not output_folder_path:
+        # Do not save files if the user specified not to save them.
+        return None
+
+    output_folder_path = os.path.abspath(output_folder_path)
+    output_paths = [
+        os.path.join(output_folder_path, f'{table_name}.csv') for table_name in table_names
+    ]
+
+    existing_paths = [output_path for output_path in output_paths if os.path.exists(output_path)]
+    if existing_paths:
+        formatted_paths = '\n'.join(existing_paths)
+        raise AssertionError(f'The following output files already exist:\n{formatted_paths}')
+
+    try:
+        os.makedirs(output_folder_path, exist_ok=True)
+
+    except PermissionError:
+        warnings.warn(
+            f"Permission denied: cannot write to '{output_folder_path}'. Skipping file creation."
+        )
+        return None
+
+    return output_paths
+
+
 def flatten_array(nested, prefix=''):
     """Flatten an array as a dict.
 

--- a/sdv/single_table/utils.py
+++ b/sdv/single_table/utils.py
@@ -197,11 +197,11 @@ def validate_folder_path_with_table_names(output_folder_path, table_names):
     """
     if output_folder_path == DISABLE_TMP_FILE:
         # Temporary way of disabling the output file feature, used by HMA1.
-        return None
+        return [None]
 
     if not output_folder_path:
         # Do not save files if the user specified not to save them.
-        return None
+        return [None]
 
     output_folder_path = os.path.abspath(output_folder_path)
     output_paths = [

--- a/tests/integration/single_table/test_base.py
+++ b/tests/integration/single_table/test_base.py
@@ -978,7 +978,7 @@ def test_range_extrapolation_warns_to_install_bundle(synthesizer_class):
             'sample_from_conditions',
             {
                 'conditions': [
-                    Condition({'column1': 1, 'column2': 4}),
+                    Condition({'column1': 1}),
                 ],
             },
             1,
@@ -1024,13 +1024,14 @@ def test_sample_methods_with_output_folder_path(
     )
 
     # Assert
+    sampled = sampled if isinstance(sampled, pd.DataFrame) else sampled['table']
     assert output_file_path.exists()
-    assert len(sampled['table']) == expected_num_rows
+    assert len(sampled) == expected_num_rows
 
     saved_data = pd.read_csv(output_file_path)
     pd.testing.assert_frame_equal(
-        saved_data,
-        sampled['table'],
+        saved_data.sort_values(by='column1').reset_index(drop=True),
+        sampled.sort_values(by='column1').reset_index(drop=True),
         check_dtype=False,
     )
 

--- a/tests/integration/single_table/test_base.py
+++ b/tests/integration/single_table/test_base.py
@@ -960,3 +960,138 @@ def test_range_extrapolation_warns_to_install_bundle(synthesizer_class):
     # Assert
     sampled = sampled['fake_hotel_guests']
     assert min(sampled['room_rate']) >= min(data['fake_hotel_guests']['room_rate'])
+
+
+@pytest.mark.parametrize(
+    'method, method_kwargs, expected_num_rows',
+    [
+        pytest.param(
+            'sample',
+            {
+                'table_name': 'table',
+                'num_rows': 10,
+            },
+            10,
+            id='sample',
+        ),
+        pytest.param(
+            'sample_from_conditions',
+            {
+                'conditions': [
+                    Condition({'column1': 1, 'column2': 4}),
+                ],
+            },
+            1,
+            id='sample_from_conditions',
+        ),
+        pytest.param(
+            'sample_remaining_columns',
+            {
+                'known_columns': pd.DataFrame(
+                    {'column1': [1, 2, 3, 1, 2]},
+                ),
+            },
+            5,
+            id='sample_remaining_columns',
+        ),
+    ],
+)
+def test_sample_methods_with_output_folder_path(
+    tmp_path,
+    method,
+    method_kwargs,
+    expected_num_rows,
+):
+    """Test that the sample methods save the sampled data in the output folder."""
+    # Setup
+    data = {
+        'table': pd.DataFrame({
+            'column1': [1, 2, 3],
+            'column2': [4, 5, 6],
+        })
+    }
+    metadata = Metadata.detect_from_dataframes(data)
+    output_folder_path = tmp_path / 'output'
+    output_file_path = output_folder_path / 'table.csv'
+
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    synthesizer.fit(data)
+
+    # Run
+    sampled = getattr(synthesizer, method)(
+        output_folder_path=str(output_folder_path),
+        **method_kwargs,
+    )
+
+    # Assert
+    assert output_file_path.exists()
+    assert len(sampled['table']) == expected_num_rows
+
+    saved_data = pd.read_csv(output_file_path)
+    pd.testing.assert_frame_equal(
+        saved_data,
+        sampled['table'],
+        check_dtype=False,
+    )
+
+
+@pytest.mark.parametrize(
+    'method, method_kwargs',
+    [
+        pytest.param(
+            'sample',
+            {
+                'table_name': 'table',
+                'num_rows': 10,
+            },
+            id='sample',
+        ),
+        pytest.param(
+            'sample_from_conditions',
+            {
+                'conditions': [
+                    Condition({'column1': 1, 'column2': 4}),
+                ],
+            },
+            id='sample_from_conditions',
+        ),
+        pytest.param(
+            'sample_remaining_columns',
+            {
+                'known_columns': pd.DataFrame(
+                    {'column1': [1, 2, 3, 1, 2]},
+                ),
+            },
+            id='sample_remaining_columns',
+        ),
+    ],
+)
+def test_sample_methods_with_existing_output_file(
+    tmp_path,
+    method,
+    method_kwargs,
+):
+    """Test that the sample methods raise an error if the output file already exists."""
+    # Setup
+    data = {
+        'table': pd.DataFrame({
+            'column1': [1, 2, 3],
+            'column2': [4, 5, 6],
+        })
+    }
+    metadata = Metadata.detect_from_dataframes(data)
+    output_folder_path = tmp_path / 'output'
+    output_folder_path.mkdir()
+    output_file_path = output_folder_path / 'table.csv'
+    output_file_path.touch()
+
+    synthesizer = GaussianCopulaSynthesizer(metadata)
+    synthesizer.fit(data)
+
+    # Run and Assert
+    error_msg = f'The following output files already exist:\n{output_file_path}'
+    with pytest.raises(AssertionError, match=re.escape(error_msg)):
+        getattr(synthesizer, method)(
+            output_folder_path=str(output_folder_path),
+            **method_kwargs,
+        )

--- a/tests/unit/multi_table/test_base.py
+++ b/tests/unit/multi_table/test_base.py
@@ -1416,6 +1416,33 @@ class TestBaseMultiTableSynthesizer:
         with pytest.raises(SynthesizerInputError, match=re.escape(expected_error)):
             instance._validate_sample_input(**arguments)
 
+    @patch('sdv.multi_table.base._validate_positive_integer')
+    @patch('sdv.multi_table.base.validate_folder_path_with_table_names')
+    def test__validate_sample_input_valid(self, mock_validate_folder_path, mock_validate_integer):
+        """Test ``_validate_sample_input`` does not raise an error for valid inputs."""
+        # Setup
+        metadata = get_multi_table_metadata()
+        instance = BaseMultiTableSynthesizer(metadata)
+        instance._fitted = True
+        instance.get_metadata = Mock(return_value=Mock(tables={'table'}))
+
+        arguments = {
+            'table_name': 'table',
+            'num_rows': 10,
+            'batch_size': 5,
+            'max_tries_per_batch': 100,
+            'output_folder_path': 'output',
+        }
+
+        # Run
+        instance._validate_sample_input(**arguments)
+
+        # Assert
+        mock_validate_integer.assert_any_call('num_rows', 10)
+        mock_validate_integer.assert_any_call('batch_size', 5)
+        mock_validate_integer.assert_any_call('max_tries_per_batch', 100)
+        mock_validate_folder_path.assert_called_once_with('output', ['table'])
+
     def test_sample_raises_sampling_error(self):
         """Test that ``sample`` will raise ``SamplingError`` when not fitted."""
         # Setup

--- a/tests/unit/single_table/test_base.py
+++ b/tests/unit/single_table/test_base.py
@@ -2121,7 +2121,8 @@ class TestBaseSingleTableSynthesizer:
         assert 'Mocked Error' in str(exception.value.__cause__)
 
     @patch('sdv.single_table.base.datetime')
-    def test_sample(self, mock_datetime, caplog):
+    @patch('sdv.single_table.base.validate_folder_path_with_table_names')
+    def test_sample(self, mock_validate_folder_path_with_table_names, mock_datetime, caplog):
         """Test that we use ``_sample_with_progress_bar`` in this method."""
         # Setup
         mock_datetime.datetime.now.return_value = '2024-04-19 16:20:10.037183'
@@ -2129,6 +2130,9 @@ class TestBaseSingleTableSynthesizer:
         max_tries_per_batch = 50
         batch_size = 5
         output_file_path = 'temp'
+        mock_validate_folder_path_with_table_names.return_value = [
+            os.path.join(output_file_path, 'table.csv')
+        ]
         instance = Mock(
             _synthesizer_id='BaseSingleTableSynthesizer_1.0.0_92aff11e9a5649d1a280990d1231a5f5',
         )
@@ -2474,9 +2478,9 @@ class TestBaseSingleTableSynthesizer:
 
     @patch('sdv.single_table.base.handle_sampling_error')
     @patch('sdv.single_table.base.tqdm')
-    @patch('sdv.single_table.base.validate_file_path')
+    @patch('sdv.single_table.base.validate_folder_path_with_table_names')
     def test_sample_from_conditions_handle_sampling_error(
-        self, mock_validate_file_path, mock_tqdm, mock_handle_sampling_error
+        self, mock_validate_folder_path, mock_tqdm, mock_handle_sampling_error
     ):
         """Test the error handling when we are using ``sample_from_conditions``."""
         # Setup
@@ -2487,7 +2491,7 @@ class TestBaseSingleTableSynthesizer:
         conditions = [Condition({'name': 'John Doe'})]
         keyboard_error = KeyboardInterrupt()
         instance._sample_with_conditions.side_effect = [keyboard_error]
-        mock_validate_file_path.return_value = 'temp_file'
+        mock_validate_folder_path.return_value = ['temp_file']
 
         # Run
         result = BaseSingleTableSynthesizer.sample_from_conditions(
@@ -2558,10 +2562,10 @@ class TestBaseSingleTableSynthesizer:
     @patch('sdv.single_table.base.check_num_rows')
     @patch('sdv.single_table.base.DataProcessor')
     @patch('sdv.single_table.base.tqdm')
-    @patch('sdv.single_table.base.validate_file_path')
+    @patch('sdv.single_table.base.validate_folder_path_with_table_names')
     def test_sample_remaining_columns_handles_sampling_error(
         self,
-        mock_validate_file_path,
+        mock_validate_folder_path,
         mock_tqdm,
         mock_data_processor,
         mock_check_num_rows,
@@ -2583,7 +2587,7 @@ class TestBaseSingleTableSynthesizer:
         instance._model = GaussianMultivariate()
         keyboard_error = KeyboardInterrupt()
         instance._sample_with_conditions.side_effect = [keyboard_error]
-        mock_validate_file_path.return_value = 'temp_file'
+        mock_validate_folder_path.return_value = ['temp_file']
 
         progress_bar = MagicMock()
         mock_tqdm.tqdm.return_value = progress_bar
@@ -2627,6 +2631,7 @@ class TestBaseSingleTableSynthesizer:
         instance._sample_with_progress_bar = Mock(return_value=pd.DataFrame())
         instance._original_columns = pd.Index([])
         instance._validate_fit_before_sample = Mock()
+        instance._table_name = 'table'
 
         # Run
         BaseSingleTableSynthesizer.sample(instance, 'table', 10)

--- a/tests/unit/single_table/test_utils.py
+++ b/tests/unit/single_table/test_utils.py
@@ -1,11 +1,12 @@
 import os
+import re
 import warnings
 from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
 import pytest
-import re
+
 from sdv.metadata._single_table import _SingleTableMetadata
 from sdv.single_table.utils import (
     _key_order,
@@ -325,17 +326,17 @@ def test_check_num_rows_valid(warning_mock):
 
 
 @patch('builtins.open')
-def test_validate_file_path(mock_open):
+def test_validate_file_path(mock_open, tmp_path):
     """Test the validate_file_path function."""
     # Setup
-    output_path = '.sample.csv.temp'
+    output_path = str(tmp_path / 'sample.csv')
 
     # Run
     result = validate_file_path(output_path)
     none_result = validate_file_path(None)
 
     # Assert
-    assert output_path in result
+    assert result == output_path
     assert none_result is None
     mock_open.assert_called_once_with(result, 'w+')
 
@@ -376,7 +377,7 @@ def test_validate_folder_path_with_table_names(mock_makedirs):
     ]
 
     assert result == expected_output_paths
-    assert none_result is None
+    assert none_result == [None]
     mock_makedirs.assert_called_once_with(expected_folder_path, exist_ok=True)
 
 
@@ -397,6 +398,7 @@ def test_validate_folder_path_with_table_names_permission_error(mock_makedirs):
     assert mock_makedirs.called
     assert any('Permission denied' in str(warning.message) for warning in warned)
 
+
 @patch('os.path.exists')
 def test_validate_folder_path_with_table_names_existing_files(mock_exists):
     """Test the function raises an error listing all existing output files."""
@@ -408,8 +410,8 @@ def test_validate_folder_path_with_table_names_existing_files(mock_exists):
     expected_folder_path = os.path.abspath(output_folder_path)
     expected_error = (
         'The following output files already exist:\n'
-        f"{os.path.join(expected_folder_path, 'users.csv')}\n"
-        f"{os.path.join(expected_folder_path, 'payments.csv')}"
+        f'{os.path.join(expected_folder_path, "users.csv")}\n'
+        f'{os.path.join(expected_folder_path, "payments.csv")}'
     )
 
     # Run and Assert

--- a/tests/unit/single_table/test_utils.py
+++ b/tests/unit/single_table/test_utils.py
@@ -1,10 +1,11 @@
+import os
 import warnings
 from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
 import pytest
-
+import re
 from sdv.metadata._single_table import _SingleTableMetadata
 from sdv.single_table.utils import (
     _key_order,
@@ -15,6 +16,7 @@ from sdv.single_table.utils import (
     handle_sampling_error,
     unflatten_dict,
     validate_file_path,
+    validate_folder_path_with_table_names,
     warn_missing_numerical_distributions,
 )
 
@@ -353,6 +355,66 @@ def test_validate_file_path_permission_error(mock_open):
     assert result is None
     assert mock_open.called
     assert any('Permission denied' in str(warning.message) for warning in warned)
+
+
+@patch('os.makedirs')
+def test_validate_folder_path_with_table_names(mock_makedirs):
+    """Test the validate_folder_path_with_table_names function."""
+    # Setup
+    output_folder_path = '.sample.temp'
+    table_names = ['users', 'transactions']
+
+    # Run
+    result = validate_folder_path_with_table_names(output_folder_path, table_names)
+    none_result = validate_folder_path_with_table_names(None, table_names)
+
+    # Assert
+    expected_folder_path = os.path.abspath(output_folder_path)
+    expected_output_paths = [
+        os.path.join(expected_folder_path, 'users.csv'),
+        os.path.join(expected_folder_path, 'transactions.csv'),
+    ]
+
+    assert result == expected_output_paths
+    assert none_result is None
+    mock_makedirs.assert_called_once_with(expected_folder_path, exist_ok=True)
+
+
+@patch('os.makedirs', side_effect=PermissionError('No permission'))
+def test_validate_folder_path_with_table_names_permission_error(mock_makedirs):
+    """Test the function emits a warning and returns None on PermissionError."""
+    # Setup
+    output_folder_path = '.sample.temp'
+    table_names = ['users', 'transactions']
+
+    # Run
+    with warnings.catch_warnings(record=True) as warned:
+        warnings.simplefilter('always')
+        result = validate_folder_path_with_table_names(output_folder_path, table_names)
+
+    # Assert
+    assert result is None
+    assert mock_makedirs.called
+    assert any('Permission denied' in str(warning.message) for warning in warned)
+
+@patch('os.path.exists')
+def test_validate_folder_path_with_table_names_existing_files(mock_exists):
+    """Test the function raises an error listing all existing output files."""
+    # Setup
+    output_folder_path = '.sample.temp'
+    table_names = ['users', 'transactions', 'payments']
+    mock_exists.side_effect = [True, False, True]
+
+    expected_folder_path = os.path.abspath(output_folder_path)
+    expected_error = (
+        'The following output files already exist:\n'
+        f"{os.path.join(expected_folder_path, 'users.csv')}\n"
+        f"{os.path.join(expected_folder_path, 'payments.csv')}"
+    )
+
+    # Run and Assert
+    with pytest.raises(AssertionError, match=re.escape(expected_error)):
+        validate_folder_path_with_table_names(output_folder_path, table_names)
 
 
 def test_warn_missing_numerical_distributions():


### PR DESCRIPTION
We discussed the renaming of the parameter for these methods in this [Slack thread](https://datacebo.slack.com/archives/C01QNE9MLUB/p1788357970143819)